### PR TITLE
Land post-protection work: Textile parity, scorecard, CI gate, protection draft

### DIFF
--- a/.github/BRANCH-PROTECTION.md
+++ b/.github/BRANCH-PROTECTION.md
@@ -1,0 +1,88 @@
+# Main-branch protection (draft, ready to apply)
+
+Draft configuration for protecting `main`. It is deliberately **not yet
+enabled** — it needs repository-admin access to apply, either through the
+GitHub UI or the Rulesets API. The one check the ruleset requires is the CI
+job from `.github/workflows/ci.yml`:
+
+> **`fmt + tests + conformance gate`** — runs `zig fmt --check`, `zig build
+> test` (148 tests), fetches the official CommonMark 0.31.2 corpus, and
+> runs the classified conformance gate (652/652, 0 regressions).
+
+If that check name ever changes (for example if the CI job is renamed or
+split), update the ruleset to match, or merges to `main` will block.
+
+## Option 1 — Apply in the GitHub UI
+
+Repository **Settings → Rules → Rulesets → New ruleset → New branch
+ruleset**:
+
+1. **Name:** `Protect main`
+2. **Enforcement status:** `Active`
+3. **Bypass list:** remove every actor (the default entry is *Repository
+   admin*). An empty list is the "no bypass" ask — nobody, not even the
+   admin, skips the rules. If you later want an admin escape hatch, add the
+   `Repository admin` role back deliberately.
+4. **Targets:** `Include default branch` (this follows the default branch
+   even if it is ever renamed).
+5. **Rules** — add:
+   - **Require a pull request before merging**
+     - Required approvals: `1`
+     - *Dismiss stale pull request approvals when new commits are pushed*:
+       ON (a new push re-runs the gate)
+     - *Require review from Code Owners*: ON (pairs with
+       `.github/CODEOWNERS`)
+     - *Require conversation resolution before merging*: ON
+     - *Require the most recent push to be approved by someone other than
+       the person who pushed it*: OFF for now (solo repo; turn ON when a
+       second contributor joins)
+   - **Require status checks to pass before merging**
+     - Add check: search and select `fmt + tests + conformance gate`
+     - *Require branches to be up to date before merging*: ON
+   - **Block force pushes**: ON
+   - **Block branch deletion**: ON (optional but recommended)
+6. **Create.**
+
+For comparison, the equivalent classic branch-protection route is
+Settings → Branches → *Add branch protection rule* for `main`, checking
+*Require a pull request*, *Require status checks*, and *Do not allow
+bypassing the above settings* — but **rulesets are preferred** (they
+supersede branch protection and apply the "no bypass" setting cleanly).
+
+## Option 2 — Apply via the Rulesets API
+
+The identical ruleset is ready in `.github/ruleset-main.json`. Requires an
+admin-scoped token (repo *Administration* write permission):
+
+```bash
+gh api --method POST repos/drawmeanelephant/oliver/rulesets --input .github/ruleset-main.json
+```
+
+Or with a personal access token:
+
+```bash
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "X-GitHub-Api-Version: 2026-03-10" \
+  https://api.github.com/repos/drawmeanelephant/oliver/rulesets \
+  -d @.github/ruleset-main.json
+```
+
+Notes on the JSON:
+
+- `"bypass_actors": []` — no actor bypasses the ruleset (the "no bypass"
+  ask). Omitting the field instead allows repository admins to bypass.
+- `strict_required_status_checks_policy: true` — the "branches up to date"
+  requirement.
+- `require_last_push_approval: false` — a solo developer cannot approve
+  their own final push; flip to `true` when a second contributor joins.
+- `allowed_merge_methods` is intentionally omitted: all of merge, squash,
+  and rebase stay permitted.
+
+## Pairing files
+
+- `.github/CODEOWNERS` — every path is owned by the repository owner; with
+  *Require review from Code Owners* ON, the owner must approve changes
+  even from future collaborators.
+- `.github/workflows/ci.yml` — the gate whose check this ruleset requires.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Every path requires review by the repository owner.
+# Pairs with "Require review from Code Owners" in the "Protect main"
+# ruleset (.github/BRANCH-PROTECTION.md). Update the handle if ownership
+# moves to a team.
+* @drawmeanelephant

--- a/.github/ruleset-main.json
+++ b/.github/ruleset-main.json
@@ -1,0 +1,42 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "fmt + tests + conformance gate"
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: fmt + tests + conformance gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Zig 0.16.0
+        uses: ziglang/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Format check
+        run: zig fmt --check build.zig build.zig.zon src tests tools
+
+      - name: Full test suite
+        run: zig build test --summary all
+
+      # The classified conformance gate binds Oliver to the exact official
+      # CommonMark 0.31.2 corpus (byte count, example count, and SHA-256 are
+      # verified first) and fails on any supported regression, unexpected
+      # pass, or changed divergence. The corpus is fetched per
+      # docs/TESTS.md; the harness refuses a different file.
+      - name: Fetch official CommonMark 0.31.2 corpus
+        run: curl -fsSL -o spec.txt https://spec.commonmark.org/0.31.2/spec.txt
+
+      - name: Classified conformance gate (652/652)
+        run: zig build spec-conformance -- spec.txt --gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # ziglang/setup-zig was deleted in the Zig org's GitHub->Codeberg
+      # migration (Nov 2025); mlugg/setup-zig is its maintained successor
+      # and a drop-in replacement supporting the same `version` input.
       - name: Install Zig 0.16.0
-        uses: ziglang/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ src/                        the library + provisional CLI
 tests/                      fixture-driven tests (fixtures live here too)
 docs/                       clean-room rules, architecture, feature matrix,
                             document model, test conventions, session report
+.github/                    CI gate (workflow) and the draft main-branch
+                            protection ruleset (BRANCH-PROTECTION.md)
 ```
 
 ## Design values

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ named via the WHATWG entities table, decoded in text, link
 destinations/titles, info strings, and autolinks but never in code
 spans/blocks or as structural syntax), plain
 inline text, a shared document model, a deterministic HTML renderer,
-Markdown (ATX) and Textile (`hN.`)
-frontends, structured diagnostics, and a provisional CLI.
+Markdown (ATX) and Textile
+frontends (`hN.` headings, `p.`/`bq.`, `*`/`#` lists, `@code@`, the
+phrase-modifier family `_x_`/`*x*`/`__x__`/`**x**`/`-x-`/`+x+`/`^x^`/`~x~`/`%x%`,
+`"text":url` links, and `!url!` images — see docs/TEXTILE-PARITY.md),
+structured diagnostics, and a provisional CLI.
 See [docs/SESSION-1-REPORT.md](docs/SESSION-1-REPORT.md) for the founding
 handoff and [docs/FEATURE-MATRIX.md](docs/FEATURE-MATRIX.md) for what is
 implemented, planned, and deferred. The emphasis/strong algorithm contract
@@ -64,6 +67,9 @@ The thematic-break/Setext precedence contract is
 [docs/LEAF-BLOCKS.md](docs/LEAF-BLOCKS.md).
 The fenced-code open-leaf/model/rendering contract is
 [docs/FENCED-CODE.md](docs/FENCED-CODE.md).
+The Textile fixture audit — inventory, gaps vs. Textile 2 semantics, and
+chosen behaviors for phrase modifiers, links, images, and lists — is
+[docs/TEXTILE-PARITY.md](docs/TEXTILE-PARITY.md).
 Code spans, links, images, autolinks, and raw HTML ride the same
 scan → match → emit seam.
 
@@ -77,11 +83,49 @@ and prints a per-section scorecard. Every example is classified in a
 reviewed manifest (docs/COMMONMARK-EXPECTATIONS.md) as supported,
 not-yet, or a named divergence; `--gate` fails on any supported regression,
 unexpected pass, or changed divergence, so the full corpus is a regression
-wall (see docs/TESTS.md for the current 652/652 scorecard and how to fetch
-the spec).
+wall (see docs/TESTS.md for how to fetch the spec).
+
+### Current scorecard: 652/652 — full CommonMark 0.31.2 conformance
+
+Every one of the 652 normative examples passes byte-for-byte (0 not-yet,
+0 named divergences). Per-section counts are derived from the harness:
 
 ```bash
-zig build test    # run all tests (140 tests)
+zig build spec-conformance -- spec.txt
+```
+
+| CommonMark 0.31.2 section | score |
+| --- | --- |
+| Tabs | 11/11 |
+| Backslash escapes | 13/13 |
+| Entity and numeric character references | 17/17 |
+| Precedence | 1/1 |
+| Thematic breaks | 19/19 |
+| ATX headings | 18/18 |
+| Setext headings | 27/27 |
+| Indented code blocks | 12/12 |
+| Fenced code blocks | 29/29 |
+| HTML blocks | 44/44 |
+| Link reference definitions | 27/27 |
+| Paragraphs | 8/8 |
+| Blank lines | 1/1 |
+| Block quotes | 25/25 |
+| List items | 48/48 |
+| Lists | 26/26 |
+| Inlines | 1/1 |
+| Code spans | 22/22 |
+| Emphasis and strong emphasis | 132/132 |
+| Links | 90/90 |
+| Images | 22/22 |
+| Autolinks | 19/19 |
+| Raw HTML | 20/20 |
+| Hard line breaks | 15/15 |
+| Soft line breaks | 2/2 |
+| Textual content | 3/3 |
+| **Total** | **652/652** |
+
+```bash
+zig build test    # run all tests (148 tests)
 zig build         # build the static library and CLI into zig-out/
 ```
 

--- a/docs/DOCUMENT-MODEL.md
+++ b/docs/DOCUMENT-MODEL.md
@@ -23,9 +23,11 @@ Node {
 ```
 
 `Tag` in the slice: `document`, `paragraph`, `heading`, `thematic_break`,
-`code_block`, `html_block`, `block_quote`, `list`, `list_item`, `text`, `emphasis`, `strong`, `code_span`, `link`, `image`,
+`code_block`, `html_block`, `block_quote`, `list`, `list_item`, `text`, `emphasis`, `strong`, `bold`, `italic`, `deleted`, `inserted`, `superscript`, `subscript`, `span`, `code_span`, `link`, `image`,
 `autolink`, `raw_html`, `soft_break`, `hard_break`. Blocks and inlines are
-distinguished by `Tag.isBlock` / `Tag.isInline`. `Data` carries `heading`
+distinguished by `Tag.isBlock` / `Tag.isInline`. The `bold`/`italic`/
+`deleted`/`inserted`/`superscript`/`subscript`/`span` tags are Textile-only
+phrase modifiers (docs/TEXTILE-PARITY.md §1); Markdown never produces them. `Data` carries `heading`
 level (1..6), list kind/marker metadata/start/looseness, the borrowed `text`
 slice, arena-owned `code_span` content, arena-owned `code_block` content/info,
 the arena-owned `html_block` verbatim content,
@@ -83,9 +85,10 @@ the arena-owned `image` src/alt/title, or the arena-owned `autolink` href/label.
 7. `.list` children are `.list_item` blocks; `.list_item` children are
    blocks, and list payloads record bullet/ordered type, marker metadata,
    ordered start, and tight/loose state.
-8. `emphasis`/`strong`/`link` contain inline children. The leaf inline
-   tags (`text`, `code_span`, `image`, `autolink`, `raw_html`, `soft_break`,
-   `hard_break`) never have children.
+8. `emphasis`/`strong`/`bold`/`italic`/`deleted`/`inserted`/
+   `superscript`/`subscript`/`span`/`link` contain inline children. The
+   leaf inline tags (`text`, `code_span`, `image`, `autolink`, `raw_html`,
+   `soft_break`, `hard_break`) never have children.
 9. `Data.text` always slices the document's source bytes; `raw_html` also
    borrows its bytes through `Node.span` and carries `Data.none`; the other
    text payloads (`code_span`, `code_block.content`, `code_block.info`,
@@ -120,10 +123,12 @@ with header flag).
 `.code_block` is implemented for fenced and indented Markdown blocks.
 `.html_block` is implemented for Markdown §4.6 HTML blocks (all seven
 types) with its arena-owned verbatim content.
-`emphasis`/`strong`/`link`/`image`/`autolink` are implemented;
+`emphasis`/`strong`/`bold`/`italic`/`deleted`/`inserted`/`superscript`/
+`subscript`/`span`/`link`/`image`/`autolink` are implemented;
 `raw_html` is implemented for Markdown inline tags; Textile keeps `<...>` as
 plain text until a dialect-specific raw-HTML decision is made.
-`emphasis`/`strong`
+`emphasis`/`strong`/`bold`/`italic`/`deleted`/`inserted`/`superscript`/
+`subscript`/`span`
 carry no special data — nesting already expresses it. `code_span`,
 `link`, `image`, and `autolink` are the implemented inlines whose
 payloads are **arena-owned**: `data.code_span` is the dialect-normalized
@@ -163,10 +168,14 @@ emit them in a fixed documented order.
 | thematic break | (planned) | `.thematic_break` |
 | fenced code block | `bc.` / `pre.` (planned) | `.code_block` (owned content/info) |
 | HTML block (Markdown §4.6 types 6/7) | (Textile has no HTML blocks; literal) | `.html_block` (owned verbatim content) |
-| `emphasis` / `strong` | (Textile inline markers: later) | `.emphasis` / `.strong` |
+| `emphasis` / `strong` | Textile `_x_` / `*x*` | `.emphasis` / `.strong` |
+| `bold` / `italic` | Textile `**x**` / `__x__` | `.bold` / `.italic` |
+| `deleted` / `inserted` | Textile `-x-` / `+x+` | `.deleted` / `.inserted` |
+| `superscript` / `subscript` | Textile `^x^` / `~x~` | `.superscript` / `.subscript` |
+| `span` | Textile `%x%` | `.span` (no attributes yet) |
 | `` `code span` `` | `@code@` | `.code_span` (arena-owned payload: Markdown §6.1-normalized vs Textile-verbatim) |
-| `[x](url "title")` | (Textile `"text":url`: later) | `.link` (arena-owned href/title) |
-| `![alt](url "title")` | (Textile `!url(alt)!`: later) | `.image` (arena-owned src/alt/title) |
+| `[x](url "title")` | Textile `"text":url`, `"text (title)":url` | `.link` (arena-owned href/title) |
+| `![alt](url "title")` | Textile `!url!`, `!url(alt)!`, `!url!:href` | `.image` (arena-owned src/alt/title) |
 | `<scheme:...>` / `<a@b.c>` | (Textile has no autolink; literal) | `.autolink` (arena-owned href/label) |
 | raw HTML tag (`<tag>`, comment, PI, declaration, CDATA) | literal text | `.raw_html` in Markdown; `.text` in Textile |
 | plain text | plain text | `.text` |

--- a/docs/FEATURE-MATRIX.md
+++ b/docs/FEATURE-MATRIX.md
@@ -100,7 +100,7 @@ below).
 | line breaks | implemented | Newline inside a paragraph → hard break → `<br />`. Textile 2 is explicit ("newlines for XHTML content receive a `<br />` tag at the end of the line, with the exception of the last line in the paragraph"); Hobix prose agrees ("Line breaks are converted to HTML breaks") though its rendered example shows a plain newline — recorded below. |
 | block quotes | implemented | Single-period `bq.` from the Hobix Textile Reference, Movable Type Textile 2 Syntax, and the current Textile Markup Language Documentation. The signature must be followed by space/tab; all separator whitespace is consumed. Unmarked following lines continue one paragraph inside `.block_quote` with Textile hard breaks until a blank line or a recognized `p.`, `hN.`, or `bq.` signature; signatures interrupt an open block. The quote and child paragraph spans exclude the marker/separator and cover their content. An empty `bq. ` stays literal because the sources do not specify empty quote behavior. Extended `bq..` and citation `bq.:URL` remain literal/deferred. |
 | pre/code | planned | `pre.` and `bc.` (block code, which also escapes `<`/`>`). |
-| lists | planned | `*` unordered, `#` ordered; nesting by repeating the marker (`**` = nested). Styling markers (`(class#id)* one` vs `*(class#id) one`) from Textile 2. |
+| lists | implemented | `*` unordered, `#` ordered; nesting by repeating the marker (`**` = nested), per both references. Each item is one line; lists are tight; a blank line, a block signature, or a non-marker line closes the list tree. A different marker at the same depth starts a sibling list; a depth jump opens empty intermediate items; `*#` runs or markers without a following space/tab are ordinary text (docs/TEXTILE-PARITY.md §3). Styling markers (`(class#id)* one` vs `*(class#id) one`) and multi-line items remain deferred. |
 | tables | planned | `|a|b|c|` rows; `|_. header|`; cell modifiers (`{style}`, `(class)`, alignment, `\2` colspan, `/3` rowspan); table/row attributes. |
 | footnotes | planned | `fn1.` blocks and `[1]` references. |
 | escaping blocks | planned | `==` delimited regions and `notextile.` (raw) — Textile 2 documents `==`; Oliver will also accept `notextile.` where documented. |
@@ -114,21 +114,21 @@ below).
 | feature | status | Oliver behavior / notes |
 | --- | --- | --- |
 | plain text | implemented | Verbatim bytes; escaped at render like Markdown (shared renderer). |
-| emphasis `_x_` | planned | → `<em>`. Both references agree. |
-| strong `*x*` | planned | → `<strong>`. Both references agree. |
-| bold `**x**` / italic `__x__` | planned | → `<b>` / `<i>`. Both references agree (Hobix: "doubling the underscores or asterisks"). |
-| deleted `-x-` / inserted `+x+` | planned | → `<del>` / `<ins>`. Both references agree. |
-| superscript `^x^` / subscript `~x~` | planned | → `<sup>` / `<sub>`. Both references agree. |
+| emphasis `_x_` | implemented | → `<em>`. Both references agree. Same-line, with the shared whitespace/punctuation boundary contract (docs/TEXTILE-PARITY.md §3). |
+| strong `*x*` | implemented | → `<strong>`. Both references agree. Same boundary contract. |
+| bold `**x**` / italic `__x__` | implemented | → `<b>` / `<i>`. Both references agree (Hobix: "doubling the underscores or asterisks"). Runs of 3+ stay entirely literal. |
+| deleted `-x-` / inserted `+x+` | implemented | → `<del>` / `<ins>`. Both references agree. |
+| superscript `^x^` / subscript `~x~` | implemented | → `<sup>` / `<sub>`. Both references agree. |
 | code `@x@` | implemented | Same-line code phrase → shared opaque `.code_span` → `<code>`; payload bytes are verbatim and the full `@...@` source range is the node span. Textile 2 explicitly requires `<`/`>` escaping; the shared renderer also escapes `&`, `"`, and NUL. Open/close operators must touch non-whitespace content and use outside Unicode whitespace/punctuation boundaries; intraword, empty, edge-whitespace, unmatched, embedded-`@`, and cross-line shapes fall back literally. Backslash has no escape role in the cited references. Exact clean-room contract: `docs/TEXTILE-INLINE-CODE.md`. |
 | citation `??x??` | planned | → `<cite>`. Hobix only. |
-| span `%x%` | planned | → `<span>` (with attributes). Both references agree. |
+| span `%x%` | implemented | → `<span>` (no attributes yet). Both references agree. Attribute forms (`%{style}x%` etc.) stay planned. |
 | big `++x++` / small `--x--` | deferred | Textile 2 only; Hobix does not document them. Oliver will not implement until the inline milestone and will record the choice. |
-| links | planned | `"text":url`, optional `(title)` inside the quotes, aliases `[alias]url` + `"text":alias`. Both references agree on the core form. |
-| images | planned | `!url!`, alt `(alt)`, size modifiers, link attachment `!url!:href`, alignment/attribute modifiers. Both references agree on core; Textile 2 adds sizing syntax. |
+| links | implemented | `"text":url`, optional `(title)` inside the quotes (both references). URL runs to whitespace or `)]}`; trailing sentence punctuation is excluded (Hobix); the bracket trick `You["gotta":url]seethis!` works (Textile 2). Display text is plain text (not re-scanned). Aliases `[alias]url` + `"text":alias` remain planned. See docs/TEXTILE-PARITY.md §3. |
+| images | implemented | `!url!`, alt `(alt)` (Hobix) / ` (alt)` (Textile 2), link attachment `!url!:href` (Hobix). The alt doubles as the title per the Hobix example. Size, alignment, and attribute modifiers remain planned; modifier-prefixed or whitespace-containing bodies stay literal. See docs/TEXTILE-PARITY.md §3. |
 | acronyms | deferred | `CSS(Cascading Style Sheets)` → `<acronym title=...>`. Hobix only. |
 | escaping | planned | `==...==` inline region (Textile 2). Backslash escaping varies by version and is unresolved in the references; Oliver will choose one documented form when implementing. |
 | character replacements | deferred | Curly quotes, `--`→em-dash, `...`→ellipsis, `(c)`/`(r)`/`(tm)`, Textile 2 macros. Oliver deliberately defers all implicit typography: implicit text transformation is the kind of magic a library should make explicit, and it is not needed by the migration consumers. |
-| whitespace sensitivity | planned | Textile 2: inline operators need whitespace before/after to be recognized; brackets/braces can force recognition. The boundary rule is implemented for `@code@`; bracket/brace forcing and the remaining phrase operators stay planned. |
+| whitespace sensitivity | implemented | Textile 2: inline operators need whitespace before/after to be recognized; brackets/braces can force recognition. The boundary rule (Unicode whitespace or punctuation/symbol before an opener and after a closer, non-whitespace content edges) is implemented uniformly for `@code@`, every phrase operator, links, and images (docs/TEXTILE-PARITY.md §3). Bracket/brace forcing stays planned. |
 
 ## Recorded ambiguities and chosen behaviors
 
@@ -222,3 +222,27 @@ below).
     the only closer candidate; invalid shapes remain literal; backslash is
     inert.** Bracket/brace forcing and `==...==` escaping are later features.
     See `docs/TEXTILE-INLINE-CODE.md`.
+18. **Textile phrase operators share the `@code@` boundary contract.** Both
+    references agree on the operator set and the doubling rule (`**` → bold,
+    `__` → italic); neither defines nesting, run splitting, intraword
+    enforcement, or mismatched-closer behavior. **Oliver: openers/closers use
+    the same Unicode whitespace/punctuation boundaries as `@code@`; matching
+    is strict LIFO by character and run length; phrase content is scanned for
+    nested phrases; runs longer than any documented operator (and unmatched
+    openers) stay entirely literal; `++`/`--` big/small are deferred.**
+    See docs/TEXTILE-PARITY.md §3.
+19. **Textile link/image URL edges.** Both references require whitespace
+    around a hyperlink and say common punctuation may follow; Textile 2
+    documents the bracket/brace trick. Neither defines URL terminators or
+    display-text formatting. **Oliver: the URL stops at whitespace or
+    `)]}`; trailing sentence punctuation (`.`, `,`, `;`, `:`, `!`, `?`,
+    quotes, `)]}`) is excluded; link display text and image src/alt are
+    opaque plain text; the image `(alt)` doubles as title.**
+    See docs/TEXTILE-PARITY.md §3.
+20. **Textile list termination and item shape.** Both references show lists
+    as marker-prefixed lines and nesting by marker count; neither defines
+    multi-line items, lazy continuation, mixed markers at one depth, or
+    depth jumps. **Oliver: items are single lines; lists are tight; a blank
+    line, a block signature, or a non-marker line closes the tree; a
+    different marker at the same depth starts a sibling list; a depth jump
+    opens empty intermediate items.** See docs/TEXTILE-PARITY.md §3.

--- a/docs/FEATURE-MATRIX.md
+++ b/docs/FEATURE-MATRIX.md
@@ -32,7 +32,7 @@ divergences.
 | fenced code blocks | implemented | §4.5, per docs/FENCED-CODE.md. Backtick or tilde opener of length ≥3 with ≤3 leading columns; same-marker closer at least as long, ≤3-column indent, trailing spaces/tabs only. Backtick info strings reject backticks; the complete trimmed info string resolves §2.4 backslash escapes and §2.5 entities, is retained, and its first word becomes an escaped `language-…` class. Content is literal, removes up to the opener indentation, normalizes every content line ending to `\n`, and closes without backtracking at the containing block/document end. Emits arena-owned `.code_block { content, info }` and deterministic `<pre><code>`. **Scorecard: 29/29**. |
 | indented code blocks | implemented | §4.4. One or more chunks of lines each indented ≥4 columns (tabs expand to four-column tab stops), separated by blank lines. Cannot interrupt a paragraph; ends at the first line with <4 columns of indentation, so a paragraph may follow immediately. Content is the literal bytes minus four columns of indentation — a tab straddling the boundary leaves its remaining columns as spaces — with blank lines between chunks retained, trailing blank lines dropped, and one final newline. List and quote composition follows the container stack. Emits arena-owned `.code_block { content, info = null }`. **Scorecard: 12/12**. |
 | HTML blocks | implemented | §4.6, all seven types, per docs/HTML-BLOCKS.md. Type 1 (`<script|pre|style|textarea`, case-insensitive), type 2 (`<!--`), type 3 (`<?`), type 4 (`<!` + letter), type 5 (`<![CDATA[`) end at their matching terminator on the line (`</script>` etc., `-->`, `?>`, `>`, `]]>`) or a blank line; type 6 (`<`/`</` + one of the 62 HTML block-tag names) and type 7 (a complete open/closing tag on its own line) end at a blank line (or containing-block boundary). Types 1–6 can interrupt a paragraph; type 7 cannot. Content is the container-stripped remainder with leading whitespace preserved, emitted verbatim as a `.html_block` leaf (pass-through policy, same as inline HTML). **Scorecard: 44/44**. |
-| tables (GFM extension) | planned | Not part of CommonMark. Oliver will define tables as an explicit extension with its own chosen syntax (GFM-style `|` rows + delimiter row), documented before implementation. |
+| tables (GFM extension) | planned | Not part of CommonMark. Oliver will define tables as an explicit extension with its own chosen syntax (GFM-style `|` rows + delimiter row), documented before implementation. This row is the contract doc the docs-authorship decision points at (recorded ambiguity 21). |
 | link reference definitions | implemented | §4.7: `[label]: destination ["title"]` collected during the block pass, before any inline parsing (a use may precede its definition). Extracted at paragraph close: the first line must be `[` + label + `]` + optional spaces/tabs + destination; an optional title may follow on the same line (separated by spaces/tabs) or on the next line; nothing else may follow the title on its line; indentation beyond 3 spaces cannot start a definition. First definition wins per label; labels are case-folded (Unicode full case fold, §6.3) with internal whitespace collapsed to a single space; an unclosed `[` cannot be a definition. Paragraphs consisting solely of definitions disappear from output; a definition may sit inside a paragraph of other content (the surrounding paragraph keeps its own inline pass). |
 | blank lines | implemented | §3; whitespace-only lines separate blocks and are never part of content. |
 
@@ -246,3 +246,18 @@ below).
     line, a block signature, or a non-marker line closes the tree; a
     different marker at the same depth starts a sibling list; a depth jump
     opens empty intermediate items.** See docs/TEXTILE-PARITY.md §3.
+21. **The repo's own docs use GFM tables by choice.** The authoring docs
+    (README.md plus ten `docs/*.md`: ARCHITECTURE, BLOCKS-PARSING,
+    DOCUMENT-MODEL, ENTITIES, FEATURE-MATRIX, IMAGES-PARSING,
+    INLINE-PARSING, TESTS, TEXTILE-PARITY, WORK-LEDGER) use GFM table
+    syntax, which Oliver renders literally today. This is deliberate: the
+    docs are read on GitHub and in source, where GFM tables are the native
+    format, and no Oliver consumer renders them (Oliver is markup
+    infrastructure; static-site generation is a documented non-goal).
+    Converting them to raw-HTML `<table>` blocks would let Oliver render
+    them today but would impose an authoring tax on every future table.
+    **Oliver: defer. The update points when the GFM tables extension lands
+    are the "tables (GFM extension)" row above (the contract doc) and the
+    table-shaped assertions that pin it — the DOCUMENT-MODEL.md
+    convergence table, the fixture index, and the shared-model convergence
+    pairs in tests/fixtures_test.zig.**

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -2,28 +2,38 @@
 
 Tests are product contracts. `zig build test` runs three suites:
 
-1. **Library module tests** — 114 `test` blocks inside `src/*.zig` covering
+1. **Library module tests** — 132 `test` blocks inside `src/*.zig` covering
    source lines/spans, the normalized document, diagnostics, both dialect
    frontends, Unicode case folding, the HTML renderer, and the public API.
    Markdown tests pin the container stack, thematic-break/list precedence,
    multiline Setext transformation, reference-definition interaction,
    terminal-backslash behavior, fenced-code payload/spans, every implemented
    inline family, exact AST shapes, and exact spans. Textile tests pin
-   `p.`/`hN.`/`bq.` structure, hard-break terminators, and `@code@` payloads.
+   `p.`/`hN.`/`bq.` structure, hard-break terminators, `@code@` payloads,
+   the phrase-modifier family (tags, spans, nesting, boundary fallbacks),
+   links (titles, bracket trick, literal fallbacks), images (alt/title,
+   link attachment, literal fallbacks), list structure/nesting/termination,
+   a 10,000-pair phrase storm, and a 2,000-deep phrase-nesting workload.
    Renderer tests construct documents directly so renderer behavior is
    verified without a dialect parser.
 2. **Fixture and adversarial tests** — 9 tests in `tests/fixtures_test.zig`.
-   The explicit index contains 246 Markdown and 24 Textile fixture pairs.
+   The explicit index contains 246 Markdown and 39 Textile fixture pairs.
    The Markdown wall includes byte-exact CommonMark 0.31.2 coverage of
    emphasis/strong, code spans, inline links, inline/reference-style images,
    block quotes, list items and lists (§§5.2–5.3: marker-width indentation,
    ordered starts and near misses, empty items, interruption, nesting,
    marker/delimiter separation, tight/loose propagation, and quote/list
-   composition), reference links, autolinks, raw HTML, thematic breaks,
+   composition),   reference links, autolinks, raw HTML, thematic breaks,
    Setext headings, fenced and indented code blocks (§4.4 chunks,
    interruption, tab-stop indentation in markers/containers), and tab-stop
    handling (§2.1); the Textile wall covers `bq.`
-   quotes and `@code@` spans. It also verifies shared-model convergence,
+   quotes, `@code@` spans, the full phrase-modifier family
+   (strong/emphasis/bold/italic/del/ins/sup/sub/span, nesting, and literal
+   boundary fallbacks), links (`"text":url`, titles, the bracket trick,
+   literal fallbacks), images (`!url!`, alt/title forms, the `!url!:href`
+   attachment, literal fallbacks), and `*`/`#` lists with nesting,
+   sibling-marker switches, and termination (docs/TEXTILE-PARITY.md). It
+   also verifies shared-model convergence,
    hostile-input completion and leak freedom, NUL policy, diagnostics, and
    deterministic repeat rendering (list stress: 2k nested items, 10k
    same-marker items, 15k alternating markers, 12k variably indented
@@ -36,7 +46,7 @@ Tests are product contracts. `zig build test` runs three suites:
    rejection, outcome classification, and the single-trailing-newline
    comparison. These tests need no downloaded corpus.
 
-The current complete result is **140/140 tests passing** with Zig 0.16.0.
+The current complete result is **148/148 tests passing** with Zig 0.16.0.
 
 ## Fixture convention
 
@@ -79,7 +89,9 @@ A completed syntax feature should include, where meaningful:
 The current Markdown wall covers emphasis/strong, code spans, inline and
 reference links/images, definitions, autolinks, inline raw HTML, block quotes,
 fenced code blocks, thematic breaks, Setext headings, escapes, breaks, paragraphs, and ATX
-headings. The leaf-block slice adds four thematic-break fixture groups, eight
+headings. The Textile wall covers the same families through the Textile
+syntax plus the Textile-only phrase modifiers, links, images, and lists
+(docs/TEXTILE-PARITY.md §5). The leaf-block slice adds four thematic-break fixture groups, eight
 Setext groups, a terminal-backslash fixture, exact AST/span tests, renderer
 profile tests, and a deterministic 10,000-cycle heading/break workload. The
 fenced-code slice adds 13 fixture groups spanning the normative rule families,
@@ -159,29 +171,45 @@ combined with `--gate`. The harness converts the spec's tab-arrow marker to
 a real tab and ignores exactly one renderer-owned final newline.
 
 Current canonical baseline: **652/652 examples pass — full conformance**
-(652 supported, 0 not-yet, 0 named divergences).
+(652 supported, 0 not-yet, 0 named divergences). The per-section table is
+derived from the harness output and kept in sync with README.md:
 
-- Tabs: 11/11 (four-column tab stops for block structure, literal bytes in
-  content).
-- Entity and numeric character references: 17/17 (named via the WHATWG
-  entities table, numeric per §2.5, decoded in text, link destinations and
-  titles, and fenced info strings; literal in code spans/code blocks).
-- HTML blocks: 44/44 — all seven §4.6 types complete (types 1–5 end at
-  their matching terminator, types 6/7 at a blank line).
-- Thematic breaks, Setext headings, ATX headings, indented code blocks,
-  fenced code blocks, block quotes, list items, backslash escapes, and
-  paragraphs: 100%.
-- Lists: 26/26.
-- Link reference definitions: 27/27 (the last not-yet example — §4.7 edge
-  case #201, an angle destination directly followed by a would-be title —
-  was closed by the full-conformance milestone).
-- Code spans, emphasis/strong, links, images, autolinks, inline raw HTML,
-  hard/soft breaks, and textual content: 100%.
+| CommonMark 0.31.2 section | score |
+| --- | --- |
+| Tabs | 11/11 |
+| Backslash escapes | 13/13 |
+| Entity and numeric character references | 17/17 |
+| Precedence | 1/1 |
+| Thematic breaks | 19/19 |
+| ATX headings | 18/18 |
+| Setext headings | 27/27 |
+| Indented code blocks | 12/12 |
+| Fenced code blocks | 29/29 |
+| HTML blocks | 44/44 |
+| Link reference definitions | 27/27 |
+| Paragraphs | 8/8 |
+| Blank lines | 1/1 |
+| Block quotes | 25/25 |
+| List items | 48/48 |
+| Lists | 26/26 |
+| Inlines | 1/1 |
+| Code spans | 22/22 |
+| Emphasis and strong emphasis | 132/132 |
+| Links | 90/90 |
+| Images | 22/22 |
+| Autolinks | 19/19 |
+| Raw HTML | 20/20 |
+| Hard line breaks | 15/15 |
+| Soft line breaks | 2/2 |
+| Textual content | 3/3 |
+| **Total** | **652/652** |
 
 The former ATX trailing-backslash divergence (example 646) was resolved to
-the normative output by the thematic-break/Setext milestone; no named
-divergences remain. Failures are not silently skipped: the classified gate
-makes the whole 0.31.2 corpus a regression wall.
+the normative output by the thematic-break/Setext milestone; the last
+not-yet example — §4.7 edge case #201, an angle destination directly
+followed by a would-be title — was closed by the full-conformance
+milestone. No named divergences remain. Failures are not silently skipped:
+the classified gate makes the whole 0.31.2 corpus a regression wall.
 
 ## Commands
 

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1,0 +1,188 @@
+# Textile parity audit
+
+Oliver's Markdown frontend is held to the 652-example CommonMark 0.31.2
+conformance corpus. Textile has no comparable normative corpus, so its
+quality bar is a **fixture audit**: every implemented feature is inventoried
+against the shared document model, pinned by fixture pairs and unit tests,
+and every gap against the published Textile 2 semantics is either closed or
+recorded as a deliberate deferral. This document is that audit. It is
+derived only from the clean-room sources of docs/CLEANROOM.md: the Hobix
+**Textile Reference**, Movable Type's **Textile 2 Syntax**, and the current
+Textile Markup Language Documentation. No parser implementation was
+consulted.
+
+## 1. Inventory: implemented Textile features vs. the shared model
+
+| Textile syntax | shared node | HTML | status |
+| --- | --- | --- | --- |
+| `p.` marker / bare paragraph lines | `.paragraph` | `<p>` | implemented (T1) |
+| `hN.` headings | `.heading` (level 1..6) | `<h1>`…`<h6>` | implemented (T1) |
+| single-period `bq.` | `.block_quote` → `.paragraph` | `<blockquote><p>` | implemented (T1) |
+| newline in a paragraph | `.hard_break` | `<br />` | implemented (T1) |
+| `@code@` | `.code_span` (verbatim arena payload) | `<code>` | implemented (T2) |
+| `*x*` strong | `.strong` | `<strong>` | implemented (T4) |
+| `_x_` emphasis | `.emphasis` | `<em>` | implemented (T4) |
+| `**x**` bold | `.bold` | `<b>` | implemented (T4) |
+| `__x__` italic | `.italic` | `<i>` | implemented (T4) |
+| `-x-` deleted | `.deleted` | `<del>` | implemented (T4) |
+| `+x+` inserted | `.inserted` | `<ins>` | implemented (T4) |
+| `^x^` superscript | `.superscript` | `<sup>` | implemented (T4) |
+| `~x~` subscript | `.subscript` | `<sub>` | implemented (T4) |
+| `%x%` span | `.span` | `<span>` | implemented (T4) |
+| `"text":url` link | `.link` (arena href/title) | `<a href title>` | implemented (T4) |
+| `"text (title)":url` link | `.link` (+ title) | `<a href title>` | implemented (T4) |
+| `!url!` image | `.image` (src, alt `""`) | `<img src alt />` | implemented (T4) |
+| `!url(alt)!` / `!url (alt)!` image | `.image` (src, alt, title) | `<img src alt title />` | implemented (T4) |
+| `!url!:href` linked image | `.link` → `.image` | `<a><img /></a>` | implemented (T4) |
+| `*` bullet lists | `.list` (bullet) → `.list_item` → `.paragraph` | `<ul><li>` | implemented (T4) |
+| `#` ordered lists | `.list` (ordered) → `.list_item` → `.paragraph` | `<ol><li>` | implemented (T4) |
+| marker-depth nesting (`**`, `##`) | nested `.list` inside `.list_item` | nested `<ul>`/`<ol>` | implemented (T4) |
+
+T1/T2/T4 refer to the ledger cards in docs/WORK-LEDGER.md. "T4" is the
+phrase/link/image/list milestone this audit drove; every new row is pinned
+by a fixture pair plus exact-span unit tests in `src/textile.zig`, and the
+convergence test in `tests/fixtures_test.zig` proves the shared renderer
+produces byte-identical output for equivalent Markdown/Textile inputs
+(Textile `*x*` ↔ Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`,
+`!img.png!` ↔ `![](img.png)`, `# x` ↔ `1. x`).
+
+## 2. Gaps vs. Textile 2 semantics: audit results
+
+The audit walked the two references feature by feature. The **biggest
+user-visible gaps** were the inline phrase-modifier family, links, images,
+and lists — the four families listed in this milestone's brief — because
+every paragraph in the documented examples uses at least one of them, and
+the previous slice rendered them literally. All four are now implemented.
+
+Remaining gaps are deliberate and recorded in docs/FEATURE-MATRIX.md as
+planned/deferred. The notable ones, so the record is honest:
+
+- **Link aliases** — `[alias]url` lookup blocks and `"text":alias`
+  references (both references document them). Deferred: needs a
+  document-level definition table mirroring the Markdown §4.7 machinery.
+- **Image modifiers** — alignment (`!<x!`, `!>x!`, `!-x!`, `!^x!`, `!~x!`),
+  CSS class/id/style, padding, and sizing (`10x20`, `10w 20h`, `20%`) from
+  Textile 2. Oliver keeps modifier-prefixed and whitespace-containing image
+  bodies literal (fixture `image-literal`).
+- **`bq..` extended blocks and citations**, **`pre.`/`bc.`**, **tables**,
+  **footnotes**, **block/line attributes**, **`==` escaping**, and the
+  **character-replacement macros** (curly quotes, em/en dashes, ellipsis,
+  `(c)`/`(r)`/`(tm)`). All planned/deferred in the feature matrix.
+- **Textile 2's `++bigger++` / `--smaller--`** (`<big>`/`<small>`): only in
+  Textile 2, not Hobix; Oliver defers per the "implement once from the
+  majority" rule. Runs of 2+ for the single-length operators stay literal.
+- **`??citation??`**, **acronyms**, and **definition lists** (Hobix-only or
+  Textile 2-only) — deferred.
+- **Textile raw HTML** — Textile keeps `<...>` as plain text (no `.raw_html`
+  recognition); documented in the model convergence table.
+- **Bracket/brace forcing** (`c[*oo*]l`) — documented by Textile 2 as a way
+  to force intraword formatting; not inferred by this slice (same position
+  as docs/TEXTILE-INLINE-CODE.md §2 for `@code@`).
+
+## 3. Chosen behaviors where the references are silent or disagree
+
+Each choice is a *choice*, recorded here and in the feature matrix, never an
+accident. "Both references" means Hobix + Textile 2; where they differ the
+disagreement is named.
+
+1. **Phrase delimiter runs.** `*`/`_` of length 1 are strong/emphasis and of
+   length 2 are bold/italic (both references agree: "doubling the
+   underscores or asterisks"); `-`, `+`, `^`, `~`, `%` are single-length
+   only. Runs longer than any documented operator stay **entirely literal**
+   (`***x***` is never split into literal `*` + bold `**`), and unmatched
+   openers stay literal — the same conservatism as `@code@` edge cases.
+2. **Boundary rule.** An opener needs a whitespace-or-punctuation boundary
+   before and non-whitespace content immediately after; a closer needs
+   non-whitespace before and a whitespace-or-punctuation boundary (or line
+   end) after. This is exactly the documented `@code@` contract
+   (docs/TEXTILE-INLINE-CODE.md §2) applied uniformly. Textile 2's
+   `c*oo*l` counterexample, edge-whitespace phrases, and intraword
+   `a^2`/`50%` all stay literal (fixture `phrase-boundaries`).
+3. **Nesting and LIFO.** Phrase content is scanned for nested phrases
+   (`*_way_*` is Textile 2's own example). Matching is strict LIFO: a
+   closer closes only the innermost open phrase with the same character and
+   run length. A mismatched closer (e.g. a `*` while an `_` is innermost)
+   stays literal and does not close a deeper opener.
+4. **Same-line and single-pass.** Phrases, like `@code@`, never cross a line
+   ending. The scanner is one linear pass over the line (scan → LIFO match →
+   emit with an explicit work stack, so deep nesting cannot overflow the
+   call stack); code-span opacity is preserved — a pending `@` opener makes
+   the intervening bytes opaque to phrases/links/images, so
+   `@*strong* "link":u@` stays one code span.
+5. **Link display text is plain text.** Textile 2 documents no formatting
+   inside `"text":url`, so the display text is one plain `.text` node (not
+   re-scanned), which also makes nested links impossible by construction.
+   Image src/alt are likewise opaque.
+6. **Link URL boundary.** The URL runs to whitespace or a closing bracket
+   (`)` `]` `}`); the bracket trick `You["gotta":url]seethis!` (Textile 2)
+   therefore never swallows its `]`. Common trailing sentence punctuation
+   (`.`, `,`, `;`, `:`, `!`, `?`, quotes, `)]}`) is excluded from the URL
+   (Hobix: "the link won't include any trailing punctuation"). `&` in URLs
+   is escaped by the shared renderer like Markdown hrefs (Textile 2's
+   "unescaped `&` within URLs will be properly escaped").
+7. **Link title.** `"text (title)":url` — the parenthesized suffix of the
+   display text, recognized only when preceded by a space (so
+   `"a(b)":url` has no title and display `a(b)`). The title is arena-owned
+   and HTML-escaped at render, like Markdown titles.
+8. **Image alt/title.** `!url(alt)!` (Hobix, no space) and `!url (alt)!`
+   (Textile 2, with space) both set the alt; per the Hobix example the alt
+   also becomes the title. The shared renderer's fixed attribute order is
+   `src`, `alt`, `title` (Hobix's raw output shows `title` before `alt`;
+   Oliver's order is the renderer policy of docs/ARCHITECTURE.md).
+9. **Lists are single-line, tight, and marker-depth driven.** Each item is
+   one line (`*`/`#` run + space/tab + content). Nesting is by marker count,
+   not indentation (both references' `**`/`##` examples). Items render
+   tight (no `<p>`), like Hobix's `<li>A first item</li>`. A blank line, a
+   block signature, or any non-marker line closes the list tree — an
+   unmarked line after list content is a fresh paragraph, and a following
+   marker line starts a new list (neither reference defines multi-line
+   items or lazy continuation).
+10. **Depth jumps and marker switches.** `* a` then `*** b` (skipping a
+    level) opens the intermediate list with an empty item — deterministic,
+    but outside the documented examples. A different marker at the same
+    depth closes that list and opens a sibling list (`* a` / `# b` are two
+    sibling lists, matching the "each item in its own paragraph" reading).
+    A mixed run (`*#`) or a run not followed by space/tab is ordinary text.
+11. **List placement.** Marker lines interrupt an open paragraph or `bq.`
+    quote (they are recognized block signatures), and the resulting list
+    attaches to the same parent the interrupted block would have had — the
+    root. Lists inside block quotes are not in either reference and are
+    deferred.
+12. **Opaque-atom precedence.** Code spans, links, and images are atoms
+    discovered in the same scan as phrase delimiters; their contents are
+    opaque and they are never split by phrase scanning. Phrase delimiters
+    inside link display text or image src/alt are not recognized (they are
+    inside atoms).
+
+## 4. Complexity
+
+The inline pass is three linear passes over the line (item scan, LIFO
+match, emit) plus a work stack for nested phrase emission — no recursion,
+no substring rescans, no quadratic delimiter storms (the 10,000-pair
+`*ok*`/near-miss storm and the 2,000-deep nesting test in `src/textile.zig`
+run as ordinary unit tests, and each passes under `std.testing.allocator`).
+Failing link/image lookaheads only ever scan up to the next `"`/`!` (or a
+URL's whitespace), and those segments are disjoint, so the scan is linear
+even for hostile quote/bang runs.
+
+## 5. Acceptance contract
+
+The fixture wall added by this audit:
+
+- the full phrase-modifier family with exact node spans and byte-exact HTML
+  (`phrase-modifiers`, `phrase-in-heading`);
+- documented nesting `*_way_*` plus deeper same-type/other-type nesting
+  (`phrase-nesting`);
+- every boundary fallback: intraword, edge whitespace, over-long runs,
+  deferred `--`, unmatched openers (`phrase-boundaries`);
+- links: trailing punctuation, mailto, relative URLs, titles, the bracket
+  trick, and literal fallbacks (`link-basic`, `link-title`,
+  `link-bracket-trick`, `link-literal`);
+- images: absolute/relative src, Hobix and Textile 2 alt forms, the link
+  attachment, and literal fallbacks for deferred modifiers and malformed
+  shapes (`image-basic`, `image-linked`, `image-literal`);
+- lists: bullet/ordered basics, mixed-depth nesting, sibling lists, and
+  termination by blank line, plain text, and signatures
+  (`list-basic`, `list-nested`, `list-mixed`);
+- cross-family composition and `@code@` opacity (`inline-composition`);
+- shared-model convergence with the Markdown frontend (see §1).

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -202,6 +202,38 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
   **652/652 — full conformance**, 0 not-yet, 0 divergences, 0 regressions.
   140/140 tests green.
 
+## T4 — Textile parity audit: phrase modifiers, links, images, lists
+
+- **Objective:** build the Textile fixture audit (docs/TEXTILE-PARITY.md):
+  inventory every implemented Textile feature against the shared document
+  model, then close the biggest gaps vs. Textile 2 semantics — the inline
+  phrase-modifier family, `"text":url` links, `!url!` images, and `*`/`#`
+  lists.
+- **Authoritative sources:** Hobix Textile Reference; Movable Type Textile 2
+  Syntax (both clean-room allowed); the existing Textile contracts
+  (docs/TEXTILE-INLINE-CODE.md).
+- **Dependencies:** shared model/renderer; the T2 `@code@` boundary contract
+  is reused uniformly for every inline family.
+- **Seams:** `src/textile.zig` (inline item scan → LIFO phrase match → emit,
+  plus the block-pass list tree), new shared tags `bold`/`italic`/`deleted`/
+  `inserted`/`superscript`/`subscript`/`span` in `src/document.zig` and
+  `src/html.zig`, Textile fixtures/index, feature matrix, model and parity
+  docs. Markdown parser files untouched.
+- **Acceptance:** the documented operator set renders to the documented HTML
+  (`_x_`→`<em>`, `*x*`→`<strong>`, `**x**`→`<b>`, `__x__`→`<i>`, `-x-`→`<del>`,
+  `+x+`→`<ins>`, `^x^`→`<sup>`, `~x~`→`<sub>`, `%x%`→`<span>`); nesting
+  `*_way_*`; links with titles and the bracket trick; images with alt/title
+  and the `!url!:href` attachment; tight single-line lists with marker-depth
+  nesting; every ambiguous shape stays literal and is pinned by a fixture.
+- **Tests:** 9 new unit tests (tags/spans, nesting, boundaries, links,
+  images, lists, a 10,000-pair phrase storm, a 2,000-deep nesting workload)
+  and 15 new Textile fixture pairs, plus shared-model convergence pairs.
+- **Parallelism:** yes; Textile-local ownership, Markdown untouched.
+- **Integration:** after M6 (the Markdown corpus is untouched, so the
+  652/652 gate is unaffected).
+- **State:** implemented on main (uncommitted). 148/148 tests green;
+  canonical scorecard still 652/652 with 0 not-yet and 0 divergences.
+
 ## C1 — Classified conformance expectations
 
 - **Objective:** bind the conformance harness to the exact 0.31.2 corpus and

--- a/src/document.zig
+++ b/src/document.zig
@@ -11,8 +11,9 @@
 //! - The root node is always a `.document` whose children are blocks.
 //! - Block tags contain block or inline children as documented per tag;
 //!   `thematic_break`, `code_block`, and `html_block` are childless leaves.
-//! - `emphasis`/`strong`/`link` contain inline children; the leaf inline
-//!   tags (`text`, `code_span`, `image`, `autolink`, `raw_html`,
+//! - `emphasis`/`strong`/`bold`/`italic`/`deleted`/`inserted`/
+//!   `superscript`/`subscript`/`span`/`link` contain inline children; the
+//!   leaf inline tags (`text`, `code_span`, `image`, `autolink`, `raw_html`,
 //!   `soft_break`, `hard_break`) never have children.
 //! - `list` children are `list_item` blocks; `list_item` children are blocks.
 //! - `Node.data.text` always points into the document's source bytes;
@@ -59,12 +60,32 @@ pub const Tag = enum {
     list_item,
     /// Plain text. `data.text` is a slice of the source.
     text,
-    /// Emphasized inline content (Markdown `*x*`, `_x_`). Children: inlines.
-    emphasis,
-    /// Strongly emphasized inline content (Markdown `**x**`, `__x__`).
+    /// Emphasized inline content (Markdown `*x*`, `_x_`; Textile `_x_`).
     /// Children: inlines.
+    emphasis,
+    /// Strongly emphasized inline content (Markdown `**x**`, `__x__`; Textile
+    /// `*x*`). Children: inlines.
     strong,
-    /// Inline code (Markdown backtick span; Textile `@x@` planned). No
+    /// Bold inline content (Textile `**x**`). Children: inlines. Textile
+    /// distinguishes bold `**x**` → `<b>` from strong `*x*` → `<strong>`;
+    /// Markdown has no bold tag.
+    bold,
+    /// Italic inline content (Textile `__x__`). Children: inlines. Textile
+    /// distinguishes italic `__x__` → `<i>` from emphasis `_x_` → `<em>`;
+    /// Markdown has no italic tag.
+    italic,
+    /// Deleted inline content (Textile `-x-`). Children: inlines.
+    deleted,
+    /// Inserted inline content (Textile `+x+`). Children: inlines.
+    inserted,
+    /// Superscript inline content (Textile `^x^`). Children: inlines.
+    superscript,
+    /// Subscript inline content (Textile `~x~`). Children: inlines.
+    subscript,
+    /// A generic inline span (Textile `%x%`). Children: inlines. No payload:
+    /// attribute-bearing forms (`%{style}x%` etc.) are a later milestone.
+    span,
+    /// Inline code (Markdown backtick span; Textile `@x@`). No
     /// children; `data.code_span` is the normalized content, one of the text
     /// payloads owned by the document arena rather than borrowed from the
     /// source (newlines become spaces, so it cannot be a source slice).
@@ -101,13 +122,13 @@ pub const Tag = enum {
     pub fn isBlock(self: Tag) bool {
         return switch (self) {
             .document, .paragraph, .heading, .thematic_break, .code_block, .html_block, .block_quote, .list, .list_item => true,
-            .text, .emphasis, .strong, .code_span, .link, .image, .autolink, .raw_html, .soft_break, .hard_break => false,
+            .text, .emphasis, .strong, .bold, .italic, .deleted, .inserted, .superscript, .subscript, .span, .code_span, .link, .image, .autolink, .raw_html, .soft_break, .hard_break => false,
         };
     }
 
     pub fn isInline(self: Tag) bool {
         return switch (self) {
-            .text, .emphasis, .strong, .code_span, .link, .image, .autolink, .raw_html, .soft_break, .hard_break => true,
+            .text, .emphasis, .strong, .bold, .italic, .deleted, .inserted, .superscript, .subscript, .span, .code_span, .link, .image, .autolink, .raw_html, .soft_break, .hard_break => true,
             .document, .paragraph, .heading, .thematic_break, .code_block, .html_block, .block_quote, .list, .list_item => false,
         };
     }

--- a/src/html.zig
+++ b/src/html.zig
@@ -223,6 +223,40 @@ fn writeOpen(
             try writer.writeAll("<strong>");
             try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
         },
+        .bold => {
+            // Textile `**x**` renders `<b>` (docs/FEATURE-MATRIX.md, Textile
+            // inlines); Markdown never produces this tag.
+            try writer.writeAll("<b>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
+        .italic => {
+            // Textile `__x__` renders `<i>` (docs/FEATURE-MATRIX.md, Textile
+            // inlines); Markdown never produces this tag.
+            try writer.writeAll("<i>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
+        .deleted => {
+            try writer.writeAll("<del>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
+        .inserted => {
+            try writer.writeAll("<ins>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
+        .superscript => {
+            try writer.writeAll("<sup>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
+        .subscript => {
+            try writer.writeAll("<sub>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
+        .span => {
+            // Textile `%x%` renders `<span>` without attributes; the
+            // attribute-bearing forms are a later milestone.
+            try writer.writeAll("<span>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+        },
         .code_span => {
             try writer.writeAll("<code>");
             // Leaf tag: the (normalized) content is escaped like text
@@ -313,6 +347,13 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
         },
         .emphasis => try writer.writeAll("</em>"),
         .strong => try writer.writeAll("</strong>"),
+        .bold => try writer.writeAll("</b>"),
+        .italic => try writer.writeAll("</i>"),
+        .deleted => try writer.writeAll("</del>"),
+        .inserted => try writer.writeAll("</ins>"),
+        .superscript => try writer.writeAll("</sup>"),
+        .subscript => try writer.writeAll("</sub>"),
+        .span => try writer.writeAll("</span>"),
         .code_span => try writer.writeAll("</code>"),
         .link => try writer.writeAll("</a>"),
         // These tags never push exit frames.

--- a/src/textile.zig
+++ b/src/textile.zig
@@ -1,12 +1,18 @@
 //! Textile frontend.
 //!
-//! Vertical slice: paragraphs, `h1.`–`h6.` headings, single-period `bq.` block
-//! quotes, plain inline text, and same-line `@code@` phrases with line breaks.
+//! Blocks: paragraphs, `h1.`–`h6.` headings, single-period `bq.` block
+//! quotes, and `*`/`#` lists with marker-depth nesting. Inlines: plain text,
+//! hard line breaks, same-line `@code@` phrases, the phrase-modifier family
+//! (`*strong*`, `_emphasis_`, `**bold**`, `__italic__`, `-deleted-`,
+//! `+inserted+`, `^superscript^`, `~subscript~`, `%span%`), `"text":url`
+//! links (with `(title)`), and `!url!` images (with `(alt)` and the
+//! `!url!:href` link attachment).
 //! Behavior is chosen from the published user-facing Textile documentation
 //! (Hobix reference; Movable Type "Textile 2 Syntax"; Textile Markup Language
 //! Documentation) where the slice implements it; disagreements between
 //! versions and Oliver's chosen resolutions are recorded in
-//! docs/FEATURE-MATRIX.md and docs/TEXTILE-INLINE-CODE.md.
+//! docs/FEATURE-MATRIX.md and docs/TEXTILE-INLINE-CODE.md and the parity
+//! audit docs/TEXTILE-PARITY.md.
 //!
 //! Chosen behaviors for this slice:
 //! - Blocks are separated by blank lines.
@@ -25,9 +31,18 @@
 //! - `@code@` is recognized only within one line, with the conservative
 //!   whitespace/punctuation boundary contract in docs/TEXTILE-INLINE-CODE.md.
 //!   Code content is an opaque, verbatim `.code_span` payload.
+//! - Phrase modifiers, links, and images use the same boundary contract and
+//!   are recognized within one line; phrase content is scanned for nested
+//!   phrases, while link display text and image src/alt are opaque plain
+//!   text (docs/TEXTILE-PARITY.md §4).
 //! - Paragraph content is preserved verbatim (only the marker's separator
 //!   whitespace is consumed).
 //! - `h0.` and `h7.`+ are not headings; they remain paragraph text.
+//! - A list item is a single line: `*` (bullet) or `#` (ordered) markers,
+//!   one per nesting level, followed by a space or tab. Consecutive marker
+//!   lines compose a tree of tight lists; a blank line, a block signature,
+//!   or a non-marker text line closes all open lists (docs/TEXTILE-PARITY.md
+//!   §6).
 
 const std = @import("std");
 const source = @import("source.zig");
@@ -44,30 +59,46 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
 
     var lines = source.Lines.init(doc.src.bytes);
     var block: ?ActiveBlock = null;
+    var lists = std.ArrayList(ListEntry).empty;
+    defer lists.deinit(doc.allocator());
     while (lines.next()) |line| {
         if (isBlank(line.text)) {
             try closeBlock(doc, &block);
+            closeLists(&lists);
             continue;
         }
         if (tryHeading(line)) |heading| {
             try closeBlock(doc, &block);
+            closeLists(&lists);
             try emitHeading(doc, line, heading);
             continue;
         }
         if (tryParagraphMarker(line)) |content| {
             try closeBlock(doc, &block);
+            closeLists(&lists);
             try appendBlockContent(doc, &block, .paragraph, content, line.terminatorSpan());
             continue;
         }
         if (tryBlockQuoteMarker(line)) |content| {
             try closeBlock(doc, &block);
+            closeLists(&lists);
             try appendBlockContent(doc, &block, .block_quote, content, line.terminatorSpan());
             continue;
         }
+        if (tryListMarker(line)) |lm| {
+            try closeBlock(doc, &block);
+            try appendListItem(doc, &lists, lm);
+            continue;
+        }
+        // A non-marker text line closes the list tree: list items are single
+        // lines, so an unmarked line is a fresh paragraph (docs/TEXTILE-PARITY.md
+        // §6, chosen behavior).
+        if (lists.items.len > 0) closeLists(&lists);
         const kind: BlockKind = if (block) |active| active.kind else .paragraph;
         try appendBlockContent(doc, &block, kind, line.contentSpan(), line.terminatorSpan());
     }
     try closeBlock(doc, &block);
+    closeLists(&lists);
 }
 
 const BlockKind = enum { paragraph, block_quote };
@@ -137,6 +168,107 @@ fn closeBlock(doc: *document.Document, block: *?ActiveBlock) ParseError!void {
         }
         try parseInlines(doc, paragraph, ref.content);
     }
+}
+
+/// One open list level of a Textile list tree. The stack is ordered by
+/// ascending depth (index 0 is depth 1). A new marker line reconciles the
+/// stack to its own depth and marker character, then appends its item.
+const ListEntry = struct {
+    depth: u32,
+    /// `*` (bullet) or `#` (ordered).
+    marker: u8,
+    list: *document.Node,
+    item: *document.Node,
+};
+
+const ListMarker = struct {
+    depth: u32,
+    marker: u8,
+    content: source.Span,
+};
+
+/// Recognizes a list item line: one or more consecutive `*` or `#` markers
+/// followed by a space or tab. A mixed marker run (`*#`) or a run not
+/// followed by space/tab is ordinary text.
+fn tryListMarker(line: source.Line) ?ListMarker {
+    const t = line.text;
+    if (t.len < 2) return null;
+    const marker = t[0];
+    if (marker != '*' and marker != '#') return null;
+    var i: usize = 0;
+    while (i < t.len and t[i] == marker) : (i += 1) {}
+    if (i == t.len or (t[i] != ' ' and t[i] != '\t')) return null;
+    var j = i;
+    while (j < t.len and (t[j] == ' ' or t[j] == '\t')) : (j += 1) {}
+    return .{
+        .depth = @intCast(i),
+        .marker = marker,
+        .content = .{
+            .start = @intCast(line.start + j),
+            .end = @intCast(line.content_end),
+        },
+    };
+}
+
+/// Reconciles the open list stack to `lm` and appends its item. Lists deeper
+/// than `lm.depth` close; a same-depth list with a different marker closes
+/// and a sibling list opens; missing intermediate depths open empty items.
+/// The item's content lives in the deepest new item's paragraph.
+fn appendListItem(doc: *document.Document, lists: *std.ArrayList(ListEntry), lm: ListMarker) ParseError!void {
+    while (lists.items.len > 0 and lists.items[lists.items.len - 1].depth > lm.depth) {
+        _ = lists.pop();
+    }
+    if (lists.items.len > 0 and lists.items[lists.items.len - 1].depth == lm.depth) {
+        const top = &lists.items[lists.items.len - 1];
+        if (top.marker == lm.marker) {
+            try appendSiblingItem(doc, lists, lm);
+            return;
+        }
+        _ = lists.pop();
+    }
+
+    var depth: u32 = if (lists.items.len > 0) lists.items[lists.items.len - 1].depth else 0;
+    while (depth < lm.depth) {
+        depth += 1;
+        const parent = if (depth == 1) doc.root else lists.items[lists.items.len - 1].item;
+        const list = try doc.createNode(.list, lm.content, .{
+            .list = .{
+                .kind = if (lm.marker == '#') .ordered else .bullet,
+                .bullet = if (lm.marker == '*') '*' else 0,
+                .delimiter = if (lm.marker == '#') '.' else 0,
+                .start = 1,
+                .loose = false,
+            },
+        });
+        try doc.appendChild(parent, list);
+        const item = try doc.createNode(.list_item, lm.content, .none);
+        try doc.appendChild(list, item);
+        const para = try doc.createNode(.paragraph, lm.content, .none);
+        try doc.appendChild(item, para);
+        // Only the deepest item carries this line's content; intermediate
+        // levels created by a depth jump get an empty item.
+        if (depth == lm.depth) try parseInlines(doc, para, lm.content);
+        try lists.append(doc.allocator(), .{ .depth = depth, .marker = lm.marker, .list = list, .item = item });
+    }
+}
+
+/// Adds a sibling item to the open list at `lm.depth` (same marker char) and
+/// extends the list span to cover the new item's content.
+fn appendSiblingItem(doc: *document.Document, lists: *std.ArrayList(ListEntry), lm: ListMarker) ParseError!void {
+    const top = &lists.items[lists.items.len - 1];
+    top.list.span.end = lm.content.end;
+    const item = try doc.createNode(.list_item, lm.content, .none);
+    try doc.appendChild(top.list, item);
+    const para = try doc.createNode(.paragraph, lm.content, .none);
+    try doc.appendChild(item, para);
+    try parseInlines(doc, para, lm.content);
+    top.item = item;
+}
+
+/// Closes every open list. The nodes are already in the tree; only the
+/// reconciliation stack is dropped.
+fn closeLists(lists: *std.ArrayList(ListEntry)) void {
+    lists.clearRetainingCapacity();
 }
 
 const Heading = struct {
@@ -215,50 +347,488 @@ fn emitHeading(doc: *document.Document, line: source.Line, heading: Heading) Par
     try parseInlines(doc, node, heading.content);
 }
 
-/// Textile-local iterative inline scanner. A qualifying `@` opener pairs only
-/// with the first following `@`; a failed closer invalidates that opener and
-/// may independently seed the next one. The scanner never rescans a substring,
-/// so even hostile at-sign runs stay linear. See docs/TEXTILE-INLINE-CODE.md.
-fn parseInlines(doc: *document.Document, parent: *document.Node, content: source.Span) ParseError!void {
-    if (content.isEmpty()) return;
+// ---------------------------------------------------------------------------
+// Inline pass.
+//
+// One linear scan turns a line's content into a flat item list (maximal
+// text runs plus atoms), then phrase delimiters are paired on a strict-LIFO
+// stack, then the items are emitted into the shared model. Code spans,
+// links, and images are atoms — their contents are opaque. Phrase delimiters
+// nest (`*_way_*`); a closer only closes the innermost open phrase whose
+// character and run length match. Each scan/emit pass visits every byte a
+// bounded number of times, so even hostile delimiter storms stay linear.
+// See docs/TEXTILE-INLINE-CODE.md and docs/TEXTILE-PARITY.md.
+// ---------------------------------------------------------------------------
 
+/// A half-open byte range relative to a line's content span.
+const Range = struct { start: usize, end: usize };
+
+const LinkData = struct {
+    /// Full construct: opening quote through the end of the URL.
+    span: Range,
+    /// Display text inside the quotes (plain text, not re-scanned).
+    display: Range,
+    href: Range,
+    title: ?Range,
+};
+
+const ImageData = struct {
+    span: Range,
+    src: Range,
+    alt: ?Range,
+    link_href: ?Range,
+};
+
+const InlineItem = union(enum) {
+    /// Maximal text run between constructs (relative offsets into the line).
+    text: Range,
+    /// A matched `@code@` span with its verbatim arena-owned payload.
+    code: struct { span: Range, payload: []const u8 },
+    /// A phrase delimiter run. `pair` is the item index of the matching
+    /// closer (on the opener side) or opener (on the closer side); an
+    /// unmatched run stays literal text.
+    phrase: struct {
+        pos: usize,
+        len: u8,
+        char: u8,
+        tag: document.Tag,
+        is_open: bool,
+        is_close: bool,
+        pair: ?usize,
+    },
+    link: LinkData,
+    image: ImageData,
+};
+
+const PhraseOp = struct {
+    char: u8,
+    len: u8,
+    tag: document.Tag,
+};
+
+/// The phrase-modifier family both references document: single `*`/`_` are
+/// strong/emphasis, doubled `**`/`__` are bold/italic, and `-`, `+`, `^`,
+/// `~`, `%` are del/ins/sup/sub/span. Textile 2's `++`/`--` (big/small) are
+/// deliberately deferred (docs/FEATURE-MATRIX.md). Runs longer than the
+/// recognized lengths stay literal.
+fn phraseOpFor(bytes: []const u8, i: usize) ?PhraseOp {
+    const c = bytes[i];
+    if (c != '*' and c != '_' and c != '-' and c != '+' and c != '^' and c != '~' and c != '%') return null;
+    var j = i + 1;
+    while (j < bytes.len and bytes[j] == c) : (j += 1) {}
+    const run = j - i;
+    return switch (c) {
+        '*' => if (run == 1) .{ .char = '*', .len = 1, .tag = .strong } else if (run == 2) .{ .char = '*', .len = 2, .tag = .bold } else null,
+        '_' => if (run == 1) .{ .char = '_', .len = 1, .tag = .emphasis } else if (run == 2) .{ .char = '_', .len = 2, .tag = .italic } else null,
+        '-' => if (run == 1) .{ .char = '-', .len = 1, .tag = .deleted } else null,
+        '+' => if (run == 1) .{ .char = '+', .len = 1, .tag = .inserted } else null,
+        '^' => if (run == 1) .{ .char = '^', .len = 1, .tag = .superscript } else null,
+        '~' => if (run == 1) .{ .char = '~', .len = 1, .tag = .subscript } else null,
+        '%' => if (run == 1) .{ .char = '%', .len = 1, .tag = .span } else null,
+        else => null,
+    };
+}
+
+/// Phase 1: scan one line's content into items. Code spans keep the exact
+/// first-following-at-sign, close-once contract of docs/TEXTILE-INLINE-CODE.md
+/// §2. Links, images, and phrase delimiters are discovered in the same pass.
+/// Lookaheads for links/images only reach the next `"`/`!` (or a URL's
+/// whitespace), so segments scanned by failing lookaheads are disjoint and
+/// the pass stays linear.
+fn scanLineItems(doc: *document.Document, items: *std.ArrayList(InlineItem), content: source.Span) ParseError!void {
     const bytes = doc.text(content);
-    var text_start: usize = 0;
-    var opener: ?usize = null;
+    var run_start: usize = 0;
+    var code_opener: ?usize = null;
     var i: usize = 0;
-    while (i < bytes.len) : (i += 1) {
-        if (bytes[i] != '@') continue;
-
-        if (opener) |open| {
-            if (canCloseCode(bytes, open, i)) {
-                try emitText(doc, parent, subSpan(content, text_start, open));
-
-                const whole = subSpan(content, open, i + 1);
-                const payload_span = subSpan(content, open + 1, i);
-                const payload = try doc.allocator().dupe(u8, doc.text(payload_span));
-                const code = try doc.createNode(.code_span, whole, .{ .code_span = payload });
-                try doc.appendChild(parent, code);
-
-                text_start = i + 1;
-                opener = null;
-                continue;
+    while (i < bytes.len) {
+        const b = bytes[i];
+        if (b == '@') {
+            if (code_opener) |open| {
+                if (canCloseCode(bytes, open, i)) {
+                    try appendTextItem(doc.allocator(), items, run_start, open);
+                    const payload = try doc.allocator().dupe(u8, doc.text(subSpan(content, open + 1, i)));
+                    try items.append(doc.allocator(), .{ .code = .{
+                        .span = .{ .start = open, .end = i + 1 },
+                        .payload = payload,
+                    } });
+                    run_start = i + 1;
+                    code_opener = null;
+                } else {
+                    // Only the first following at-sign can close this opener.
+                    // If it cannot, preserve the old candidate literally and
+                    // let this byte act as a fresh opener only when it
+                    // qualifies on its own.
+                    code_opener = if (canOpenCode(bytes, i)) i else null;
+                }
+            } else if (canOpenCode(bytes, i)) {
+                code_opener = i;
             }
-
-            // Only the first following at-sign can close this opener. If it
-            // cannot, preserve the old candidate literally and let this byte
-            // act as a fresh opener only when it qualifies on its own.
-            opener = if (canOpenCode(bytes, i)) i else null;
+            i += 1;
             continue;
         }
+        // While a code opener is pending, every byte until the next at-sign
+        // is candidate code content: phrases, links, and images inside are
+        // opaque (docs/TEXTILE-INLINE-CODE.md §3, "opaque leaf").
+        if (code_opener == null) {
+            if (b == '"') {
+                if (scanLink(bytes, i)) |link| {
+                    try appendTextItem(doc.allocator(), items, run_start, i);
+                    try items.append(doc.allocator(), .{ .link = link });
+                    run_start = link.span.end;
+                    i = run_start;
+                    continue;
+                }
+                i += 1;
+                continue;
+            }
+            if (b == '!') {
+                if (scanImage(bytes, i)) |image| {
+                    try appendTextItem(doc.allocator(), items, run_start, i);
+                    try items.append(doc.allocator(), .{ .image = image });
+                    run_start = image.span.end;
+                    i = run_start;
+                    continue;
+                }
+                i += 1;
+                continue;
+            }
+            if (phraseOpFor(bytes, i)) |op| {
+                const open_ok = canOpenPhrase(bytes, i, op.len);
+                const close_ok = canClosePhrase(bytes, i, op.len);
+                if (open_ok or close_ok) {
+                    try appendTextItem(doc.allocator(), items, run_start, i);
+                    try items.append(doc.allocator(), .{ .phrase = .{
+                        .pos = i,
+                        .len = op.len,
+                        .char = op.char,
+                        .tag = op.tag,
+                        .is_open = open_ok,
+                        .is_close = close_ok,
+                        .pair = null,
+                    } });
+                    i += op.len;
+                    run_start = i;
+                    continue;
+                }
+                // A run that qualifies neither way is literal. Runs longer
+                // than any documented operator stay whole and literal: a
+                // `***` is never split into a literal `*` plus a bold `**`
+                // (conservative; docs/TEXTILE-PARITY.md §4.1).
+                i += op.len;
+                continue;
+            } else if (b == '*' or b == '_' or b == '-' or b == '+' or b == '^' or b == '~' or b == '%') {
+                // Long runs (3+ for `*`/`_`, 2+ for the rest) stay entirely
+                // literal; skip the whole run so it cannot reseed a shorter
+                // operator from inside itself.
+                var j = i + 1;
+                while (j < bytes.len and bytes[j] == b) : (j += 1) {}
+                i = j;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    try appendTextItem(doc.allocator(), items, run_start, bytes.len);
+}
 
-        if (canOpenCode(bytes, i)) opener = i;
+fn appendTextItem(allocator: std.mem.Allocator, items: *std.ArrayList(InlineItem), start: usize, end: usize) ParseError!void {
+    if (start >= end) return;
+    try items.append(allocator, .{ .text = .{ .start = start, .end = end } });
+}
+
+/// Recognizes `"text":url` and `"text (title)":url` (Textile 2 links).
+/// The display text must be non-empty and not start/end with whitespace; the
+/// URL runs to the first whitespace, with common trailing sentence
+/// punctuation excluded (Hobix: "the link won't include any trailing
+/// punctuation"). A title is the parenthesized suffix of the display text
+/// when preceded by a space. Returns null (the `"` stays literal text) for
+/// any shape the references do not define; see docs/TEXTILE-PARITY.md §5.
+fn scanLink(bytes: []const u8, i: usize) ?LinkData {
+    if (!isInlineBoundaryBefore(bytes, i)) return null;
+    const close = std.mem.indexOfScalarPos(u8, bytes, i + 1, '"') orelse return null;
+    if (close == i + 1) return null;
+    if (isWhitespaceByte(bytes[i + 1]) or isWhitespaceByte(bytes[close - 1])) return null;
+    if (close + 1 >= bytes.len or bytes[close + 1] != ':') return null;
+    const url_start = close + 2;
+    if (url_start >= bytes.len) return null;
+    var url_end = url_start;
+    while (url_end < bytes.len and !isUrlStop(bytes[url_end])) : (url_end += 1) {}
+    while (url_end > url_start and isLinkTrailingPunct(bytes[url_end - 1])) : (url_end -= 1) {}
+    if (url_end == url_start) return null;
+
+    var display_end = close;
+    var title: ?Range = null;
+    if (bytes[close - 1] == ')') {
+        if (lastIndexOfByte(bytes[i + 1 .. close], '(')) |p| {
+            const open = i + 1 + p;
+            // The title is the parenthesized suffix; the `)` at `close - 1`
+            // is its closing paren, so the range ends before it.
+            if (open > i + 1 and open + 1 < close - 1 and bytes[open - 1] == ' ') {
+                title = .{ .start = open + 1, .end = close - 1 };
+                display_end = open - 1;
+            }
+        }
+    }
+    return .{
+        .span = .{ .start = i, .end = url_end },
+        .display = .{ .start = i + 1, .end = display_end },
+        .href = .{ .start = url_start, .end = url_end },
+        .title = title,
+    };
+}
+
+/// Recognizes `!url!`, `!url(alt)!` (Hobix) / `!url (alt)!` (Textile 2), and
+/// the `!url!:href` link attachment. The src must be non-empty, contain no
+/// whitespace, and not begin with a documented image modifier (`<`, `>`, `-`,
+/// `^`, `~`, `{`, `(`, `)`) — modifier/sizing forms stay literal until their
+/// milestone (docs/FEATURE-MATRIX.md). A parenthesized suffix before the
+/// closing `!` is the alt, which doubles as the title (Hobix example). The
+/// `!` closer requires a whitespace/punctuation boundary after, so `!a.png!b`
+/// stays literal. See docs/TEXTILE-PARITY.md §5.
+fn scanImage(bytes: []const u8, i: usize) ?ImageData {
+    if (!isInlineBoundaryBefore(bytes, i)) return null;
+    const close = std.mem.indexOfScalarPos(u8, bytes, i + 1, '!') orelse return null;
+    if (close == i + 1) return null;
+
+    var src_end = close;
+    var alt: ?Range = null;
+    if (bytes[close - 1] == ')') {
+        if (lastIndexOfByte(bytes[i + 1 .. close], '(')) |p| {
+            const open = i + 1 + p;
+            // The alt is the parenthesized suffix; the `)` at `close - 1`
+            // is its closing paren, so the range ends before it.
+            if (open > i + 1 and open + 1 < close - 1) {
+                alt = .{ .start = open + 1, .end = close - 1 };
+                src_end = open;
+                while (src_end > i + 1 and isWhitespaceByte(bytes[src_end - 1])) src_end -= 1;
+            }
+        }
+    }
+    if (src_end == i + 1 or isDeferredImageModifier(bytes[i + 1])) return null;
+    var k = i + 1;
+    while (k < src_end) : (k += 1) {
+        if (isWhitespaceByte(bytes[k])) return null;
     }
 
-    try emitText(doc, parent, subSpan(content, text_start, bytes.len));
+    var link_href: ?Range = null;
+    if (close + 1 < bytes.len and bytes[close + 1] == ':') {
+        const url_start = close + 2;
+        if (url_start < bytes.len) {
+            var url_end = url_start;
+            while (url_end < bytes.len and !isUrlStop(bytes[url_end])) : (url_end += 1) {}
+            while (url_end > url_start and isLinkTrailingPunct(bytes[url_end - 1])) : (url_end -= 1) {}
+            if (url_end > url_start) link_href = .{ .start = url_start, .end = url_end };
+        }
+    }
+    const span_end = if (link_href) |h| h.end else close + 1;
+    if (!isInlineBoundaryAfter(bytes, span_end)) return null;
+
+    return .{
+        .span = .{ .start = i, .end = span_end },
+        .src = .{ .start = i + 1, .end = src_end },
+        .alt = alt,
+        .link_href = link_href,
+    };
+}
+
+/// A phrase opener qualifies when it has a whitespace/punctuation boundary
+/// before and non-whitespace content immediately after the run. A closer
+/// qualifies symmetrically. The boundary contract mirrors `@code@`
+/// (docs/TEXTILE-INLINE-CODE.md §2); edge-whitespace and intraword shapes
+/// stay literal.
+fn canOpenPhrase(bytes: []const u8, i: usize, len: usize) bool {
+    if (!isInlineBoundaryBefore(bytes, i)) return false;
+    if (i + len >= bytes.len) return false;
+    if (unicode.decode(bytes, i + len)) |next| {
+        if (unicode.isWhitespace(next)) return false;
+    }
+    return true;
+}
+
+fn canClosePhrase(bytes: []const u8, i: usize, len: usize) bool {
+    if (i == 0) return false;
+    if (unicode.decodePrev(bytes, i)) |previous| {
+        if (unicode.isWhitespace(previous)) return false;
+    }
+    return isInlineBoundaryAfter(bytes, i + len);
+}
+
+fn isWhitespaceByte(b: u8) bool {
+    return b == ' ' or b == '\t';
+}
+
+/// Common sentence punctuation that may follow (and is therefore excluded
+/// from) a Textile link/image URL (Hobix trailing-punctuation rule; Textile 2
+/// "common punctuation which can reside at the end of the URL").
+fn isLinkTrailingPunct(b: u8) bool {
+    return switch (b) {
+        '.', ',', ';', ':', '!', '?', ')', ']', '}', '\'', '"' => true,
+        else => false,
+    };
+}
+
+/// A URL run stops at whitespace or a closing bracket. The closing bracket
+/// is Textile 2's documented bracket/brace trick — `You["gotta":url]seethis!`
+/// — so the URL never swallows the `]` (or `)`/`}`) that ends it.
+fn isUrlStop(b: u8) bool {
+    return isWhitespaceByte(b) or b == ')' or b == ']' or b == '}';
+}
+
+/// Documented Textile image modifiers that begin the content after `!`;
+/// Oliver defers them, so such images stay literal.
+fn isDeferredImageModifier(b: u8) bool {
+    return switch (b) {
+        '<', '>', '-', '^', '~', '{', '(', ')' => true,
+        else => false,
+    };
+}
+
+fn lastIndexOfByte(haystack: []const u8, needle: u8) ?usize {
+    var i = haystack.len;
+    while (i > 0) {
+        i -= 1;
+        if (haystack[i] == needle) return i;
+    }
+    return null;
+}
+
+/// Phase 2: pair phrase openers/closers on a strict-LIFO stack. A closer
+/// only matches the innermost open phrase with the same character and run
+/// length (`*_way_*` nests; a different type in between leaves both literal,
+/// docs/TEXTILE-PARITY.md §4.1).
+fn matchPhrases(doc: *document.Document, items: *std.ArrayList(InlineItem)) ParseError!void {
+    var stack = std.ArrayList(usize).empty;
+    defer stack.deinit(doc.allocator());
+    for (items.items, 0..) |item, idx| {
+        switch (item) {
+            .phrase => |p| {
+                if (p.is_close) {
+                    if (stack.items.len > 0) {
+                        const top = stack.items[stack.items.len - 1];
+                        const top_phrase = items.items[top].phrase;
+                        if (top_phrase.char == p.char and top_phrase.len == p.len) {
+                            items.items[top].phrase.pair = idx;
+                            items.items[idx].phrase.pair = top;
+                            _ = stack.pop();
+                        }
+                    }
+                } else if (p.is_open) {
+                    try stack.append(doc.allocator(), idx);
+                }
+            },
+            else => {},
+        }
+    }
+}
+
+const EmitScope = struct {
+    items: []const InlineItem,
+    from: usize,
+    to: usize,
+    parent: *document.Node,
+};
+
+/// Phase 3: emit items into the model. Phrase pairs become container nodes
+/// whose content is emitted into a nested scope. The work stack is explicit
+/// (no recursion), so deeply nested phrases cannot overflow the call stack.
+fn emitItems(doc: *document.Document, parent: *document.Node, content: source.Span, items: []const InlineItem) ParseError!void {
+    var work = std.ArrayList(EmitScope).empty;
+    defer work.deinit(doc.allocator());
+    try work.append(doc.allocator(), .{ .items = items, .from = 0, .to = items.len, .parent = parent });
+    while (work.pop()) |scope| {
+        var i = scope.from;
+        while (i < scope.to) {
+            switch (scope.items[i]) {
+                .text => |t| {
+                    try emitText(doc, scope.parent, subSpan(content, t.start, t.end));
+                    i += 1;
+                },
+                .code => |c| {
+                    const node = try doc.createNode(.code_span, subSpan(content, c.span.start, c.span.end), .{ .code_span = c.payload });
+                    try doc.appendChild(scope.parent, node);
+                    i += 1;
+                },
+                .phrase => |p| {
+                    if (p.pair) |j| {
+                        const closer = scope.items[j].phrase;
+                        const node = try doc.createNode(p.tag, subSpan(content, p.pos, closer.pos + closer.len), .none);
+                        try doc.appendChild(scope.parent, node);
+                        try work.append(doc.allocator(), .{ .items = items, .from = i + 1, .to = j, .parent = node });
+                        i = j + 1;
+                    } else {
+                        try emitText(doc, scope.parent, subSpan(content, p.pos, p.pos + p.len));
+                        i += 1;
+                    }
+                },
+                .link => |l| {
+                    const link = try doc.createNode(.link, subSpan(content, l.span.start, l.span.end), .{
+                        .link = .{
+                            .href = try doc.allocator().dupe(u8, bytesOf(doc, content, l.href)),
+                            .title = if (l.title) |t| try doc.allocator().dupe(u8, bytesOf(doc, content, t)) else null,
+                        },
+                    });
+                    try doc.appendChild(scope.parent, link);
+                    const display = subSpan(content, l.display.start, l.display.end);
+                    const text_node = try doc.createNode(.text, display, .{ .text = doc.text(display) });
+                    try doc.appendChild(link, text_node);
+                    i += 1;
+                },
+                .image => |im| {
+                    const image = try doc.createNode(.image, subSpan(content, im.span.start, im.span.end), .{
+                        .image = .{
+                            .src = try doc.allocator().dupe(u8, bytesOf(doc, content, im.src)),
+                            .alt = if (im.alt) |a| try doc.allocator().dupe(u8, bytesOf(doc, content, a)) else "",
+                            .title = if (im.alt) |a| try doc.allocator().dupe(u8, bytesOf(doc, content, a)) else null,
+                        },
+                    });
+                    if (im.link_href) |href| {
+                        const link = try doc.createNode(.link, subSpan(content, im.span.start, im.span.end), .{
+                            .link = .{ .href = try doc.allocator().dupe(u8, bytesOf(doc, content, href)), .title = null },
+                        });
+                        try doc.appendChild(scope.parent, link);
+                        try doc.appendChild(link, image);
+                    } else {
+                        try doc.appendChild(scope.parent, image);
+                    }
+                    i += 1;
+                },
+            }
+        }
+    }
+}
+
+/// The source bytes covered by a relative range of `content`.
+fn bytesOf(doc: *const document.Document, content: source.Span, range: Range) []const u8 {
+    return doc.text(subSpan(content, range.start, range.end));
+}
+
+/// Parses one line's content into inline nodes under `parent`.
+fn parseInlines(doc: *document.Document, parent: *document.Node, content: source.Span) ParseError!void {
+    if (content.isEmpty()) return;
+    var items = std.ArrayList(InlineItem).empty;
+    defer items.deinit(doc.allocator());
+    try scanLineItems(doc, &items, content);
+    try matchPhrases(doc, &items);
+    try emitItems(doc, parent, content, items.items);
 }
 
 fn emitText(doc: *document.Document, parent: *document.Node, span: source.Span) ParseError!void {
     if (span.isEmpty()) return;
+    // Contiguous text in the same parent merges into one node (model
+    // invariant 11): scanning artifacts like unmatched phrase delimiters
+    // must not fragment the normalized model. Mirrors the Markdown engine's
+    // merge rule, including the backslash exception so renderer entity
+    // decoding stays escape-aware.
+    if (parent.children.items.len > 0) {
+        const last = parent.children.items[parent.children.items.len - 1];
+        if (last.tag == .text and last.span.end == span.start and
+            !(last.span.start > 0 and doc.src.bytes[last.span.start - 1] == '\\'))
+        {
+            last.span.end = span.end;
+            last.data.text = doc.text(last.span);
+            return;
+        }
+    }
     const node = try doc.createNode(.text, span, .{ .text = doc.text(span) });
     try doc.appendChild(parent, node);
 }
@@ -561,6 +1131,379 @@ test "textile: block-quote signature flood stays iterative" {
     try std.testing.expectEqual(@as(usize, count), result.document.root.children.items.len);
     try std.testing.expectEqual(document.Tag.block_quote, result.document.root.children.items[0].tag);
     try std.testing.expectEqual(document.Tag.block_quote, result.document.root.children.items[count - 1].tag);
+
+    var first_writer = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer first_writer.deinit();
+    try oliver.html.render(std.testing.allocator, &first_writer.writer, &result.document, .{});
+    var first = first_writer.toArrayList();
+    defer first.deinit(std.testing.allocator);
+
+    var second_writer = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer second_writer.deinit();
+    try oliver.html.render(std.testing.allocator, &second_writer.writer, &result.document, .{});
+    var second = second_writer.toArrayList();
+    defer second.deinit(std.testing.allocator);
+    try std.testing.expectEqualSlices(u8, first.items, second.items);
+}
+
+test "textile: phrase modifier family tags, spans, and rendering" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        std.testing.allocator,
+        "a *strong* _em_ **bold** __italic__ -del- +ins+ ^sup^ ~sub~ %span%",
+        .textile,
+        .{},
+    );
+    defer result.deinit();
+
+    const p = result.document.root.children.items[0];
+    try std.testing.expectEqual(@as(usize, 18), p.children.items.len);
+    try std.testing.expectEqual(document.Tag.text, p.children.items[0].tag);
+    try std.testing.expectEqual(document.Tag.strong, p.children.items[1].tag);
+    try std.testing.expectEqual(source.Span{ .start = 2, .end = 10 }, p.children.items[1].span);
+    try std.testing.expectEqual(document.Tag.emphasis, p.children.items[3].tag);
+    try std.testing.expectEqual(source.Span{ .start = 11, .end = 15 }, p.children.items[3].span);
+    try std.testing.expectEqual(document.Tag.bold, p.children.items[5].tag);
+    try std.testing.expectEqual(source.Span{ .start = 16, .end = 24 }, p.children.items[5].span);
+    try std.testing.expectEqual(document.Tag.italic, p.children.items[7].tag);
+    try std.testing.expectEqual(source.Span{ .start = 25, .end = 35 }, p.children.items[7].span);
+    try std.testing.expectEqual(document.Tag.deleted, p.children.items[9].tag);
+    try std.testing.expectEqual(source.Span{ .start = 36, .end = 41 }, p.children.items[9].span);
+    try std.testing.expectEqual(document.Tag.inserted, p.children.items[11].tag);
+    try std.testing.expectEqual(source.Span{ .start = 42, .end = 47 }, p.children.items[11].span);
+    try std.testing.expectEqual(document.Tag.superscript, p.children.items[13].tag);
+    try std.testing.expectEqual(source.Span{ .start = 48, .end = 53 }, p.children.items[13].span);
+    try std.testing.expectEqual(document.Tag.subscript, p.children.items[15].tag);
+    try std.testing.expectEqual(source.Span{ .start = 54, .end = 59 }, p.children.items[15].span);
+    try std.testing.expectEqual(document.Tag.span, p.children.items[17].tag);
+    try std.testing.expectEqual(source.Span{ .start = 60, .end = 66 }, p.children.items[17].span);
+    // Phrase content spans and child text.
+    try std.testing.expectEqualStrings("strong", p.children.items[1].children.items[0].data.text);
+    try std.testing.expectEqualStrings("em", p.children.items[3].children.items[0].data.text);
+
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.html.render(std.testing.allocator, &aw.writer, &result.document, .{});
+    var out = aw.toArrayList();
+    defer out.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "<p>a <strong>strong</strong> <em>em</em> <b>bold</b> <i>italic</i> <del>del</del> <ins>ins</ins> <sup>sup</sup> <sub>sub</sub> <span>span</span></p>\n",
+        out.items,
+    );
+}
+
+test "textile: phrase modifiers nest and close in order" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(std.testing.allocator, "Textile is *_way_* cool.", .textile, .{});
+    defer result.deinit();
+    const p = result.document.root.children.items[0];
+    // text, strong, text
+    try std.testing.expectEqual(@as(usize, 3), p.children.items.len);
+    const strong = p.children.items[1];
+    try std.testing.expectEqual(document.Tag.strong, strong.tag);
+    try std.testing.expectEqual(@as(usize, 1), strong.children.items.len);
+    try std.testing.expectEqual(document.Tag.emphasis, strong.children.items[0].tag);
+    try std.testing.expectEqual(source.Span{ .start = 11, .end = 18 }, strong.span);
+    try std.testing.expectEqual(source.Span{ .start = 12, .end = 17 }, strong.children.items[0].span);
+
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.html.render(std.testing.allocator, &aw.writer, &result.document, .{});
+    var out = aw.toArrayList();
+    defer out.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("<p>Textile is <strong><em>way</em></strong> cool.</p>\n", out.items);
+}
+
+test "textile: phrase modifier boundary fallbacks stay literal" {
+    const oliver = @import("oliver.zig");
+    const cases = [_][]const u8{
+        "Textile is way c*oo*l.", // intraword (Textile 2 counterexample)
+        "Text * x*", // edge whitespace after opener
+        "*x *", // edge whitespace before closer
+        "***triple***", // run longer than any documented operator
+        "--smaller--", // Textile 2 big/small are deferred
+        "a^2 + b", // intraword caret
+        "50% of", // intraword percent
+        "*open", // unmatched opener
+    };
+    for (cases) |input| {
+        var result = try oliver.parse(std.testing.allocator, input, .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        try std.testing.expectEqual(@as(usize, 1), p.children.items.len);
+        try std.testing.expectEqual(document.Tag.text, p.children.items[0].tag);
+        try std.testing.expectEqualStrings(input, p.children.items[0].data.text);
+    }
+}
+
+test "textile: links have exact spans, hrefs, titles, and literal fallbacks" {
+    const oliver = @import("oliver.zig");
+
+    // Trailing sentence punctuation is excluded from the href (Hobix).
+    {
+        var result = try oliver.parse(std.testing.allocator, "I searched \"Google\":http://google.com.", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        try std.testing.expectEqual(@as(usize, 3), p.children.items.len);
+        const link = p.children.items[1];
+        try std.testing.expectEqual(document.Tag.link, link.tag);
+        try std.testing.expectEqual(source.Span{ .start = 11, .end = 37 }, link.span);
+        try std.testing.expectEqualStrings("http://google.com", link.data.link.href);
+        try std.testing.expectEqual(@as(?[]const u8, null), link.data.link.title);
+        try std.testing.expectEqual(@as(usize, 1), link.children.items.len);
+        try std.testing.expectEqualStrings("Google", link.children.items[0].data.text);
+        try std.testing.expectEqualStrings(".", p.children.items[2].data.text);
+    }
+    // Parenthesized title (Textile 2).
+    {
+        var result = try oliver.parse(std.testing.allocator, "\"E-mail me (Please)\":mailto:someone@example.com", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        const link = p.children.items[0];
+        try std.testing.expectEqual(document.Tag.link, link.tag);
+        try std.testing.expectEqualStrings("mailto:someone@example.com", link.data.link.href);
+        try std.testing.expectEqualStrings("Please", link.data.link.title.?);
+        try std.testing.expectEqualStrings("E-mail me", link.children.items[0].data.text);
+    }
+    // The bracket trick (Textile 2): the URL stops at the closing bracket.
+    {
+        var result = try oliver.parse(std.testing.allocator, "You[\"gotta\":http://example.com]seethis!", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        const link = p.children.items[1];
+        try std.testing.expectEqual(document.Tag.link, link.tag);
+        try std.testing.expectEqualStrings("http://example.com", link.data.link.href);
+        try std.testing.expectEqualStrings("gotta", link.children.items[0].data.text);
+    }
+    // Undefined shapes stay literal: no colon, empty display, edge whitespace.
+    const literal_cases = [_][]const u8{
+        "a \"no colon\" b",
+        "\"\":url",
+        "\" spaced \":url",
+        "\"x\": ",
+    };
+    for (literal_cases) |input| {
+        var result = try oliver.parse(std.testing.allocator, input, .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        var has_link = false;
+        for (p.children.items) |child| {
+            if (child.tag == .link) has_link = true;
+        }
+        try std.testing.expect(!has_link);
+    }
+}
+
+test "textile: images have exact spans, alts, titles, links, and fallbacks" {
+    const oliver = @import("oliver.zig");
+
+    {
+        var result = try oliver.parse(std.testing.allocator, "!https://hobix.com/sample.jpg!", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        const img = p.children.items[0];
+        try std.testing.expectEqual(document.Tag.image, img.tag);
+        try std.testing.expectEqual(source.Span{ .start = 0, .end = 30 }, img.span);
+        try std.testing.expectEqualStrings("https://hobix.com/sample.jpg", img.data.image.src);
+        try std.testing.expectEqualStrings("", img.data.image.alt);
+        try std.testing.expectEqual(@as(?[]const u8, null), img.data.image.title);
+    }
+    // Hobix: the parenthesized alt doubles as the title.
+    {
+        var result = try oliver.parse(std.testing.allocator, "!openwindow1.gif(Bunny.)!", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        const img = p.children.items[0];
+        try std.testing.expectEqualStrings("openwindow1.gif", img.data.image.src);
+        try std.testing.expectEqualStrings("Bunny.", img.data.image.alt);
+        try std.testing.expectEqualStrings("Bunny.", img.data.image.title.?);
+    }
+    // Textile 2 allows a space before the alt.
+    {
+        var result = try oliver.parse(std.testing.allocator, "!/path/to/image (Alt text)!", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        const img = p.children.items[0];
+        try std.testing.expectEqualStrings("/path/to/image", img.data.image.src);
+        try std.testing.expectEqualStrings("Alt text", img.data.image.alt);
+    }
+    // Link attachment wraps the image in a link (Hobix).
+    {
+        var result = try oliver.parse(std.testing.allocator, "!openwindow1.gif!:https://hobix.com/", .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        const link = p.children.items[0];
+        try std.testing.expectEqual(document.Tag.link, link.tag);
+        try std.testing.expectEqualStrings("https://hobix.com/", link.data.link.href);
+        try std.testing.expectEqual(@as(usize, 1), link.children.items.len);
+        try std.testing.expectEqual(document.Tag.image, link.children.items[0].tag);
+        try std.testing.expectEqualStrings("openwindow1.gif", link.children.items[0].data.image.src);
+    }
+    // Deferred modifier/sizing forms and malformed shapes stay literal.
+    const literal_cases = [_][]const u8{
+        "!>obake.gif!", // alignment modifier (deferred)
+        "!-(middle).gif!", // middle-alignment modifier (deferred)
+        "!a b.png!", // whitespace in src (sizing form, deferred)
+        "!img.png", // no closer
+        "!img.png!word", // no boundary after the closer
+    };
+    for (literal_cases) |input| {
+        var result = try oliver.parse(std.testing.allocator, input, .textile, .{});
+        defer result.deinit();
+        const p = result.document.root.children.items[0];
+        var has_image = false;
+        for (p.children.items) |child| {
+            if (child.tag == .image) has_image = true;
+        }
+        try std.testing.expect(!has_image);
+    }
+}
+
+test "textile: lists structure, nesting, and spans" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        std.testing.allocator,
+        "* one\n* two\n** two A\n* three\n\n# first\n# second",
+        .textile,
+        .{},
+    );
+    defer result.deinit();
+
+    const root = result.document.root;
+    try std.testing.expectEqual(@as(usize, 2), root.children.items.len);
+
+    const ul = root.children.items[0];
+    try std.testing.expectEqual(document.Tag.list, ul.tag);
+    try std.testing.expectEqual(document.ListKind.bullet, ul.data.list.kind);
+    try std.testing.expect(!ul.data.list.loose);
+    try std.testing.expectEqual(@as(usize, 3), ul.children.items.len);
+    try std.testing.expectEqual(source.Span{ .start = 2, .end = 28 }, ul.span);
+
+    const first = ul.children.items[0];
+    try std.testing.expectEqual(document.Tag.list_item, first.tag);
+    try std.testing.expectEqual(source.Span{ .start = 2, .end = 5 }, first.span);
+    try std.testing.expectEqualStrings("one", first.children.items[0].children.items[0].data.text);
+
+    // The nested `** two A` list lives inside the second item.
+    const second = ul.children.items[1];
+    const nested = second.children.items[1];
+    try std.testing.expectEqual(document.Tag.list, nested.tag);
+    try std.testing.expectEqual(@as(usize, 1), nested.children.items.len);
+    try std.testing.expectEqualStrings("two A", nested.children.items[0].children.items[0].children.items[0].data.text);
+
+    const ol = root.children.items[1];
+    try std.testing.expectEqual(document.Tag.list, ol.tag);
+    try std.testing.expectEqual(document.ListKind.ordered, ol.data.list.kind);
+    try std.testing.expectEqual(@as(usize, 2), ol.children.items.len);
+
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.html.render(std.testing.allocator, &aw.writer, &result.document, .{});
+    var out = aw.toArrayList();
+    defer out.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "<ul>\n<li>one</li>\n<li>two\n<ul>\n<li>two A</li>\n</ul>\n</li>\n<li>three</li>\n</ul>\n<ol>\n<li>first</li>\n<li>second</li>\n</ol>\n",
+        out.items,
+    );
+}
+
+test "textile: list markers, signatures, and plain lines close lists" {
+    const oliver = @import("oliver.zig");
+
+    // A different marker at the same depth starts a sibling list.
+    {
+        var result = try oliver.parse(std.testing.allocator, "* a\n# b", .textile, .{});
+        defer result.deinit();
+        try std.testing.expectEqual(@as(usize, 2), result.document.root.children.items.len);
+        try std.testing.expectEqual(document.Tag.list, result.document.root.children.items[0].tag);
+        try std.testing.expectEqual(document.Tag.list, result.document.root.children.items[1].tag);
+    }
+    // A marker run without a following space/tab is ordinary text.
+    {
+        var result = try oliver.parse(std.testing.allocator, "*not a list\n#nope", .textile, .{});
+        defer result.deinit();
+        try std.testing.expectEqual(@as(usize, 1), result.document.root.children.items.len);
+        try std.testing.expectEqual(document.Tag.paragraph, result.document.root.children.items[0].tag);
+    }
+    // A plain line closes the list; the next marker starts a new list.
+    {
+        var result = try oliver.parse(std.testing.allocator, "* one\nplain\n* two", .textile, .{});
+        defer result.deinit();
+        const root = result.document.root;
+        try std.testing.expectEqual(@as(usize, 3), root.children.items.len);
+        try std.testing.expectEqual(document.Tag.list, root.children.items[0].tag);
+        try std.testing.expectEqual(document.Tag.paragraph, root.children.items[1].tag);
+        try std.testing.expectEqual(document.Tag.list, root.children.items[2].tag);
+        try std.testing.expectEqual(@as(usize, 1), root.children.items[2].children.items.len);
+    }
+    // A block signature closes lists too.
+    {
+        var result = try oliver.parse(std.testing.allocator, "* one\nh2. Two\n* three", .textile, .{});
+        defer result.deinit();
+        const root = result.document.root;
+        try std.testing.expectEqual(document.Tag.list, root.children.items[0].tag);
+        try std.testing.expectEqual(document.Tag.heading, root.children.items[1].tag);
+        try std.testing.expectEqual(document.Tag.list, root.children.items[2].tag);
+    }
+}
+
+test "textile: phrase delimiter storm stays deterministic and linear" {
+    const oliver = @import("oliver.zig");
+    const count = 10_000;
+    var input = std.ArrayList(u8).empty;
+    defer input.deinit(std.testing.allocator);
+    var expected = std.ArrayList(u8).empty;
+    defer expected.deinit(std.testing.allocator);
+    try expected.appendSlice(std.testing.allocator, "<p>");
+    for (0..count) |i| {
+        if (i % 2 == 0) {
+            try input.appendSlice(std.testing.allocator, "*ok* ");
+            try expected.appendSlice(std.testing.allocator, "<strong>ok</strong> ");
+        } else {
+            // Intraword delimiters stay literal: near-miss shape.
+            try input.appendSlice(std.testing.allocator, "x*yz ");
+            try expected.appendSlice(std.testing.allocator, "x*yz ");
+        }
+    }
+    try expected.appendSlice(std.testing.allocator, "</p>\n");
+
+    var result = try oliver.parse(std.testing.allocator, input.items, .textile, .{});
+    defer result.deinit();
+    const p = result.document.root.children.items[0];
+    var strong_count: usize = 0;
+    for (p.children.items) |child| {
+        if (child.tag == .strong) strong_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, count / 2), strong_count);
+
+    var first_writer = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer first_writer.deinit();
+    try oliver.html.render(std.testing.allocator, &first_writer.writer, &result.document, .{});
+    var first = first_writer.toArrayList();
+    defer first.deinit(std.testing.allocator);
+    try std.testing.expectEqualSlices(u8, expected.items, first.items);
+
+    var second_writer = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer second_writer.deinit();
+    try oliver.html.render(std.testing.allocator, &second_writer.writer, &result.document, .{});
+    var second = second_writer.toArrayList();
+    defer second.deinit(std.testing.allocator);
+    try std.testing.expectEqualSlices(u8, first.items, second.items);
+}
+
+test "textile: deeply nested phrases emit iteratively" {
+    const oliver = @import("oliver.zig");
+    const depth = 2_000;
+    var input = std.ArrayList(u8).empty;
+    defer input.deinit(std.testing.allocator);
+    for (0..depth) |_| try input.appendSlice(std.testing.allocator, "*a ");
+    for (0..depth) |_| try input.appendSlice(std.testing.allocator, " b*");
+
+    var result = try oliver.parse(std.testing.allocator, input.items, .textile, .{});
+    defer result.deinit();
+    const p = result.document.root.children.items[0];
+    try std.testing.expectEqual(@as(usize, 1), p.children.items.len);
+    try std.testing.expectEqual(document.Tag.strong, p.children.items[0].tag);
 
     var first_writer = std.Io.Writer.Allocating.init(std.testing.allocator);
     defer first_writer.deinit();

--- a/tests/fixtures/textile/image-basic.html
+++ b/tests/fixtures/textile/image-basic.html
@@ -1,0 +1,3 @@
+<p><img src="https://hobix.com/sample.jpg" alt="" /><br />
+A relative <img src="openwindow1.gif" alt="Bunny." title="Bunny." /> image.<br />
+<img src="openwindow1.gif" alt="Bunny." title="Bunny." /> spaced alt.</p>

--- a/tests/fixtures/textile/image-basic.textile
+++ b/tests/fixtures/textile/image-basic.textile
@@ -1,0 +1,3 @@
+!https://hobix.com/sample.jpg!
+A relative !openwindow1.gif(Bunny.)! image.
+!openwindow1.gif (Bunny.)! spaced alt.

--- a/tests/fixtures/textile/image-linked.html
+++ b/tests/fixtures/textile/image-linked.html
@@ -1,0 +1,2 @@
+<p><a href="https://hobix.com/"><img src="openwindow1.gif" alt="" /></a><br />
+<a href="https://example.test/"><img src="img.png" alt="Logo" title="Logo" /></a></p>

--- a/tests/fixtures/textile/image-linked.textile
+++ b/tests/fixtures/textile/image-linked.textile
@@ -1,0 +1,2 @@
+!openwindow1.gif!:https://hobix.com/
+!img.png(Logo)!:https://example.test/

--- a/tests/fixtures/textile/image-literal.html
+++ b/tests/fixtures/textile/image-literal.html
@@ -1,0 +1,4 @@
+<p>!&gt;obake.gif!<br />
+!a b.png!<br />
+!img.png<br />
+!img.png!word</p>

--- a/tests/fixtures/textile/image-literal.textile
+++ b/tests/fixtures/textile/image-literal.textile
@@ -1,0 +1,4 @@
+!>obake.gif!
+!a b.png!
+!img.png
+!img.png!word

--- a/tests/fixtures/textile/inline-composition.html
+++ b/tests/fixtures/textile/inline-composition.html
@@ -1,0 +1,4 @@
+<p>A <strong>strong</strong> with a <a href="http://x.test">link</a> and an <img src="img.png" alt="" /> image and <code>code</code>.</p>
+<blockquote>
+<p><em>Quoted</em> <strong>emph</strong> with <a href="/u">more</a>.</p>
+</blockquote>

--- a/tests/fixtures/textile/inline-composition.textile
+++ b/tests/fixtures/textile/inline-composition.textile
@@ -1,0 +1,2 @@
+p. A *strong* with a "link":http://x.test and an !img.png! image and @code@.
+bq. _Quoted_ *emph* with "more":/u.

--- a/tests/fixtures/textile/link-basic.html
+++ b/tests/fixtures/textile/link-basic.html
@@ -1,0 +1,3 @@
+<p>I searched <a href="http://google.com">Google</a>.<br />
+<a href="mailto:someone@example.com">E-mail me please</a><br />
+A <a href="/path">relative</a> and a <a href="/u" title="T">quoted</a>.</p>

--- a/tests/fixtures/textile/link-basic.textile
+++ b/tests/fixtures/textile/link-basic.textile
@@ -1,0 +1,3 @@
+I searched "Google":http://google.com.
+"E-mail me please":mailto:someone@example.com
+A "relative":/path and a "quoted (T)":/u.

--- a/tests/fixtures/textile/link-bracket-trick.html
+++ b/tests/fixtures/textile/link-bracket-trick.html
@@ -1,0 +1,2 @@
+<p>You[<a href="http://example.com">gotta</a>]seethis!<br />
+See {also <a href="/x">this</a>} here.</p>

--- a/tests/fixtures/textile/link-bracket-trick.textile
+++ b/tests/fixtures/textile/link-bracket-trick.textile
@@ -1,0 +1,2 @@
+You["gotta":http://example.com]seethis!
+See {also "this":/x} here.

--- a/tests/fixtures/textile/link-literal.html
+++ b/tests/fixtures/textile/link-literal.html
@@ -1,0 +1,4 @@
+<p>&quot;no colon&quot; here<br />
+&quot;&quot; is empty<br />
+&quot; spaced &quot;:url<br />
+&quot;x&quot;:</p>

--- a/tests/fixtures/textile/link-literal.textile
+++ b/tests/fixtures/textile/link-literal.textile
@@ -1,0 +1,4 @@
+"no colon" here
+"" is empty
+" spaced ":url
+"x":

--- a/tests/fixtures/textile/link-title.html
+++ b/tests/fixtures/textile/link-title.html
@@ -1,0 +1,2 @@
+<p><a href="mailto:someone@example.com" title="Please">E-mail me</a><br />
+<a href="http://example.com" title="More">Text (With)</a></p>

--- a/tests/fixtures/textile/link-title.textile
+++ b/tests/fixtures/textile/link-title.textile
@@ -1,0 +1,2 @@
+"E-mail me (Please)":mailto:someone@example.com
+"Text (With) (More)":http://example.com

--- a/tests/fixtures/textile/list-basic.html
+++ b/tests/fixtures/textile/list-basic.html
@@ -1,0 +1,9 @@
+<ul>
+<li>one</li>
+<li>two</li>
+<li>three</li>
+</ul>
+<ol>
+<li>first</li>
+<li>second</li>
+</ol>

--- a/tests/fixtures/textile/list-basic.textile
+++ b/tests/fixtures/textile/list-basic.textile
@@ -1,0 +1,6 @@
+* one
+* two
+* three
+
+# first
+# second

--- a/tests/fixtures/textile/list-mixed.html
+++ b/tests/fixtures/textile/list-mixed.html
@@ -1,0 +1,17 @@
+<ul>
+<li>alpha</li>
+</ul>
+<ol>
+<li>one</li>
+<li>two</li>
+</ol>
+<ul>
+<li>beta</li>
+</ul>
+<ul>
+<li>after blank</li>
+</ul>
+<p>plain text</p>
+<ul>
+<li>new list</li>
+</ul>

--- a/tests/fixtures/textile/list-mixed.textile
+++ b/tests/fixtures/textile/list-mixed.textile
@@ -1,0 +1,8 @@
+* alpha
+# one
+# two
+* beta
+
+* after blank
+plain text
+* new list

--- a/tests/fixtures/textile/list-nested.html
+++ b/tests/fixtures/textile/list-nested.html
@@ -1,0 +1,14 @@
+<ul>
+<li>Fuel could be:
+<ul>
+<li>Coal</li>
+<li>Gasoline</li>
+</ul>
+</li>
+<li>Humans need only:
+<ol>
+<li>Water</li>
+<li>Protein</li>
+</ol>
+</li>
+</ul>

--- a/tests/fixtures/textile/list-nested.textile
+++ b/tests/fixtures/textile/list-nested.textile
@@ -1,0 +1,6 @@
+* Fuel could be:
+** Coal
+** Gasoline
+* Humans need only:
+## Water
+## Protein

--- a/tests/fixtures/textile/phrase-boundaries.html
+++ b/tests/fixtures/textile/phrase-boundaries.html
@@ -1,0 +1,7 @@
+<p>Textile is way c*oo*l.<br />
+Text * x* and *x * are literal.<br />
+***triple*** stays literal.<br />
+--smaller-- stays literal.<br />
+a^2 is not a superscript.<br />
+50% is not a span.<br />
+*unmatched stays literal.</p>

--- a/tests/fixtures/textile/phrase-boundaries.textile
+++ b/tests/fixtures/textile/phrase-boundaries.textile
@@ -1,0 +1,7 @@
+Textile is way c*oo*l.
+Text * x* and *x * are literal.
+***triple*** stays literal.
+--smaller-- stays literal.
+a^2 is not a superscript.
+50% is not a span.
+*unmatched stays literal.

--- a/tests/fixtures/textile/phrase-in-heading.html
+++ b/tests/fixtures/textile/phrase-in-heading.html
@@ -1,0 +1,2 @@
+<h1>A <strong>bold</strong> <em>head</em></h1>
+<h3>Mixed <code>code</code> and <strong>strong</strong>.</h3>

--- a/tests/fixtures/textile/phrase-in-heading.textile
+++ b/tests/fixtures/textile/phrase-in-heading.textile
@@ -1,0 +1,2 @@
+h1. A *bold* _head_
+h3. Mixed @code@ and *strong*.

--- a/tests/fixtures/textile/phrase-modifiers.html
+++ b/tests/fixtures/textile/phrase-modifiers.html
@@ -1,0 +1,8 @@
+<p>I <em>believe</em> every word.<br />
+She <strong>fell</strong>!<br />
+I <i>know</i> and <b>really</b>.<br />
+I am <del>sure</del> not sure.<br />
+You are a <ins>pleasant</ins> child.<br />
+a <sup>2</sup> + b <sup>2</sup> = c <sup>2</sup><br />
+log <sub>2</sub> x<br />
+I'm <span>unaware</span> of most soft drinks.</p>

--- a/tests/fixtures/textile/phrase-modifiers.textile
+++ b/tests/fixtures/textile/phrase-modifiers.textile
@@ -1,0 +1,8 @@
+I _believe_ every word.
+She *fell*!
+I __know__ and **really**.
+I am -sure- not sure.
+You are a +pleasant+ child.
+a ^2^ + b ^2^ = c ^2^
+log ~2~ x
+I'm %unaware% of most soft drinks.

--- a/tests/fixtures/textile/phrase-nesting.html
+++ b/tests/fixtures/textile/phrase-nesting.html
@@ -1,0 +1,3 @@
+<p>Textile is <strong><em>way</em></strong> cool.<br />
+Nested <em><strong>inner</strong></em> phrases.<br />
+<strong>one <em>and <strong>two</strong></em> three</strong>.</p>

--- a/tests/fixtures/textile/phrase-nesting.textile
+++ b/tests/fixtures/textile/phrase-nesting.textile
@@ -1,0 +1,3 @@
+Textile is *_way_* cool.
+Nested _*inner*_ phrases.
+*one _and *two*_ three*.

--- a/tests/fixtures_test.zig
+++ b/tests/fixtures_test.zig
@@ -1525,6 +1525,86 @@ const textile_fixtures = [_]TextileFixture{
         .input = @embedFile("fixtures/textile/unicode.textile"),
         .expected = @embedFile("fixtures/textile/unicode.html"),
     },
+    // --- phrase modifiers (Textile 2 inline formatting; both references) ---
+    .{
+        .name = "phrase-modifiers",
+        .input = @embedFile("fixtures/textile/phrase-modifiers.textile"),
+        .expected = @embedFile("fixtures/textile/phrase-modifiers.html"),
+    },
+    .{
+        .name = "phrase-nesting",
+        .input = @embedFile("fixtures/textile/phrase-nesting.textile"),
+        .expected = @embedFile("fixtures/textile/phrase-nesting.html"),
+    },
+    .{
+        .name = "phrase-boundaries",
+        .input = @embedFile("fixtures/textile/phrase-boundaries.textile"),
+        .expected = @embedFile("fixtures/textile/phrase-boundaries.html"),
+    },
+    .{
+        .name = "phrase-in-heading",
+        .input = @embedFile("fixtures/textile/phrase-in-heading.textile"),
+        .expected = @embedFile("fixtures/textile/phrase-in-heading.html"),
+    },
+    // --- links (Textile 2; Hobix "External References") ---
+    .{
+        .name = "link-basic",
+        .input = @embedFile("fixtures/textile/link-basic.textile"),
+        .expected = @embedFile("fixtures/textile/link-basic.html"),
+    },
+    .{
+        .name = "link-title",
+        .input = @embedFile("fixtures/textile/link-title.textile"),
+        .expected = @embedFile("fixtures/textile/link-title.html"),
+    },
+    .{
+        .name = "link-bracket-trick",
+        .input = @embedFile("fixtures/textile/link-bracket-trick.textile"),
+        .expected = @embedFile("fixtures/textile/link-bracket-trick.html"),
+    },
+    .{
+        .name = "link-literal",
+        .input = @embedFile("fixtures/textile/link-literal.textile"),
+        .expected = @embedFile("fixtures/textile/link-literal.html"),
+    },
+    // --- images (Hobix "External References"; Textile 2 "Images") ---
+    .{
+        .name = "image-basic",
+        .input = @embedFile("fixtures/textile/image-basic.textile"),
+        .expected = @embedFile("fixtures/textile/image-basic.html"),
+    },
+    .{
+        .name = "image-linked",
+        .input = @embedFile("fixtures/textile/image-linked.textile"),
+        .expected = @embedFile("fixtures/textile/image-linked.html"),
+    },
+    .{
+        .name = "image-literal",
+        .input = @embedFile("fixtures/textile/image-literal.textile"),
+        .expected = @embedFile("fixtures/textile/image-literal.html"),
+    },
+    // --- lists (Hobix "Lists"; Textile 2 "Lists") ---
+    .{
+        .name = "list-basic",
+        .input = @embedFile("fixtures/textile/list-basic.textile"),
+        .expected = @embedFile("fixtures/textile/list-basic.html"),
+    },
+    .{
+        .name = "list-nested",
+        .input = @embedFile("fixtures/textile/list-nested.textile"),
+        .expected = @embedFile("fixtures/textile/list-nested.html"),
+    },
+    .{
+        .name = "list-mixed",
+        .input = @embedFile("fixtures/textile/list-mixed.textile"),
+        .expected = @embedFile("fixtures/textile/list-mixed.html"),
+    },
+    // --- composition and opacity across inline families ---
+    .{
+        .name = "inline-composition",
+        .input = @embedFile("fixtures/textile/inline-composition.textile"),
+        .expected = @embedFile("fixtures/textile/inline-composition.html"),
+    },
 };
 
 fn renderHtml(input: []const u8, dialect: oliver.Dialect) !std.ArrayList(u8) {
@@ -1583,6 +1663,41 @@ test "shared model: equivalent inputs render identically through one renderer" {
             .markdown = "> quote",
             .textile = "bq. quote",
             .expected = "<blockquote>\n<p>quote</p>\n</blockquote>\n",
+        },
+        // Textile `*x*` (strong) converges with Markdown `**x**`; Textile
+        // `_x_` (emphasis) with Markdown `*x_`.
+        .{
+            .markdown = "**Hello**",
+            .textile = "*Hello*",
+            .expected = "<p><strong>Hello</strong></p>\n",
+        },
+        .{
+            .markdown = "*Hello*",
+            .textile = "_Hello_",
+            .expected = "<p><em>Hello</em></p>\n",
+        },
+        // Textile `"text":url` converges with the Markdown inline link.
+        .{
+            .markdown = "[x](http://u)",
+            .textile = "\"x\":http://u",
+            .expected = "<p><a href=\"http://u\">x</a></p>\n",
+        },
+        // Textile `!url!` converges with the Markdown empty-alt image.
+        .{
+            .markdown = "![](img.png)",
+            .textile = "!img.png!",
+            .expected = "<p><img src=\"img.png\" alt=\"\" /></p>\n",
+        },
+        // Textile `*`/`#` lists converge with Markdown lists.
+        .{
+            .markdown = "* one\n* two",
+            .textile = "* one\n* two",
+            .expected = "<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n",
+        },
+        .{
+            .markdown = "1. one\n2. two",
+            .textile = "# one\n# two",
+            .expected = "<ol>\n<li>one</li>\n<li>two</li>\n</ol>\n",
         },
     };
     for (pairs) |p| {


### PR DESCRIPTION
Syncs the 7 local commits (ea046ce..f195635) that predate the Protect-main ruleset onto origin/main:
- Textile phrase modifiers, links, images, lists (fixtures + unit tests)
- Textile parity audit, per-section 652/652 scorecard
- CI conformance gate workflow
- GFM-tables decision, branch-protection draft

No direct push is possible under the live ruleset, so this PR is the merge path.