### PR TITLE
Tools: classified CommonMark conformance expectations gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,19 @@ scan → match → emit seam.
 
 ## Building and testing
 
-Requires Zig 0.16.0. `zig build test` runs the unit and fixture suites;
-`zig build spec-conformance -- spec.txt` scores Oliver against every
-normative example in a CommonMark spec (see docs/TESTS.md for the current
-546/652 CommonMark 0.31.2 scorecard and how to fetch the spec).
+Requires Zig 0.16.0. `zig build test` runs the unit, fixture, and
+conformance-harness suites; `zig build spec-conformance -- spec.txt` scores
+Oliver against every normative example in the exact official CommonMark
+0.31.2 corpus (byte count, example count, and SHA-256 are verified first)
+and prints a per-section scorecard. Every example is classified in a
+reviewed manifest (docs/COMMONMARK-EXPECTATIONS.md) as supported,
+not-yet, or a named divergence; `--gate` fails on any supported regression,
+unexpected pass, or changed divergence, so the full corpus is a regression
+wall (see docs/TESTS.md for the current 546/652 scorecard and how to fetch
+the spec).
 
 ```bash
-zig build test    # run all tests (114 tests)
+zig build test    # run all tests (130 tests)
 zig build         # build the static library and CLI into zig-out/
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,23 @@ pub fn build(b: *std.Build) void {
     const spec_step = b.step("spec-conformance", "Run the CommonMark spec-conformance scorecard");
     spec_step.dependOn(&spec_run.step);
 
+    // Synthetic unit tests for corpus parsing, identity checks, the complete
+    // expectation partition, and outcome classification. These do not need a
+    // downloaded spec.txt and therefore run as part of the ordinary test gate.
+    const spec_tool_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tools/spec_conformance.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "oliver", .module = oliver_mod },
+            },
+        }),
+    });
+    const run_spec_tool_tests = b.addRunArtifact(spec_tool_tests);
+    const spec_test_step = b.step("spec-conformance-test", "Test the CommonMark conformance harness");
+    spec_test_step.dependOn(&run_spec_tool_tests.step);
+
     // Unit tests embedded in the library modules.
     const lib_tests = b.addTest(.{
         .root_module = oliver_mod,
@@ -81,4 +98,5 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_lib_tests.step);
     test_step.dependOn(&run_fixture_tests.step);
+    test_step.dependOn(&run_spec_tool_tests.step);
 }

--- a/docs/COMMONMARK-EXPECTATIONS.md
+++ b/docs/COMMONMARK-EXPECTATIONS.md
@@ -1,0 +1,84 @@
+# CommonMark conformance expectations
+
+Oliver's conformance gate is bound to the exact official CommonMark 0.31.2
+`spec.txt`, not merely to a file that happens to contain parseable examples.
+The identity recorded in `tools/commonmark_expectations.zig` is:
+
+- source: <https://spec.commonmark.org/0.31.2/spec.txt>
+- bytes: `204857`
+- normative examples: `652`
+- SHA-256:
+  `bfef4ddc97276b6ab6c2a28ace48478e35b1c50e60cde9f517ab8ab030aa3b82`
+
+The harness rejects a different digest or byte/example count before running
+Oliver. It also rejects malformed example fences, missing input/output
+separators, nested example openings, empty section headings, and truncated
+examples. The official corpus is downloaded for development and CI; it is not
+vendored into the library or read by Oliver's filesystem-free core.
+
+## Expectation classes
+
+`tools/commonmark_expectations.zig` is a sorted, complete, nonoverlapping
+partition of official example numbers:
+
+- **supported** — Oliver must produce the normative HTML. A failure is a
+  regression.
+- **not-yet** — Oliver is known not to produce the normative HTML. A new pass
+  is an expectation mismatch, not a silent score increase; it must be reviewed
+  and moved to `supported`.
+- **divergence** — Oliver deliberately differs from CommonMark. Each entry has
+  a name, repository rationale, and exact pinned Oliver output. Conforming or
+  changing to some third output both require review.
+
+At `cb9ea53`, the partition is **472 supported, 179 not-yet, and 1 named
+divergence**. The divergence is example 646, the recorded ATX
+trailing-backslash choice in `docs/FEATURE-MATRIX.md` ambiguity 10. Example 644 remains
+`not_yet`; it is not declared a product divergence.
+
+The classified `--gate` fails on any supported regression, unexpected not-yet
+pass, or changed divergence. Report mode prints the same mismatches but exits
+successfully and retains the classified normative-failure details, which is
+useful while investigating. `--section` is report-only
+and cannot be combined with `--gate`, because a partial run cannot validate the
+complete manifest.
+
+## Updating expectations
+
+Expectation changes are reviewed product changes, not regenerated snapshots:
+
+1. Run the official corpus and inspect every mismatch.
+2. For an unexpected pass, verify the normative HTML and the corresponding
+   feature tests, then move only that example/range from `not_yet` to
+   `supported`.
+3. Fix a supported regression rather than weakening its class.
+4. Change a divergence only alongside its named rationale and exact pinned
+   Oliver output. Do not edit the official expected HTML.
+5. Keep ranges sorted and adjacent. The synthetic tests reject gaps, overlaps,
+   out-of-range entries, unnamed divergences, and duplicate divergence records.
+
+A CommonMark version upgrade is a separate migration: update the URL, byte
+count, example count, digest, and the entire reviewed partition together.
+
+## Acceptance commands
+
+```bash
+curl --fail --location \
+  https://spec.commonmark.org/0.31.2/spec.txt \
+  --output /tmp/commonmark-0.31.2-spec.txt
+
+printf '%s  %s\n' \
+  bfef4ddc97276b6ab6c2a28ace48478e35b1c50e60cde9f517ab8ab030aa3b82 \
+  /tmp/commonmark-0.31.2-spec.txt | shasum -a 256 --check
+
+zig build spec-conformance-test --summary all
+zig build spec-conformance -- /tmp/commonmark-0.31.2-spec.txt --gate
+zig build test --summary all
+zig fmt --check build.zig build.zig.zon src tests tools
+```
+
+For a focused scorecard while developing, use an exact specification heading:
+
+```bash
+zig build spec-conformance -- /tmp/commonmark-0.31.2-spec.txt \
+  --section "List items"
+```

--- a/docs/COMMONMARK-EXPECTATIONS.md
+++ b/docs/COMMONMARK-EXPECTATIONS.md
@@ -30,10 +30,16 @@ partition of official example numbers:
   a name, repository rationale, and exact pinned Oliver output. Conforming or
   changing to some third output both require review.
 
-At `cb9ea53`, the partition is **472 supported, 179 not-yet, and 1 named
-divergence**. The divergence is example 646, the recorded ATX
-trailing-backslash choice in `docs/FEATURE-MATRIX.md` ambiguity 10. Example 644 remains
-`not_yet`; it is not declared a product divergence.
+At the integrated thematic-break/Setext, fenced-code, and list milestones
+(merge `561c810`), the partition is **546 supported, 106 not-yet, and 0
+named divergences**. The former divergence — example 646, the recorded ATX
+trailing-backslash choice in `docs/FEATURE-MATRIX.md` ambiguity 10 — was
+resolved to the normative output by the thematic-break/Setext milestone:
+both example 644 and example 646 now render the literal trailing backslash
+and were moved to `supported`. The `divergences` table is empty by design;
+a future deliberate divergence must add a named record with its rationale
+and exact pinned Oliver output, and the expectation tests pin the current
+partition.
 
 The classified `--gate` fails on any supported regression, unexpected not-yet
 pass, or changed divergence. Report mode prints the same mismatches but exits

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,15 +1,17 @@
 # Oliver tests and fixtures
 
-Tests are product contracts. `zig build test` runs two suites:
+Tests are product contracts. `zig build test` runs three suites:
 
-1. **Library module tests** — 105 `test` blocks inside `src/*.zig` covering
+1. **Library module tests** — 114 `test` blocks inside `src/*.zig` covering
    source lines/spans, the normalized document, diagnostics, both dialect
    frontends, Unicode case folding, the HTML renderer, and the public API.
    Markdown tests pin the container stack, thematic-break/list precedence,
    multiline Setext transformation, reference-definition interaction,
-   terminal-backslash behavior, every implemented inline family, exact AST
-   shapes, and exact spans. Renderer tests construct documents directly so
-   renderer behavior is verified without a dialect parser.
+   terminal-backslash behavior, fenced-code payload/spans, every implemented
+   inline family, exact AST shapes, and exact spans. Textile tests pin
+   `p.`/`hN.`/`bq.` structure, hard-break terminators, and `@code@` payloads.
+   Renderer tests construct documents directly so renderer behavior is
+   verified without a dialect parser.
 2. **Fixture and adversarial tests** — 9 tests in `tests/fixtures_test.zig`.
    The explicit index contains 242 Markdown and 10 Textile fixture pairs.
    The Markdown wall includes byte-exact CommonMark 0.31.2 coverage of
@@ -18,14 +20,21 @@ Tests are product contracts. `zig build test` runs two suites:
    ordered starts and near misses, empty items, interruption, nesting,
    marker/delimiter separation, tight/loose propagation, and quote/list
    composition), reference links, autolinks, raw HTML, thematic breaks,
-   Setext headings, and fenced code blocks. It also verifies shared-model
-   convergence, hostile-input completion and leak freedom, NUL policy,
-   diagnostics, and deterministic repeat rendering (list stress: 2k nested
-   items, 10k same-marker items, 15k alternating markers, 12k variably
-   indented markers, and 8k valid plus 8k near-miss ordered markers, each
-   rendered twice).
+   Setext headings, and fenced code blocks; the Textile wall covers `bq.`
+   quotes and `@code@` spans. It also verifies shared-model convergence,
+   hostile-input completion and leak freedom, NUL policy, diagnostics, and
+   deterministic repeat rendering (list stress: 2k nested items, 10k
+   same-marker items, 15k alternating markers, 12k variably indented
+   markers, and 8k valid plus 8k near-miss ordered markers, each rendered
+   twice).
+3. **Conformance-harness tests** — 7 tests in `tools/spec_conformance.zig`:
+   synthetic corpus extraction (CRLF, tab arrows), malformed-corpus
+   rejection, official byte/example-count and SHA-256 identity checks,
+   complete/nonoverlapping manifest validation, malformed divergence-record
+   rejection, outcome classification, and the single-trailing-newline
+   comparison. These tests need no downloaded corpus.
 
-The current complete result is **114/114 tests passing** with Zig 0.16.0.
+The current complete result is **130/130 tests passing** with Zig 0.16.0.
 
 ## Fixture convention
 
@@ -131,14 +140,24 @@ curl -O https://spec.commonmark.org/0.31.2/spec.txt
 
 zig build spec-conformance -- spec.txt
 zig build spec-conformance -- spec.txt --section "Setext headings"
-zig build spec-conformance -- spec.txt --section "Code spans" --gate
+zig build spec-conformance -- spec.txt --gate
+zig build spec-conformance-test
 ```
 
-The harness converts the spec's tab-arrow marker to a real tab and ignores one
-renderer-owned final newline. Report mode exits zero while showing failures;
-`--gate` exits nonzero on any mismatch in the selected corpus.
+The harness is bound to the exact official 0.31.2 corpus (byte count,
+example count, and SHA-256, recorded in `tools/commonmark_expectations.zig`)
+and rejects a different file before running Oliver. Every example is
+classified in a reviewed manifest (`docs/COMMONMARK-EXPECTATIONS.md`):
+**supported** (must match byte-for-byte), **not-yet** (a new pass must be
+reviewed, not silently counted), or a named **divergence** with pinned
+Oliver output. The classified `--gate` fails on a supported regression, an
+unexpected not-yet pass, or a changed divergence — in either direction. It
+requires the complete corpus: `--section` is report-only and cannot be
+combined with `--gate`. The harness converts the spec's tab-arrow marker to
+a real tab and ignores exactly one renderer-owned final newline.
 
-Current canonical baseline: **546/652 examples pass**.
+Current canonical baseline: **546/652 examples pass** (546 supported,
+106 not-yet, 0 named divergences).
 
 - Thematic breaks: 18/19; the remaining example is indented code.
 - Setext headings: 25/27; both remaining examples are indented code.
@@ -147,12 +166,14 @@ Current canonical baseline: **546/652 examples pass**.
 - Backslash escapes: 11/13; fenced info-string escapes are implemented.
 - Link reference definitions: 25/27.
 - Block quotes: 22/25.
-- List items: 33/48; Lists: 24/27.
+- List items: 33/48; Lists: 23/26.
 - Code spans, emphasis/strong, images, autolinks, inline raw HTML, hard/soft
   breaks, and textual content: 100%.
 
-Failures are not silently skipped. Scores for implemented sections can be
-strictly gated; unfinished sections remain visible in the full report.
+The former ATX trailing-backslash divergence (example 646) was resolved to
+the normative output by the thematic-break/Setext milestone; no named
+divergences remain. Failures are not silently skipped: the classified gate
+makes the whole 0.31.2 corpus a regression wall.
 
 ## Commands
 

--- a/tools/commonmark_expectations.zig
+++ b/tools/commonmark_expectations.zig
@@ -22,20 +22,19 @@ pub const Range = struct {
     class: Class,
 };
 
-/// Generated once from the reviewed cb9ea53 scorecard, then committed as a
-/// plain, diffable partition. Keep ranges sorted, adjacent, and nonoverlapping.
+/// Reviewed partition as of the thematic-break/Setext, fenced-code, and list
+/// milestones (546 supported / 106 not-yet / 0 divergences), then committed
+/// as a plain, diffable partition. Keep ranges sorted, adjacent, and
+/// nonoverlapping.
 pub const ranges = [_]Range{
     // Tabs (examples 1-11).
     .{ .first = 1, .last = 9, .class = .not_yet },
-    .{ .first = 10, .last = 10, .class = .supported },
-    .{ .first = 11, .last = 11, .class = .not_yet },
+    .{ .first = 10, .last = 17, .class = .supported },
     // Backslash escapes (12-24).
-    .{ .first = 12, .last = 17, .class = .supported },
-    .{ .first = 18, .last = 19, .class = .not_yet },
-    .{ .first = 20, .last = 20, .class = .supported },
+    .{ .first = 18, .last = 18, .class = .not_yet },
+    .{ .first = 19, .last = 20, .class = .supported },
     .{ .first = 21, .last = 21, .class = .not_yet },
-    .{ .first = 22, .last = 23, .class = .supported },
-    .{ .first = 24, .last = 24, .class = .not_yet },
+    .{ .first = 22, .last = 24, .class = .supported },
     // Entity references (25-41).
     .{ .first = 25, .last = 27, .class = .not_yet },
     .{ .first = 28, .last = 30, .class = .supported },
@@ -43,29 +42,17 @@ pub const ranges = [_]Range{
     .{ .first = 35, .last = 35, .class = .supported },
     .{ .first = 36, .last = 41, .class = .not_yet },
     // Block/inline precedence (42) and thematic breaks (43-61).
-    .{ .first = 42, .last = 42, .class = .supported },
-    .{ .first = 43, .last = 43, .class = .not_yet },
-    .{ .first = 44, .last = 46, .class = .supported },
-    .{ .first = 47, .last = 48, .class = .not_yet },
-    .{ .first = 49, .last = 49, .class = .supported },
-    .{ .first = 50, .last = 54, .class = .not_yet },
-    .{ .first = 55, .last = 56, .class = .supported },
-    .{ .first = 57, .last = 61, .class = .not_yet },
+    .{ .first = 42, .last = 47, .class = .supported },
+    .{ .first = 48, .last = 48, .class = .not_yet },
+    .{ .first = 49, .last = 68, .class = .supported },
     // ATX headings (62-79).
-    .{ .first = 62, .last = 68, .class = .supported },
     .{ .first = 69, .last = 69, .class = .not_yet },
-    .{ .first = 70, .last = 76, .class = .supported },
-    .{ .first = 77, .last = 77, .class = .not_yet },
-    .{ .first = 78, .last = 79, .class = .supported },
+    .{ .first = 70, .last = 84, .class = .supported },
     // Setext headings (80-106).
-    .{ .first = 80, .last = 86, .class = .not_yet },
-    .{ .first = 87, .last = 87, .class = .supported },
-    .{ .first = 88, .last = 92, .class = .not_yet },
-    .{ .first = 93, .last = 93, .class = .supported },
-    .{ .first = 94, .last = 96, .class = .not_yet },
-    .{ .first = 97, .last = 97, .class = .supported },
-    .{ .first = 98, .last = 105, .class = .not_yet },
-    .{ .first = 106, .last = 106, .class = .supported },
+    .{ .first = 85, .last = 85, .class = .not_yet },
+    .{ .first = 86, .last = 99, .class = .supported },
+    .{ .first = 100, .last = 100, .class = .not_yet },
+    .{ .first = 101, .last = 106, .class = .supported },
     // Indented code blocks (107-118).
     .{ .first = 107, .last = 107, .class = .not_yet },
     .{ .first = 108, .last = 109, .class = .supported },
@@ -73,13 +60,9 @@ pub const ranges = [_]Range{
     .{ .first = 113, .last = 113, .class = .supported },
     .{ .first = 114, .last = 118, .class = .not_yet },
     // Fenced code blocks (119-147).
-    .{ .first = 119, .last = 120, .class = .not_yet },
-    .{ .first = 121, .last = 121, .class = .supported },
-    .{ .first = 122, .last = 137, .class = .not_yet },
-    .{ .first = 138, .last = 138, .class = .supported },
-    .{ .first = 139, .last = 144, .class = .not_yet },
-    .{ .first = 145, .last = 145, .class = .supported },
-    .{ .first = 146, .last = 147, .class = .not_yet },
+    .{ .first = 119, .last = 133, .class = .supported },
+    .{ .first = 134, .last = 134, .class = .not_yet },
+    .{ .first = 135, .last = 147, .class = .supported },
     // HTML blocks (148-191).
     .{ .first = 148, .last = 167, .class = .not_yet },
     .{ .first = 168, .last = 168, .class = .supported },
@@ -90,81 +73,39 @@ pub const ranges = [_]Range{
     .{ .first = 192, .last = 200, .class = .supported },
     .{ .first = 201, .last = 201, .class = .not_yet },
     .{ .first = 202, .last = 210, .class = .supported },
-    .{ .first = 211, .last = 212, .class = .not_yet },
-    .{ .first = 213, .last = 214, .class = .supported },
-    .{ .first = 215, .last = 215, .class = .not_yet },
-    .{ .first = 216, .last = 218, .class = .supported },
+    .{ .first = 211, .last = 211, .class = .not_yet },
+    .{ .first = 212, .last = 224, .class = .supported },
     // Paragraphs (219-226).
-    .{ .first = 219, .last = 224, .class = .supported },
     .{ .first = 225, .last = 225, .class = .not_yet },
-    .{ .first = 226, .last = 226, .class = .supported },
-    // Blank lines (227).
-    .{ .first = 227, .last = 227, .class = .supported },
+    .{ .first = 226, .last = 230, .class = .supported },
     // Block quotes (228-252).
-    .{ .first = 228, .last = 230, .class = .supported },
     .{ .first = 231, .last = 231, .class = .not_yet },
-    .{ .first = 232, .last = 233, .class = .supported },
-    .{ .first = 234, .last = 234, .class = .not_yet },
-    .{ .first = 235, .last = 235, .class = .supported },
-    .{ .first = 236, .last = 237, .class = .not_yet },
-    .{ .first = 238, .last = 245, .class = .supported },
-    .{ .first = 246, .last = 246, .class = .not_yet },
-    .{ .first = 247, .last = 251, .class = .supported },
-    .{ .first = 252, .last = 252, .class = .not_yet },
+    .{ .first = 232, .last = 235, .class = .supported },
+    .{ .first = 236, .last = 236, .class = .not_yet },
+    .{ .first = 237, .last = 251, .class = .supported },
+    .{ .first = 252, .last = 254, .class = .not_yet },
     // List items (253-300).
-    .{ .first = 253, .last = 254, .class = .not_yet },
     .{ .first = 255, .last = 256, .class = .supported },
     .{ .first = 257, .last = 257, .class = .not_yet },
-    .{ .first = 258, .last = 262, .class = .supported },
-    .{ .first = 263, .last = 264, .class = .not_yet },
+    .{ .first = 258, .last = 263, .class = .supported },
+    .{ .first = 264, .last = 264, .class = .not_yet },
     .{ .first = 265, .last = 269, .class = .supported },
     .{ .first = 270, .last = 274, .class = .not_yet },
     .{ .first = 275, .last = 277, .class = .supported },
     .{ .first = 278, .last = 278, .class = .not_yet },
     .{ .first = 279, .last = 285, .class = .supported },
     .{ .first = 286, .last = 290, .class = .not_yet },
-    .{ .first = 291, .last = 299, .class = .supported },
-    .{ .first = 300, .last = 300, .class = .not_yet },
+    .{ .first = 291, .last = 307, .class = .supported },
     // Lists (301-326).
-    .{ .first = 301, .last = 307, .class = .supported },
     .{ .first = 308, .last = 309, .class = .not_yet },
     .{ .first = 310, .last = 312, .class = .supported },
     .{ .first = 313, .last = 313, .class = .not_yet },
-    .{ .first = 314, .last = 317, .class = .supported },
-    .{ .first = 318, .last = 318, .class = .not_yet },
-    .{ .first = 319, .last = 320, .class = .supported },
-    .{ .first = 321, .last = 321, .class = .not_yet },
-    .{ .first = 322, .last = 323, .class = .supported },
-    .{ .first = 324, .last = 324, .class = .not_yet },
-    .{ .first = 325, .last = 326, .class = .supported },
-    // Inlines preamble example (327).
-    .{ .first = 327, .last = 327, .class = .supported },
-    // Code spans (328-349).
-    .{ .first = 328, .last = 349, .class = .supported },
-    // Emphasis and strong emphasis (350-481).
-    .{ .first = 350, .last = 481, .class = .supported },
+    .{ .first = 314, .last = 502, .class = .supported },
     // Links (482-571).
-    .{ .first = 482, .last = 502, .class = .supported },
     .{ .first = 503, .last = 503, .class = .not_yet },
     .{ .first = 504, .last = 505, .class = .supported },
     .{ .first = 506, .last = 506, .class = .not_yet },
-    .{ .first = 507, .last = 571, .class = .supported },
-    // Images (572-593).
-    .{ .first = 572, .last = 593, .class = .supported },
-    // Autolinks (594-612).
-    .{ .first = 594, .last = 612, .class = .supported },
-    // Raw HTML (613-632).
-    .{ .first = 613, .last = 632, .class = .supported },
-    // Hard line breaks (633-647).
-    .{ .first = 633, .last = 643, .class = .supported },
-    .{ .first = 644, .last = 644, .class = .not_yet },
-    .{ .first = 645, .last = 645, .class = .supported },
-    .{ .first = 646, .last = 646, .class = .divergence },
-    .{ .first = 647, .last = 647, .class = .supported },
-    // Soft line breaks (648-649).
-    .{ .first = 648, .last = 649, .class = .supported },
-    // Textual content (650-652).
-    .{ .first = 650, .last = 652, .class = .supported },
+    .{ .first = 507, .last = 652, .class = .supported },
 };
 
 pub const Divergence = struct {
@@ -174,15 +115,12 @@ pub const Divergence = struct {
     actual: []const u8,
 };
 
-pub const divergences = [_]Divergence{
-    .{
-        .example = 646,
-        .name = "ATX trailing backslash is a hard break",
-        .rationale = "docs/FEATURE-MATRIX.md recorded ambiguity 10",
-        .actual = "<h3>foo<br />\n</h3>\n",
-    },
-};
+pub const divergences = [_]Divergence{};
 
+/// No named divergences remain: the recorded ATX trailing-backslash choice
+/// (old divergence example 646) was resolved to the normative output by the
+/// thematic-break/Setext milestone. A future deliberate divergence must add
+/// a record here with its rationale and exact pinned Oliver output.
 pub fn classFor(number: usize) ?Class {
     // There are few ranges and this runs once per example; a simple binary
     // search keeps lookup predictable without introducing a generated table.

--- a/tools/commonmark_expectations.zig
+++ b/tools/commonmark_expectations.zig
@@ -1,0 +1,210 @@
+//! Reviewed expectations for the canonical CommonMark 0.31.2 `spec.txt`.
+//!
+//! Every official example number belongs to exactly one adjacent range below:
+//! - `supported`: Oliver must match the normative HTML byte-for-byte.
+//! - `not_yet`: Oliver is known not to match yet; an unexpected pass fails the
+//!   classified gate so the manifest cannot silently become stale.
+//! - `divergence`: Oliver deliberately differs. The named record also pins the
+//!   current Oliver HTML, so either conformance or a different failure requires
+//!   an explicit review.
+
+pub const spec_version = "0.31.2";
+pub const spec_url = "https://spec.commonmark.org/0.31.2/spec.txt";
+pub const spec_sha256_hex = "bfef4ddc97276b6ab6c2a28ace48478e35b1c50e60cde9f517ab8ab030aa3b82";
+pub const spec_byte_count: usize = 204_857;
+pub const example_count: usize = 652;
+
+pub const Class = enum { supported, not_yet, divergence };
+
+pub const Range = struct {
+    first: usize,
+    last: usize,
+    class: Class,
+};
+
+/// Generated once from the reviewed cb9ea53 scorecard, then committed as a
+/// plain, diffable partition. Keep ranges sorted, adjacent, and nonoverlapping.
+pub const ranges = [_]Range{
+    // Tabs (examples 1-11).
+    .{ .first = 1, .last = 9, .class = .not_yet },
+    .{ .first = 10, .last = 10, .class = .supported },
+    .{ .first = 11, .last = 11, .class = .not_yet },
+    // Backslash escapes (12-24).
+    .{ .first = 12, .last = 17, .class = .supported },
+    .{ .first = 18, .last = 19, .class = .not_yet },
+    .{ .first = 20, .last = 20, .class = .supported },
+    .{ .first = 21, .last = 21, .class = .not_yet },
+    .{ .first = 22, .last = 23, .class = .supported },
+    .{ .first = 24, .last = 24, .class = .not_yet },
+    // Entity references (25-41).
+    .{ .first = 25, .last = 27, .class = .not_yet },
+    .{ .first = 28, .last = 30, .class = .supported },
+    .{ .first = 31, .last = 34, .class = .not_yet },
+    .{ .first = 35, .last = 35, .class = .supported },
+    .{ .first = 36, .last = 41, .class = .not_yet },
+    // Block/inline precedence (42) and thematic breaks (43-61).
+    .{ .first = 42, .last = 42, .class = .supported },
+    .{ .first = 43, .last = 43, .class = .not_yet },
+    .{ .first = 44, .last = 46, .class = .supported },
+    .{ .first = 47, .last = 48, .class = .not_yet },
+    .{ .first = 49, .last = 49, .class = .supported },
+    .{ .first = 50, .last = 54, .class = .not_yet },
+    .{ .first = 55, .last = 56, .class = .supported },
+    .{ .first = 57, .last = 61, .class = .not_yet },
+    // ATX headings (62-79).
+    .{ .first = 62, .last = 68, .class = .supported },
+    .{ .first = 69, .last = 69, .class = .not_yet },
+    .{ .first = 70, .last = 76, .class = .supported },
+    .{ .first = 77, .last = 77, .class = .not_yet },
+    .{ .first = 78, .last = 79, .class = .supported },
+    // Setext headings (80-106).
+    .{ .first = 80, .last = 86, .class = .not_yet },
+    .{ .first = 87, .last = 87, .class = .supported },
+    .{ .first = 88, .last = 92, .class = .not_yet },
+    .{ .first = 93, .last = 93, .class = .supported },
+    .{ .first = 94, .last = 96, .class = .not_yet },
+    .{ .first = 97, .last = 97, .class = .supported },
+    .{ .first = 98, .last = 105, .class = .not_yet },
+    .{ .first = 106, .last = 106, .class = .supported },
+    // Indented code blocks (107-118).
+    .{ .first = 107, .last = 107, .class = .not_yet },
+    .{ .first = 108, .last = 109, .class = .supported },
+    .{ .first = 110, .last = 112, .class = .not_yet },
+    .{ .first = 113, .last = 113, .class = .supported },
+    .{ .first = 114, .last = 118, .class = .not_yet },
+    // Fenced code blocks (119-147).
+    .{ .first = 119, .last = 120, .class = .not_yet },
+    .{ .first = 121, .last = 121, .class = .supported },
+    .{ .first = 122, .last = 137, .class = .not_yet },
+    .{ .first = 138, .last = 138, .class = .supported },
+    .{ .first = 139, .last = 144, .class = .not_yet },
+    .{ .first = 145, .last = 145, .class = .supported },
+    .{ .first = 146, .last = 147, .class = .not_yet },
+    // HTML blocks (148-191).
+    .{ .first = 148, .last = 167, .class = .not_yet },
+    .{ .first = 168, .last = 168, .class = .supported },
+    .{ .first = 169, .last = 186, .class = .not_yet },
+    .{ .first = 187, .last = 187, .class = .supported },
+    .{ .first = 188, .last = 191, .class = .not_yet },
+    // Link reference definitions (192-218).
+    .{ .first = 192, .last = 200, .class = .supported },
+    .{ .first = 201, .last = 201, .class = .not_yet },
+    .{ .first = 202, .last = 210, .class = .supported },
+    .{ .first = 211, .last = 212, .class = .not_yet },
+    .{ .first = 213, .last = 214, .class = .supported },
+    .{ .first = 215, .last = 215, .class = .not_yet },
+    .{ .first = 216, .last = 218, .class = .supported },
+    // Paragraphs (219-226).
+    .{ .first = 219, .last = 224, .class = .supported },
+    .{ .first = 225, .last = 225, .class = .not_yet },
+    .{ .first = 226, .last = 226, .class = .supported },
+    // Blank lines (227).
+    .{ .first = 227, .last = 227, .class = .supported },
+    // Block quotes (228-252).
+    .{ .first = 228, .last = 230, .class = .supported },
+    .{ .first = 231, .last = 231, .class = .not_yet },
+    .{ .first = 232, .last = 233, .class = .supported },
+    .{ .first = 234, .last = 234, .class = .not_yet },
+    .{ .first = 235, .last = 235, .class = .supported },
+    .{ .first = 236, .last = 237, .class = .not_yet },
+    .{ .first = 238, .last = 245, .class = .supported },
+    .{ .first = 246, .last = 246, .class = .not_yet },
+    .{ .first = 247, .last = 251, .class = .supported },
+    .{ .first = 252, .last = 252, .class = .not_yet },
+    // List items (253-300).
+    .{ .first = 253, .last = 254, .class = .not_yet },
+    .{ .first = 255, .last = 256, .class = .supported },
+    .{ .first = 257, .last = 257, .class = .not_yet },
+    .{ .first = 258, .last = 262, .class = .supported },
+    .{ .first = 263, .last = 264, .class = .not_yet },
+    .{ .first = 265, .last = 269, .class = .supported },
+    .{ .first = 270, .last = 274, .class = .not_yet },
+    .{ .first = 275, .last = 277, .class = .supported },
+    .{ .first = 278, .last = 278, .class = .not_yet },
+    .{ .first = 279, .last = 285, .class = .supported },
+    .{ .first = 286, .last = 290, .class = .not_yet },
+    .{ .first = 291, .last = 299, .class = .supported },
+    .{ .first = 300, .last = 300, .class = .not_yet },
+    // Lists (301-326).
+    .{ .first = 301, .last = 307, .class = .supported },
+    .{ .first = 308, .last = 309, .class = .not_yet },
+    .{ .first = 310, .last = 312, .class = .supported },
+    .{ .first = 313, .last = 313, .class = .not_yet },
+    .{ .first = 314, .last = 317, .class = .supported },
+    .{ .first = 318, .last = 318, .class = .not_yet },
+    .{ .first = 319, .last = 320, .class = .supported },
+    .{ .first = 321, .last = 321, .class = .not_yet },
+    .{ .first = 322, .last = 323, .class = .supported },
+    .{ .first = 324, .last = 324, .class = .not_yet },
+    .{ .first = 325, .last = 326, .class = .supported },
+    // Inlines preamble example (327).
+    .{ .first = 327, .last = 327, .class = .supported },
+    // Code spans (328-349).
+    .{ .first = 328, .last = 349, .class = .supported },
+    // Emphasis and strong emphasis (350-481).
+    .{ .first = 350, .last = 481, .class = .supported },
+    // Links (482-571).
+    .{ .first = 482, .last = 502, .class = .supported },
+    .{ .first = 503, .last = 503, .class = .not_yet },
+    .{ .first = 504, .last = 505, .class = .supported },
+    .{ .first = 506, .last = 506, .class = .not_yet },
+    .{ .first = 507, .last = 571, .class = .supported },
+    // Images (572-593).
+    .{ .first = 572, .last = 593, .class = .supported },
+    // Autolinks (594-612).
+    .{ .first = 594, .last = 612, .class = .supported },
+    // Raw HTML (613-632).
+    .{ .first = 613, .last = 632, .class = .supported },
+    // Hard line breaks (633-647).
+    .{ .first = 633, .last = 643, .class = .supported },
+    .{ .first = 644, .last = 644, .class = .not_yet },
+    .{ .first = 645, .last = 645, .class = .supported },
+    .{ .first = 646, .last = 646, .class = .divergence },
+    .{ .first = 647, .last = 647, .class = .supported },
+    // Soft line breaks (648-649).
+    .{ .first = 648, .last = 649, .class = .supported },
+    // Textual content (650-652).
+    .{ .first = 650, .last = 652, .class = .supported },
+};
+
+pub const Divergence = struct {
+    example: usize,
+    name: []const u8,
+    rationale: []const u8,
+    actual: []const u8,
+};
+
+pub const divergences = [_]Divergence{
+    .{
+        .example = 646,
+        .name = "ATX trailing backslash is a hard break",
+        .rationale = "docs/FEATURE-MATRIX.md recorded ambiguity 10",
+        .actual = "<h3>foo<br />\n</h3>\n",
+    },
+};
+
+pub fn classFor(number: usize) ?Class {
+    // There are few ranges and this runs once per example; a simple binary
+    // search keeps lookup predictable without introducing a generated table.
+    var lo: usize = 0;
+    var hi: usize = ranges.len;
+    while (lo < hi) {
+        const mid = lo + (hi - lo) / 2;
+        const range = ranges[mid];
+        if (number < range.first) {
+            hi = mid;
+        } else if (number > range.last) {
+            lo = mid + 1;
+        } else {
+            return range.class;
+        }
+    }
+    return null;
+}
+
+pub fn divergenceFor(number: usize) ?Divergence {
+    for (divergences) |divergence| {
+        if (divergence.example == number) return divergence;
+    }
+    return null;
+}

--- a/tools/spec_conformance.zig
+++ b/tools/spec_conformance.zig
@@ -1,44 +1,92 @@
-//! CommonMark spec-conformance runner.
+//! CommonMark 0.31.2 conformance scorecard and classified expectation gate.
 //!
-//! Extracts the normative examples from a CommonMark `spec.txt` (the
-//! specification's own test corpus — an explicitly allowed clean-room
-//! source) and runs each through Oliver, reporting a per-section
-//! scorecard.
+//!     zig build spec-conformance -- <spec.txt> [--gate] [--section <name>]
 //!
-//!     zig build spec-conformance -- <path-to-spec.txt> [--gate]
-//!
-//! Normalization, mirroring the spec's own test driver:
-//! - The examples use `→` (U+2192) to represent tab characters; those are
-//!   converted to real tabs in both input and expected output.
-//! - The expected outputs omit the final newline that block-rendering
-//!   renderers emit; one trailing newline on the actual output is ignored
-//!   when comparing.
-//!
-//! Exit status is 0 in report mode; with `--gate`, 1 when any example
-//! fails (intended for CI enforcement once the scorecard is where we want
-//! it — the block-level constructs are not yet implemented, so the full
-//! corpus is expected to fail today).
-//!
-//! This tool reads files (the spec text) — it is a development harness,
-//! not part of the no-filesystem library core.
+//! The classified gate is intentionally stricter than a frozen pass count:
+//! supported examples must pass, not-yet examples must still fail (an
+//! unexpected pass requires review and reclassification), and named
+//! divergences must retain their pinned Oliver output. The canonical corpus is
+//! bound by version, exact byte count, SHA-256 digest, and example count.
 
 const std = @import("std");
 const oliver = @import("oliver");
+const expectations = @import("commonmark_expectations.zig");
 
 const fence = "````````````````````````````````";
+const max_spec_bytes = 32 * 1024 * 1024;
+
+const CorpusError = error{
+    MissingSeparator,
+    UnterminatedExample,
+    NestedExample,
+    UnexpectedClosingFence,
+    EmptySection,
+    ByteCountMismatch,
+    ExampleCountMismatch,
+    DigestMismatch,
+    InvalidManifest,
+};
 
 const Example = struct {
-    /// Current `## ` section (captured only outside example fences, so
-    /// `## foo` inside example input never hijacks the tracker).
     section: []const u8,
     input: []const u8,
     expected: []const u8,
     number: usize,
 };
 
-/// Replaces the spec's tab arrow `→` with a real tab. Always returns
-/// owned memory (even when no arrow is present), so callers can free
-/// every `input`/`expected` uniformly.
+const ParseResult = struct {
+    examples: std.ArrayList(Example),
+
+    fn deinit(self: *ParseResult, allocator: std.mem.Allocator) void {
+        for (self.examples.items) |ex| {
+            allocator.free(ex.input);
+            allocator.free(ex.expected);
+        }
+        self.examples.deinit(allocator);
+    }
+};
+
+const RenderResult = struct {
+    bytes: std.ArrayList(u8),
+    matches_spec: bool,
+
+    fn deinit(self: *RenderResult, allocator: std.mem.Allocator) void {
+        self.bytes.deinit(allocator);
+    }
+};
+
+const Outcome = enum {
+    expected_pass,
+    expected_not_yet,
+    expected_divergence,
+    regression,
+    unexpected_pass,
+    changed_divergence,
+
+    fn isMismatch(self: Outcome) bool {
+        return switch (self) {
+            .expected_pass, .expected_not_yet, .expected_divergence => false,
+            .regression, .unexpected_pass, .changed_divergence => true,
+        };
+    }
+};
+
+const Counts = struct {
+    supported: usize = 0,
+    not_yet: usize = 0,
+    divergence: usize = 0,
+    expected_pass: usize = 0,
+    expected_not_yet: usize = 0,
+    expected_divergence: usize = 0,
+    regression: usize = 0,
+    unexpected_pass: usize = 0,
+    changed_divergence: usize = 0,
+
+    fn mismatches(self: Counts) usize {
+        return self.regression + self.unexpected_pass + self.changed_divergence;
+    }
+};
+
 fn replaceTabs(allocator: std.mem.Allocator, s: []const u8) ![]const u8 {
     var out = std.ArrayList(u8).empty;
     defer out.deinit(allocator);
@@ -55,15 +103,19 @@ fn replaceTabs(allocator: std.mem.Allocator, s: []const u8) ![]const u8 {
     return try out.toOwnedSlice(allocator);
 }
 
+fn isOpeningFence(line: []const u8) bool {
+    return std.mem.eql(u8, line, fence ++ " example");
+}
+
 fn isClosingFence(line: []const u8) bool {
     return std.mem.startsWith(u8, line, fence) and
         std.mem.indexOfNone(u8, line[fence.len..], " \t\r") == null;
 }
 
-/// Parses the example corpus out of a spec.txt. The separator between
-/// input and expected output is the first line that is exactly `.`
-/// (the curated examples never contain a lone `.` line in their input).
-fn parseSpec(allocator: std.mem.Allocator, text: []const u8) !std.ArrayList(Example) {
+/// Extracts normative examples and rejects malformed or truncated fences.
+/// `# ` and `## ` headings are captured only outside examples, so example
+/// input cannot hijack the section tracker.
+fn parseSpec(allocator: std.mem.Allocator, text: []const u8) !ParseResult {
     var examples = std.ArrayList(Example).empty;
     errdefer {
         for (examples.items) |ex| {
@@ -75,72 +127,152 @@ fn parseSpec(allocator: std.mem.Allocator, text: []const u8) !std.ArrayList(Exam
 
     var section: []const u8 = "(preamble)";
     var in_example = false;
-    var after_sep = false;
+    var after_separator = false;
     var md = std.ArrayList(u8).empty;
+    defer md.deinit(allocator);
     var expected = std.ArrayList(u8).empty;
+    defer expected.deinit(allocator);
 
     var it = std.mem.splitScalar(u8, text, '\n');
     while (it.next()) |raw| {
         const line = std.mem.trimEnd(u8, raw, "\r");
         if (!in_example) {
             if (std.mem.startsWith(u8, line, "## ")) {
+                if (line.len == 3) return CorpusError.EmptySection;
                 section = line[3..];
-            } else if (std.mem.eql(u8, line, fence ++ " example")) {
+            } else if (std.mem.startsWith(u8, line, "# ")) {
+                if (line.len == 2) return CorpusError.EmptySection;
+                section = line[2..];
+            } else if (isOpeningFence(line)) {
                 in_example = true;
-                after_sep = false;
-                md = std.ArrayList(u8).empty;
-                expected = std.ArrayList(u8).empty;
+                after_separator = false;
+                md.clearRetainingCapacity();
+                expected.clearRetainingCapacity();
+            } else if (isClosingFence(line)) {
+                return CorpusError.UnexpectedClosingFence;
             }
             continue;
         }
-        if (!after_sep) {
-            // Collect markdown until the `.` separator (the first lone
-            // dot line; the curated examples never contain one in input).
+
+        if (isOpeningFence(line)) return CorpusError.NestedExample;
+        if (!after_separator) {
             if (std.mem.eql(u8, line, ".")) {
-                after_sep = true;
-                if (md.items.len > 0) md.items.len -= 1; // drop trailing \n
+                after_separator = true;
+                if (md.items.len > 0) md.items.len -= 1;
                 continue;
             }
+            if (isClosingFence(line)) return CorpusError.MissingSeparator;
             try md.appendSlice(allocator, line);
             try md.append(allocator, '\n');
             continue;
         }
-        // Collect expected output until the closing fence.
+
         if (isClosingFence(line)) {
-            if (expected.items.len > 0) expected.items.len -= 1; // drop trailing \n
+            if (expected.items.len > 0) expected.items.len -= 1;
+            const input = try replaceTabs(allocator, md.items);
+            errdefer allocator.free(input);
+            const expected_owned = try replaceTabs(allocator, expected.items);
+            errdefer allocator.free(expected_owned);
             try examples.append(allocator, .{
                 .section = section,
-                .input = try replaceTabs(allocator, md.items),
-                .expected = try replaceTabs(allocator, expected.items),
+                .input = input,
+                .expected = expected_owned,
                 .number = examples.items.len + 1,
             });
-            md.deinit(allocator);
-            expected.deinit(allocator);
             in_example = false;
             continue;
         }
         try expected.appendSlice(allocator, line);
         try expected.append(allocator, '\n');
     }
-    return examples;
+    if (in_example) return CorpusError.UnterminatedExample;
+    return .{ .examples = examples };
 }
 
-/// Runs one example through Oliver and reports whether the rendered HTML
-/// matches the spec's expected bytes (allowing one trailing newline).
-fn runExample(gpa: std.mem.Allocator, ex: Example) !bool {
+fn actualMatchesExpected(expected: []const u8, actual: []const u8) bool {
+    if (std.mem.eql(u8, expected, actual)) return true;
+    return actual.len == expected.len + 1 and
+        std.mem.eql(u8, expected, actual[0..expected.len]) and
+        actual[expected.len] == '\n';
+}
+
+fn runExample(gpa: std.mem.Allocator, ex: Example) !RenderResult {
     var result = try oliver.parse(gpa, ex.input, .markdown, .{});
     defer result.deinit();
     var aw = std.Io.Writer.Allocating.init(gpa);
     defer aw.deinit();
     try oliver.html.render(gpa, &aw.writer, &result.document, .{});
-    var out = aw.toArrayList();
-    defer out.deinit(gpa);
-    const actual = out.items;
-    if (std.mem.eql(u8, ex.expected, actual)) return true;
-    if (actual.len == ex.expected.len + 1 and
-        std.mem.eql(u8, ex.expected, actual[0..ex.expected.len]) and
-        actual[ex.expected.len] == '\n') return true;
-    return false;
+    const bytes = aw.toArrayList();
+    return .{
+        .matches_spec = actualMatchesExpected(ex.expected, bytes.items),
+        .bytes = bytes,
+    };
+}
+
+fn classify(class: expectations.Class, matches_spec: bool, actual: []const u8, number: usize) Outcome {
+    return switch (class) {
+        .supported => if (matches_spec) .expected_pass else .regression,
+        .not_yet => if (matches_spec) .unexpected_pass else .expected_not_yet,
+        .divergence => if (matches_spec)
+            .changed_divergence
+        else if (expectations.divergenceFor(number)) |divergence|
+            if (std.mem.eql(u8, divergence.actual, actual)) .expected_divergence else .changed_divergence
+        else
+            .changed_divergence,
+    };
+}
+
+fn classForRanges(ranges: []const expectations.Range, number: usize) ?expectations.Class {
+    for (ranges) |range| {
+        if (number >= range.first and number <= range.last) return range.class;
+    }
+    return null;
+}
+
+fn validateManifestData(
+    ranges: []const expectations.Range,
+    divergences: []const expectations.Divergence,
+    expected_count: usize,
+) !Counts {
+    if (ranges.len == 0) return CorpusError.InvalidManifest;
+    var next: usize = 1;
+    var counts = Counts{};
+    for (ranges) |range| {
+        if (range.first != next or range.first > range.last or range.last > expected_count)
+            return CorpusError.InvalidManifest;
+        const len = range.last - range.first + 1;
+        switch (range.class) {
+            .supported => counts.supported += len,
+            .not_yet => counts.not_yet += len,
+            .divergence => counts.divergence += len,
+        }
+        next = range.last + 1;
+    }
+    if (next != expected_count + 1) return CorpusError.InvalidManifest;
+
+    if (divergences.len != counts.divergence) return CorpusError.InvalidManifest;
+    var previous: usize = 0;
+    for (divergences) |divergence| {
+        if (divergence.example <= previous or
+            classForRanges(ranges, divergence.example) != .divergence or
+            divergence.name.len == 0 or divergence.rationale.len == 0)
+            return CorpusError.InvalidManifest;
+        previous = divergence.example;
+    }
+    return counts;
+}
+
+fn validateManifest(expected_count: usize) !Counts {
+    return validateManifestData(&expectations.ranges, &expectations.divergences, expected_count);
+}
+
+fn verifyOfficialCorpus(text: []const u8, parsed_count: usize) !void {
+    if (text.len != expectations.spec_byte_count) return CorpusError.ByteCountMismatch;
+    if (parsed_count != expectations.example_count) return CorpusError.ExampleCountMismatch;
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(text, &digest, .{});
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    if (!std.mem.eql(u8, expectations.spec_sha256_hex, &hex)) return CorpusError.DigestMismatch;
 }
 
 fn printTruncated(writer: anytype, label: []const u8, s: []const u8) !void {
@@ -152,18 +284,26 @@ fn printTruncated(writer: anytype, label: []const u8, s: []const u8) !void {
     }
 }
 
+fn printUsage() void {
+    std.debug.print(
+        \\usage: spec-conformance <path-to-spec.txt> [--gate] [--section <name>]
+        \\  --gate     enforce the classified CommonMark 0.31.2 expectations
+        \\  --section  report one exact specification heading (cannot be combined with --gate)
+        \\
+    , .{});
+}
+
 pub fn main(init: std.process.Init) !u8 {
     const gpa = init.gpa;
-
-    var it = try init.minimal.args.iterateAllocator(gpa);
-    defer it.deinit();
-    _ = it.next(); // program name
+    var args = try init.minimal.args.iterateAllocator(gpa);
+    defer args.deinit();
+    _ = args.next();
 
     var spec_path: ?[]const u8 = null;
     var gate = false;
     var only_section: ?[]const u8 = null;
     var next_is_section = false;
-    while (it.next()) |arg| {
+    while (args.next()) |arg| {
         if (next_is_section) {
             only_section = arg;
             next_is_section = false;
@@ -174,104 +314,290 @@ pub fn main(init: std.process.Init) !u8 {
         } else if (std.mem.startsWith(u8, arg, "-")) {
             std.debug.print("spec-conformance: unknown option {s}\n", .{arg});
             return 2;
+        } else if (spec_path != null) {
+            std.debug.print("spec-conformance: multiple spec paths supplied\n", .{});
+            return 2;
         } else {
             spec_path = arg;
         }
     }
+    if (next_is_section or (gate and only_section != null)) {
+        printUsage();
+        return 2;
+    }
     const path = spec_path orelse {
-        std.debug.print(
-            \\usage: spec-conformance <path-to-spec.txt> [--gate] [--section <name>]
-            \\  --gate     exit 1 when any example fails (report mode exits 0)
-            \\  --section  only run the examples in one `## ` section
-            \\
-        , .{});
+        printUsage();
         return 2;
     };
 
-    const text = std.Io.Dir.cwd().readFileAlloc(init.io, path, gpa, .limited(32 * 1024 * 1024)) catch |err| {
+    const text = std.Io.Dir.cwd().readFileAlloc(init.io, path, gpa, .limited(max_spec_bytes)) catch |err| {
         std.debug.print("spec-conformance: cannot read {s}: {s}\n", .{ path, @errorName(err) });
         return 2;
     };
     defer gpa.free(text);
 
-    var examples = try parseSpec(gpa, text);
-    defer {
-        for (examples.items) |ex| {
-            gpa.free(ex.input);
-            gpa.free(ex.expected);
-        }
-        examples.deinit(gpa);
-    }
+    var parsed = parseSpec(gpa, text) catch |err| {
+        std.debug.print("spec-conformance: malformed corpus: {s}\n", .{@errorName(err)});
+        return 2;
+    };
+    defer parsed.deinit(gpa);
 
-    // Run every example; keep per-section tallies (first-seen order) and
-    // the failure list. Section names alias the spec text (as do the
-    // examples' inputs and expected outputs), so nothing here is copied.
+    verifyOfficialCorpus(text, parsed.examples.items.len) catch |err| {
+        std.debug.print(
+            "spec-conformance: corpus identity mismatch for CommonMark {s}: {s}\nexpected {d} bytes, {d} examples, SHA-256 {s}\nsource: {s}\n",
+            .{ expectations.spec_version, @errorName(err), expectations.spec_byte_count, expectations.example_count, expectations.spec_sha256_hex, expectations.spec_url },
+        );
+        return 2;
+    };
+    var counts = validateManifest(expectations.example_count) catch |err| {
+        std.debug.print("spec-conformance: invalid expectation manifest: {s}\n", .{@errorName(err)});
+        return 2;
+    };
+
     const SectionTally = struct { pass: usize = 0, total: usize = 0 };
     var tallies = std.StringHashMap(SectionTally).init(gpa);
     defer tallies.deinit();
     var sections = std.ArrayList([]const u8).empty;
     defer sections.deinit(gpa);
-    var failures = std.ArrayList(Example).empty;
-    defer failures.deinit(gpa);
+    const Mismatch = struct { ex: Example, outcome: Outcome, actual: []const u8 };
+    var mismatches = std.ArrayList(Mismatch).empty;
+    defer {
+        for (mismatches.items) |mismatch| gpa.free(mismatch.actual);
+        mismatches.deinit(gpa);
+    }
+    const NormativeFailure = struct { ex: Example, class: expectations.Class, actual: []const u8 };
+    var failures = std.ArrayList(NormativeFailure).empty;
+    defer {
+        for (failures.items) |failure| gpa.free(failure.actual);
+        failures.deinit(gpa);
+    }
 
     var pass_total: usize = 0;
     var run_total: usize = 0;
-    for (examples.items) |ex| {
-        if (only_section) |sect| {
-            if (!std.mem.eql(u8, sect, ex.section)) continue;
+    for (parsed.examples.items) |ex| {
+        if (only_section) |section| {
+            if (!std.mem.eql(u8, section, ex.section)) continue;
         }
         run_total += 1;
-        const ok = try runExample(gpa, ex);
+        var rendered = try runExample(gpa, ex);
+        defer rendered.deinit(gpa);
+        if (rendered.matches_spec) pass_total += 1;
+
+        const class = expectations.classFor(ex.number) orelse {
+            std.debug.print("spec-conformance: example #{d} is not classified\n", .{ex.number});
+            return 2;
+        };
+        if (!gate and !rendered.matches_spec) {
+            try failures.append(gpa, .{
+                .ex = ex,
+                .class = class,
+                .actual = try gpa.dupe(u8, rendered.bytes.items),
+            });
+        }
+        const outcome = classify(class, rendered.matches_spec, rendered.bytes.items, ex.number);
+        switch (outcome) {
+            .expected_pass => counts.expected_pass += 1,
+            .expected_not_yet => counts.expected_not_yet += 1,
+            .expected_divergence => counts.expected_divergence += 1,
+            .regression => counts.regression += 1,
+            .unexpected_pass => counts.unexpected_pass += 1,
+            .changed_divergence => counts.changed_divergence += 1,
+        }
+        if (outcome.isMismatch()) {
+            try mismatches.append(gpa, .{
+                .ex = ex,
+                .outcome = outcome,
+                .actual = try gpa.dupe(u8, rendered.bytes.items),
+            });
+        }
+
         const gop = try tallies.getOrPut(ex.section);
         if (!gop.found_existing) {
             gop.value_ptr.* = .{};
             try sections.append(gpa, ex.section);
         }
         gop.value_ptr.total += 1;
-        if (ok) {
-            gop.value_ptr.pass += 1;
-            pass_total += 1;
-        } else {
-            try failures.append(gpa, ex);
-        }
+        if (rendered.matches_spec) gop.value_ptr.pass += 1;
     }
 
-    var out_buf: [4096]u8 = undefined;
-    var out_writer = std.Io.File.stdout().writer(init.io, &out_buf);
-    const w = &out_writer.interface;
-
-    try w.print("CommonMark spec-conformance: {d}/{d} examples pass\n", .{ pass_total, run_total });
-    try w.print("\nPer-section scorecard:", .{});
-    for (sections.items) |key| {
-        const t = tallies.get(key).?;
-        const pct: usize = if (t.total == 0) 0 else (100 * t.pass) / t.total;
-        try w.print("\n  {s:>44}  {d:>3}/{d:<3}  {d:>3}%", .{ key, t.pass, t.total, pct });
+    if (only_section != null and run_total == 0) {
+        std.debug.print("spec-conformance: section not found: {s}\n", .{only_section.?});
+        return 2;
     }
-    try w.print("\n", .{});
+
+    var out_buffer: [4096]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(init.io, &out_buffer);
+    const writer = &stdout.interface;
+    try writer.print(
+        "CommonMark {s} spec-conformance: {d}/{d} examples pass (SHA-256 {s})\n",
+        .{ expectations.spec_version, pass_total, run_total, expectations.spec_sha256_hex },
+    );
+    try writer.print("\nPer-section scorecard:", .{});
+    for (sections.items) |section| {
+        const tally = tallies.get(section).?;
+        const percent: usize = if (tally.total == 0) 0 else (100 * tally.pass) / tally.total;
+        try writer.print("\n  {s:>44}  {d:>3}/{d:<3}  {d:>3}%", .{ section, tally.pass, tally.total, percent });
+    }
+    try writer.print("\n", .{});
 
     if (failures.items.len > 0) {
-        try w.print("\nFailures ({d}):\n", .{failures.items.len});
-        for (failures.items, 0..) |ex, idx| {
-            if (idx >= 40) {
-                try w.print("  ... and {d} more\n", .{failures.items.len - 40});
+        try writer.print("\nNormative failures ({d}):\n", .{failures.items.len});
+        for (failures.items, 0..) |failure, index| {
+            if (index >= 40) {
+                try writer.print("  ... and {d} more\n", .{failures.items.len - 40});
                 break;
             }
-            try w.print("  #{d} [{s}]\n", .{ ex.number, ex.section });
-            try printTruncated(w, "input", ex.input);
-            try printTruncated(w, "expected", ex.expected);
-            // Re-run to show what Oliver actually produced.
-            var result = try oliver.parse(gpa, ex.input, .markdown, .{});
-            defer result.deinit();
-            var aw = std.Io.Writer.Allocating.init(gpa);
-            defer aw.deinit();
-            try oliver.html.render(gpa, &aw.writer, &result.document, .{});
-            var out = aw.toArrayList();
-            defer out.deinit(gpa);
-            try printTruncated(w, "actual", out.items);
+            try writer.print(
+                "  #{d} [{s}] class={s}\n",
+                .{ failure.ex.number, failure.ex.section, @tagName(failure.class) },
+            );
+            if (expectations.divergenceFor(failure.ex.number)) |divergence| {
+                try writer.print("    divergence: {s} ({s})\n", .{ divergence.name, divergence.rationale });
+            }
+            try printTruncated(writer, "input", failure.ex.input);
+            try printTruncated(writer, "expected", failure.ex.expected);
+            try printTruncated(writer, "actual", failure.actual);
         }
     }
 
-    out_writer.flush() catch {};
-    if (gate and failures.items.len > 0) return 1;
+    if (only_section == null) {
+        try writer.print(
+            "\nExpectations: {d} supported, {d} not-yet, {d} named divergence\n",
+            .{ counts.supported, counts.not_yet, counts.divergence },
+        );
+        try writer.print(
+            "Observed: {d} expected passes, {d} expected not-yet failures, {d} expected divergences\n",
+            .{ counts.expected_pass, counts.expected_not_yet, counts.expected_divergence },
+        );
+        try writer.print(
+            "Gate mismatches: {d} regressions, {d} unexpected passes, {d} changed divergences\n",
+            .{ counts.regression, counts.unexpected_pass, counts.changed_divergence },
+        );
+        try writer.print("Named divergences:\n", .{});
+        for (expectations.divergences) |divergence| {
+            try writer.print(
+                "  #{d}: {s} ({s})\n",
+                .{ divergence.example, divergence.name, divergence.rationale },
+            );
+        }
+    }
+
+    if (mismatches.items.len > 0) {
+        try writer.print("\nExpectation mismatches ({d}):\n", .{mismatches.items.len});
+        for (mismatches.items) |mismatch| {
+            try writer.print("  #{d} [{s}] {s}\n", .{ mismatch.ex.number, mismatch.ex.section, @tagName(mismatch.outcome) });
+            try printTruncated(writer, "input", mismatch.ex.input);
+            try printTruncated(writer, "expected", mismatch.ex.expected);
+            try printTruncated(writer, "actual", mismatch.actual);
+        }
+    }
+
+    stdout.flush() catch {};
+    if (gate and counts.mismatches() > 0) return 1;
     return 0;
+}
+
+fn syntheticSpec(body: []const u8) []const u8 {
+    return body;
+}
+
+test "parseSpec accepts synthetic examples, sections, CRLF, and tab arrows" {
+    const allocator = std.testing.allocator;
+    const text = syntheticSpec(
+        "# Alpha\r\n" ++
+            fence ++ " example\r\n" ++
+            "a→b\r\n.\r\n<p>a→b</p>\r\n" ++ fence ++ "\r\n" ++
+            "## Beta\n" ++ fence ++ " example\n.\n\n" ++ fence ++ "\n",
+    );
+    var parsed = try parseSpec(allocator, text);
+    defer parsed.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), parsed.examples.items.len);
+    try std.testing.expectEqualStrings("Alpha", parsed.examples.items[0].section);
+    try std.testing.expectEqualStrings("a\tb", parsed.examples.items[0].input);
+    try std.testing.expectEqualStrings("<p>a\tb</p>", parsed.examples.items[0].expected);
+    try std.testing.expectEqualStrings("Beta", parsed.examples.items[1].section);
+    try std.testing.expectEqualStrings("", parsed.examples.items[1].input);
+    try std.testing.expectEqualStrings("", parsed.examples.items[1].expected);
+}
+
+test "parseSpec rejects missing separator, truncation, nesting, and empty section" {
+    const allocator = std.testing.allocator;
+    const cases = [_]struct { text: []const u8, expected: anyerror }{
+        .{ .text = fence ++ " example\nx\n" ++ fence ++ "\n", .expected = CorpusError.MissingSeparator },
+        .{ .text = fence ++ " example\nx\n.\n<p>x</p>\n", .expected = CorpusError.UnterminatedExample },
+        .{ .text = fence ++ " example\nx\n" ++ fence ++ " example\n", .expected = CorpusError.NestedExample },
+        .{ .text = fence ++ "\n", .expected = CorpusError.UnexpectedClosingFence },
+        .{ .text = "## \n", .expected = CorpusError.EmptySection },
+    };
+    for (cases) |case| {
+        try std.testing.expectError(case.expected, parseSpec(allocator, case.text));
+    }
+}
+
+test "official identity rejects wrong byte count, example count, and digest" {
+    try std.testing.expectError(CorpusError.ByteCountMismatch, verifyOfficialCorpus("x", 1));
+
+    const wrong = try std.testing.allocator.alloc(u8, expectations.spec_byte_count);
+    defer std.testing.allocator.free(wrong);
+    @memset(wrong, 0);
+    try std.testing.expectError(CorpusError.ExampleCountMismatch, verifyOfficialCorpus(wrong, 1));
+    try std.testing.expectError(CorpusError.DigestMismatch, verifyOfficialCorpus(wrong, expectations.example_count));
+}
+
+test "expectation partition is complete and named divergences are exact" {
+    const counts = try validateManifest(expectations.example_count);
+    try std.testing.expectEqual(expectations.example_count, counts.supported + counts.not_yet + counts.divergence);
+    try std.testing.expectEqual(@as(usize, 1), counts.divergence);
+    try std.testing.expectEqual(expectations.Class.divergence, expectations.classFor(646).?);
+    try std.testing.expect(expectations.classFor(0) == null);
+    try std.testing.expect(expectations.classFor(expectations.example_count + 1) == null);
+}
+
+test "manifest validation rejects gaps overlaps and malformed divergence records" {
+    const valid_ranges = [_]expectations.Range{
+        .{ .first = 1, .last = 1, .class = .supported },
+        .{ .first = 2, .last = 2, .class = .not_yet },
+    };
+    _ = try validateManifestData(&valid_ranges, &.{}, 2);
+
+    const gap = [_]expectations.Range{
+        .{ .first = 1, .last = 1, .class = .supported },
+        .{ .first = 3, .last = 3, .class = .not_yet },
+    };
+    try std.testing.expectError(CorpusError.InvalidManifest, validateManifestData(&gap, &.{}, 3));
+
+    const overlap = [_]expectations.Range{
+        .{ .first = 1, .last = 2, .class = .supported },
+        .{ .first = 2, .last = 3, .class = .not_yet },
+    };
+    try std.testing.expectError(CorpusError.InvalidManifest, validateManifestData(&overlap, &.{}, 3));
+
+    const divergence_range = [_]expectations.Range{
+        .{ .first = 1, .last = 1, .class = .divergence },
+    };
+    try std.testing.expectError(CorpusError.InvalidManifest, validateManifestData(&divergence_range, &.{}, 1));
+    const unnamed = [_]expectations.Divergence{.{
+        .example = 1,
+        .name = "",
+        .rationale = "reason",
+        .actual = "output",
+    }};
+    try std.testing.expectError(CorpusError.InvalidManifest, validateManifestData(&divergence_range, &unnamed, 1));
+}
+
+test "classification exposes regressions unexpected passes and changed divergences" {
+    try std.testing.expectEqual(Outcome.expected_pass, classify(.supported, true, "", 1));
+    try std.testing.expectEqual(Outcome.regression, classify(.supported, false, "", 1));
+    try std.testing.expectEqual(Outcome.expected_not_yet, classify(.not_yet, false, "", 1));
+    try std.testing.expectEqual(Outcome.unexpected_pass, classify(.not_yet, true, "", 1));
+    const divergence = expectations.divergenceFor(646).?;
+    try std.testing.expectEqual(Outcome.expected_divergence, classify(.divergence, false, divergence.actual, 646));
+    try std.testing.expectEqual(Outcome.changed_divergence, classify(.divergence, true, divergence.actual, 646));
+    try std.testing.expectEqual(Outcome.changed_divergence, classify(.divergence, false, "different", 646));
+}
+
+test "expected comparison permits exactly one generated trailing newline" {
+    try std.testing.expect(actualMatchesExpected("<p>x</p>", "<p>x</p>\n"));
+    try std.testing.expect(actualMatchesExpected("<p>x</p>", "<p>x</p>"));
+    try std.testing.expect(!actualMatchesExpected("<p>x</p>", "<p>x</p>\n\n"));
 }

--- a/tools/spec_conformance.zig
+++ b/tools/spec_conformance.zig
@@ -547,8 +547,14 @@ test "official identity rejects wrong byte count, example count, and digest" {
 test "expectation partition is complete and named divergences are exact" {
     const counts = try validateManifest(expectations.example_count);
     try std.testing.expectEqual(expectations.example_count, counts.supported + counts.not_yet + counts.divergence);
-    try std.testing.expectEqual(@as(usize, 1), counts.divergence);
-    try std.testing.expectEqual(expectations.Class.divergence, expectations.classFor(646).?);
+    // Steady state after the thematic-break/Setext, fenced-code, and list
+    // milestones: 546 supported, 106 not-yet, and the former ATX
+    // trailing-backslash divergence (example 646) now conforms. These pins
+    // move only with a reviewed manifest change.
+    try std.testing.expectEqual(@as(usize, 546), counts.supported);
+    try std.testing.expectEqual(@as(usize, 106), counts.not_yet);
+    try std.testing.expectEqual(@as(usize, 0), counts.divergence);
+    try std.testing.expectEqual(expectations.Class.supported, expectations.classFor(646).?);
     try std.testing.expect(expectations.classFor(0) == null);
     try std.testing.expect(expectations.classFor(expectations.example_count + 1) == null);
 }
@@ -590,9 +596,14 @@ test "classification exposes regressions unexpected passes and changed divergenc
     try std.testing.expectEqual(Outcome.regression, classify(.supported, false, "", 1));
     try std.testing.expectEqual(Outcome.expected_not_yet, classify(.not_yet, false, "", 1));
     try std.testing.expectEqual(Outcome.unexpected_pass, classify(.not_yet, true, "", 1));
-    const divergence = expectations.divergenceFor(646).?;
-    try std.testing.expectEqual(Outcome.expected_divergence, classify(.divergence, false, divergence.actual, 646));
-    try std.testing.expectEqual(Outcome.changed_divergence, classify(.divergence, true, divergence.actual, 646));
+    // No named divergences remain (example 646 now conforms), so a
+    // `.divergence` class is always a change: a spec-matching output must
+    // not be classified divergence, and with no pinned record any other
+    // output is a change too. The expected_divergence outcome is asserted
+    // by whichever future milestone reintroduces a divergence record.
+    try std.testing.expect(expectations.divergenceFor(646) == null);
+    try std.testing.expectEqual(Outcome.changed_divergence, classify(.divergence, true, "", 646));
+    try std.testing.expectEqual(Outcome.changed_divergence, classify(.divergence, false, "<h3>foo\\</h3>\n", 646));
     try std.testing.expectEqual(Outcome.changed_divergence, classify(.divergence, false, "different", 646));
 }
 


### PR DESCRIPTION
## Summary

- bind the conformance harness to the exact official CommonMark 0.31.2 corpus (byte count 204,857; 652 examples; SHA-256 verified before parsing)
- classify every example as supported / not-yet / named divergence in a reviewed manifest (`tools/commonmark_expectations.zig`, documented in `docs/COMMONMARK-EXPECTATIONS.md`)
- `--gate` fails on any supported regression, unexpected not-yet pass, or changed divergence — the full corpus becomes a regression wall
- add 7 synthetic harness tests (corpus extraction/identity/rejection, manifest validation, classification, trailing-newline rule) wired into `zig build test`
- regenerated after the thematic-break/Setext, fenced-code, and list milestones landed: 546 supported, 106 not-yet, 0 named divergences (the former ATX trailing-backslash divergence at example 646 now conforms), plus README/TESTS.md truthfulness amendments

## Validation

- `zig fmt --check build.zig build.zig.zon src tests tools`
- `zig build test --summary all` — 130/130 passed (114 lib + 9 fixture + 7 harness)
- `zig build spec-conformance -- spec.txt --gate` — 0 regressions, 0 unexpected passes, 0 changed divergences
- `zig build`

No third-party parser implementation source was consulted.
