### PR TITLE
Markdown extensions and fixes consumed by the Boris renderer migration (hold until embargo lifts)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,9 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // The core library. Consumers import it by name (see build.zig.zon).
-    const oliver_mod = b.createModule(.{
+    // The core library. Consumers import it by name (see build.zig.zon);
+    // `addModule` registers it as the package's "oliver" module.
+    const oliver_mod = b.addModule("oliver", .{
         .root_source_file = b.path("src/oliver.zig"),
         .target = target,
         .optimize = optimize,

--- a/docs/INLINE-PARSING.md
+++ b/docs/INLINE-PARSING.md
@@ -25,7 +25,11 @@ stack: unescaped `[`/`]` become scan items, a `]` whose nearest `[` is
 followed by a valid `(...)` splices the range into a `link` item, every
 earlier `[` dies (links cannot contain links), and link text is matched as
 a fresh inline scope (the spec's "process emphasis with the `[` opener as
-stack_bottom"). Reference links required a two-phase restructure: link
+stack_bottom"). When the spliced range's last item extends past the
+closing paren/`]` (e.g. `[foo](/uri) and more`), its tail is re-appended
+as literal text **after** the shrink that consumes the construct — a bug
+that previously dropped all inline content after a link (`table-inline-content`
+and `link-trailing-text` fixtures lock this). Reference links required a two-phase restructure: link
 reference definitions (§4.7) are collected during the block pass (before
 any inline parsing, since a use may precede its definition), and the
 inline pass then resolves the full `[text][label]`, collapsed `[text][]`,

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -1,4 +1,4 @@
-# Markdown extensions (footnotes, definition lists, heading attributes)
+# Markdown extensions (footnotes, definition lists, heading attributes, strikethrough)
 
 **Status:** implemented — opt-in Markdown dialect extensions  \
 **Modules:** `src/markdown.zig` (parse), `src/html.zig` (render), `src/document.zig` (model)  \
@@ -121,7 +121,31 @@ headings:
   the heading model. See the `heading_ids` render option for how the
   explicit id interacts with auto-generated ids.
 
-## 4. GFM-style heading ids (`render: heading_ids`)
+## 4. GFM strikethrough (`parse: strikethrough`)
+
+Wraps text in `<del>` when it is surrounded by a matching pair of exactly
+**two** tildes, per GFM spec §6.5 "Strikethrough (extension)".
+
+- Only runs of exactly two tildes are delimiters; a single `~` and runs of
+  three or more tildes stay literal text (consumed whole, so a three-tilde
+  run cannot re-scan as a two-tilde delimiter).
+- Flanking follows the CommonMark emphasis rules (`*`-style: opening needs
+  left-flanking, closing needs right-flanking), and strikethrough cannot
+  span paragraph boundaries. Within a paragraph it may span soft-wrapped
+  lines, and it composes with emphasis, links, code spans, and tables.
+- `~~` delimiters never interact with `*`/`_` emphasis runs, and the
+  block-level definition-list `~` marker is unaffected (definitions require
+  a `~` at line start; a two-tilde run never matches).
+- Rendered as the document-model `deleted` node (the same node Textile's
+  `-x-` produces), so both dialects emit `<del>`.
+- Examples: `~~Hi~~ Hello, world!` → `<del>Hi</del> Hello, world!`;
+  `~x~` and `~~~x~~~` render literally.
+- Fixtures: `tests/fixtures/markdown/ext-strikethrough.md`; unit tests in
+  `src/markdown.zig`.
+
+---
+
+## 5. GFM-style heading ids (`render: heading_ids`)
 
 Auto-generated `id` attributes on every heading that has no explicit IAL
 id, following GFM §5.3 applied byte-wise:
@@ -159,7 +183,8 @@ suffixes), matching the GFM reference implementation.
   `heading_ids` is on; footnotes may appear inside definition bodies; link
   reference definitions and footnote definitions can lead the same
   paragraph (footnote definitions are tried first).
-- Fenced code, code spans, HTML blocks, and raw HTML are opaque to all four
-  extensions (a `[^x]:` line inside a fence is code, not a definition).
+- Fenced code, code spans, HTML blocks, and raw HTML are opaque to all five
+  extensions (a `[^x]:` line inside a fence is code, not a definition; a
+  `~~` pair inside a code span or fence is literal).
 - Fixtures: `tests/fixtures/markdown/ext-*.md` (parsed with all extensions
   enabled) plus unit tests in `src/markdown.zig` and `src/html.zig`.

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -1,0 +1,165 @@
+# Markdown extensions (footnotes, definition lists, heading attributes)
+
+**Status:** implemented — opt-in Markdown dialect extensions  \
+**Modules:** `src/markdown.zig` (parse), `src/html.zig` (render), `src/document.zig` (model)  \
+**Options:** `oliver.ParseOptions.markdown` (parse) and `oliver.html.RenderOptions` (render)
+
+The Markdown frontend is byte-exact CommonMark 0.31.2 by default (the
+652/652 conformance corpus is green with default options). The extensions
+below are **off by default** and enabled per parse/render call, so no
+consumer pays for syntax it did not ask for, and the CommonMark regression
+wall stays meaningful.
+
+The four extensions were added for a real consumer (the Boris static-site
+compiler) that publishes footnotes, definition lists, explicit heading
+anchors, and GFM-style auto heading ids. They are implemented here, in the
+markup library, rather than as consumer-side post-processing, so their
+behavior is a library contract with fixtures.
+
+---
+
+## 1. Footnotes (`parse: footnotes`)
+
+Pandoc-style footnotes:
+
+```markdown
+Hi[^note].
+
+[^note]: The note body.
+```
+
+- A reference is `[^label]` where `label` is any non-empty bytes between
+  the caret and the closing bracket (spaces allowed, `]` not). A reference
+  is recognized **only when the label names a registered definition**;
+  undefined references stay literal text.
+- A definition line is `[^label]:` at the start of a paragraph line with
+  at most three columns of indentation, followed by optional whitespace
+  and the note body. A definition may be continued on following lines
+  indented 1–3 columns. Definitions are extracted from the start of each
+  paragraph, exactly like §4.7 link reference definitions, and a paragraph
+  consisting only of definitions produces no block.
+- Definitions never appear in the body; the renderer (with the `footnotes`
+  render option) appends a footnotes section at the end of the document
+  containing the **used** definitions in **first-reference order**,
+  numbered 1..N:
+
+```html
+<p>Hi<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>.</p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-1">
+<p>The note body. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+</ol>
+</section>
+```
+
+- Labels match **exactly** (case-sensitive byte equality).
+- Render-side numbering is first-reference order, so the numbers follow the
+  order the author references the notes, not the order of the definitions.
+- The back-reference anchor is appended inside the definition's last
+  paragraph; a definition whose last block is not a paragraph gets the
+  anchor on its own line before `</li>`.
+- The footnotes section renders only when the `footnotes` render option is
+  on **and** at least one reference exists.
+
+## 2. Definition lists (`parse: definition_lists`)
+
+Pandoc-style definition lists:
+
+```markdown
+Term
+: Definition text.
+```
+
+- A definition marker is `:` or `~` preceded by at most three columns of
+  indentation and followed by a space/tab. The marker line must directly
+  follow a term paragraph (no blank line).
+- The term is the immediately preceding paragraph. Consecutive
+  term/definition pairs without a blank line between them merge into **one**
+  `<dl>`.
+- A definition's content is the marker-stripped line; following lines
+  indented 1–3 columns continue the definition's paragraph (the inline pass
+  trims their leading whitespace). A line with four or more columns of
+  indentation ends the definition body (it is reprocessed as an indented
+  code block).
+- A blank line, a block start (heading, fence, thematic break, list, block
+  quote, table, HTML block, ...), or end of input ends the list. A
+  definition marker with no open term paragraph and no open list is
+  ordinary text.
+- Within block quotes and list items the marker is matched after container
+  markers are stripped (`> Term`, `> : Definition` works).
+- Rendering: a single-paragraph definition body renders tight (`<dd>text</dd>`);
+  a multi-block body keeps its `<p>` wrappers:
+
+```html
+<dl>
+<dt>Term</dt>
+<dd>Definition text.</dd>
+</dl>
+```
+
+## 3. Heading attribute lists (`parse: heading_attributes`)
+
+Kramdown/MultiMarkdown-style inline attribute lists on ATX and Setext
+headings:
+
+```markdown
+## Exit codes {#exit-codes}
+
+### Warning {#warn .important}
+```
+
+- The attribute list is the last thing on the heading line, preceded by
+  whitespace: `{#id .class}`. `#id` sets the heading's explicit id and
+  `.class` its class (first token of each kind wins; values are the raw
+  source bytes). Unknown token shapes, an empty `{}`, or a `{...}` that is
+  not preceded by whitespace leave the heading unchanged (the `{...}`
+  stays literal text).
+- The list is consumed: it never appears in the rendered heading text.
+- The parse option only affects recognition; the id/class are carried on
+  the heading model. See the `heading_ids` render option for how the
+  explicit id interacts with auto-generated ids.
+
+## 4. GFM-style heading ids (`render: heading_ids`)
+
+Auto-generated `id` attributes on every heading that has no explicit IAL
+id, following GFM §5.3 applied byte-wise:
+
+1. Lowercase ASCII letters.
+2. Keep `a-z 0-9 _ -`; drop everything else (including non-ASCII bytes).
+3. Collapse every whitespace run into a single `-`.
+4. Trim leading/trailing `-`.
+
+The slug is computed from the heading's **plain-text content**: text is
+entity-decoded, code spans contribute their normalized content, images
+their alt, autolinks their label, nested inline containers their text,
+breaks become spaces, and raw HTML is skipped. Examples:
+
+| Heading | id |
+| --- | --- |
+| `## Hello, World!` | `hello-world` |
+| `## Sub & More` | `sub-more` |
+| `## Café résumé` | `caf-rsum` |
+| `## Code ` + `` `span` `` + ` here` | `code-span-here` |
+| `## **Bold** and *italic*` | `bold-and-italic` |
+| `## Exit codes {#exit-codes}` (IAL) | `exit-codes` (explicit wins) |
+
+Byte-wise application means non-ASCII letters are dropped (their base
+letters are not recovered), which matches the observed GitHub behavior for
+accented headings (`Café résumé` → `caf-rsum`) without a Unicode
+normalization table. Duplicate headings keep duplicate ids (no `-1`
+suffixes), matching the GFM reference implementation.
+
+---
+
+## Interaction and precedence
+
+- Extensions compose: a heading with an IAL id renders that id even when
+  `heading_ids` is on; footnotes may appear inside definition bodies; link
+  reference definitions and footnote definitions can lead the same
+  paragraph (footnote definitions are tried first).
+- Fenced code, code spans, HTML blocks, and raw HTML are opaque to all four
+  extensions (a `[^x]:` line inside a fence is code, not a definition).
+- Fixtures: `tests/fixtures/markdown/ext-*.md` (parsed with all extensions
+  enabled) plus unit tests in `src/markdown.zig` and `src/html.zig`.

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -57,6 +57,19 @@ Hi[^note].
 - Labels match **exactly** (case-sensitive byte equality).
 - Render-side numbering is first-reference order, so the numbers follow the
   order the author references the notes, not the order of the definitions.
+- **Repeated references are tracked per reference.** The first reference to
+  a footnote is `fnref-N`; the second is `fnref-N-2`, the third
+  `fnref-N-3`, and so on, so every reference has a unique id (a duplicate
+  `id` would be invalid HTML and break fragment navigation and
+  `getElementById`). The footnote body emits **one backref per reference**,
+  each pointing at its own reference id — the `data-footnote-backref-idx`
+  carries the `N`, `N-2`, `N-3`, … form. Example (three references to one
+  note):
+
+```html
+<p>The note body. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩</a> <a href="#fnref-1-3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-3" aria-label="Back to reference 1-3">↩</a></p>
+```
+
 - The back-reference anchor is appended inside the definition's last
   paragraph; a definition whose last block is not a paragraph gets the
   anchor on its own line before `</li>`.

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -70,6 +70,33 @@ Hi[^note].
 <p>The note body. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩</a> <a href="#fnref-1-3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-3" aria-label="Back to reference 1-3">↩</a></p>
 ```
 
+**Convention provenance (checked against reference implementations).**
+Footnotes are not in CommonMark 0.31.2, and GitHub never added them to the
+GFM spec document (announced 2021-09-30), so GFM is the de facto — not
+specified — authority. Against the reference implementations, on source:
+
+- **GFM / GitHub** (`micromark-extension-gfm-footnote`, which states it
+  "matches github.com"; `dev/lib/html.js`): reference ids are
+  `fnref-<label>` for the first call and `fnref-<label>-2`, `-3`, … for
+  rereferences — the same `-N` counter this extension uses. Backrefs are
+  emitted one per reference, hrefs `#fnref-<label>` / `#fnref-<label>-2`,
+  with `aria-label` from its `defaultBackLabel(referenceIndex,
+  rereferenceIndex)` template: `Back to reference 1`, `Back to reference
+  1-2`, … — byte-identical to the `aria-label`s above. GFM keys the base
+  id on the *label* (`fnref-speed`); Oliver keys on the first-reference
+  *number* (`fnref-1`). For numeric labels the two coincide; for named
+  labels it is internal naming with no spec authority either way.
+- **Pandoc** (`src/Text/Pandoc/Writers/HTML.hs`, the `Note` case): ids are
+  number-based (`fnref1`, first-reference order) — the same base
+  philosophy as `fnref-N`. Pandoc emits the *same* `id="fnref1"` for
+  every reference to a note and a single backref, i.e. it has the
+  duplicate-id defect this extension deliberately fixes; the same defect
+  is reported for Hugo/Goldmark (hugo#9757) and Python-Markdown (#468).
+- **Presentation note:** GFM and Pandoc render a visible `↩<sup>2</sup>`
+  counter on the second and later backrefs; this extension carries the
+  same information in `data-footnote-backref-idx` (`N-2`, `N-3`, …) and
+  the `aria-label` instead, with no visible counter.
+
 - The back-reference anchor is appended inside the definition's last
   paragraph; a definition whose last block is not a paragraph gets the
   anchor on its own line before `</li>`.

--- a/src/document.zig
+++ b/src/document.zig
@@ -153,10 +153,24 @@ pub const Tag = enum {
     /// "Acronyms"): renders `<acronym title="…">CSS</acronym>`. Leaf:
     /// `data.acronym` holds the letters and the definition title.
     acronym,
+    /// A Markdown definition list (Pandoc-style extension): container whose
+    /// children are alternating `.definition_term` and `.definition_body`
+    /// nodes, rendered as `<dl><dt>…</dt><dd>…</dd>…</dl>`.
+    definition_list,
+    /// A definition list term: container whose children are inlines (like a
+    /// heading).
+    definition_term,
+    /// A definition list body: container whose children are blocks (the
+    /// definition content).
+    definition_body,
+    /// A footnote definition body (Markdown `[^label]:` extension): a
+    /// container whose children are blocks. Never a document child — the
+    /// renderer emits it inside the footnotes section.
+    footnote,
 
     pub fn isBlock(self: Tag) bool {
         return switch (self) {
-            .document, .paragraph, .heading, .thematic_break, .code_block, .html_block, .block_quote, .list, .list_item, .table, .table_row, .table_cell => true,
+            .document, .paragraph, .heading, .thematic_break, .code_block, .html_block, .block_quote, .list, .list_item, .table, .table_row, .table_cell, .definition_list, .definition_term, .definition_body, .footnote => true,
             .text, .emphasis, .strong, .bold, .italic, .deleted, .inserted, .big, .small, .superscript, .subscript, .cite, .span, .code_span, .link, .image, .autolink, .raw_html, .soft_break, .hard_break, .footnote_ref, .acronym => false,
         };
     }
@@ -164,7 +178,7 @@ pub const Tag = enum {
     pub fn isInline(self: Tag) bool {
         return switch (self) {
             .text, .emphasis, .strong, .bold, .italic, .deleted, .inserted, .big, .small, .superscript, .subscript, .cite, .span, .code_span, .link, .image, .autolink, .raw_html, .soft_break, .hard_break, .footnote_ref, .acronym => true,
-            .document, .paragraph, .heading, .thematic_break, .code_block, .html_block, .block_quote, .list, .list_item, .table, .table_row, .table_cell => false,
+            .document, .paragraph, .heading, .thematic_break, .code_block, .html_block, .block_quote, .list, .list_item, .table, .table_row, .table_cell, .definition_list, .definition_term, .definition_body, .footnote => false,
         };
     }
 };
@@ -182,8 +196,10 @@ pub const Data = union(enum) {
     /// `.heading`: level, 1..6, plus the Textile block attributes
     /// (`hN(...).`/`hN{...}.` signatures); Markdown headings carry none.
     heading: Heading,
-    /// `.footnote_ref`: the footnote number (Textile `[N]` references).
-    footnote_ref: u16,
+    /// `.footnote_ref`: the footnote reference payload. Textile `[N]`
+    /// references carry a `number`; Markdown `[^label]` references carry
+    /// the label (numbered at render time in first-reference order).
+    footnote_ref: FootnoteRef,
     /// `.acronym`: the Textile acronym (`CSS(Cascading Style Sheets)`, Hobix
     /// "Acronyms"): the uppercase letters (a source slice, verbatim) and
     /// the definition as the `title` (arena-owned, like link/image
@@ -291,10 +307,39 @@ pub const BlockQuote = struct {
 };
 
 /// The payload of a `.heading` node: the level (1..6) and the Textile
-/// block attributes.
+/// block attributes, plus the optional Markdown heading-attribute-list
+/// (IAL) `id` and `class` (`## Heading {#id .class}` extension). When
+/// `heading_ids` rendering is enabled, an absent explicit `id` is replaced
+/// by the GFM-style slug of the heading's text.
 pub const Heading = struct {
     level: u8,
     attrs: []const Attribute = &.{},
+    /// Markdown IAL `{#id}`; null when absent. Raw source slice (escapes
+    /// and entities are not resolved).
+    id: ?[]const u8 = null,
+    /// Markdown IAL `{.class}`; null when absent. Raw source slice.
+    class: ?[]const u8 = null,
+};
+
+/// The payload of a `.footnote_ref` node.
+pub const FootnoteRef = struct {
+    /// Markdown `[^label]` reference label, or empty for a Textile `[N]`
+    /// reference. The renderer numbers Markdown references in
+    /// first-reference order.
+    label: []const u8 = "",
+    /// Textile footnote number (`[N]`, rendered directly). Unused for
+    /// Markdown references.
+    number: u16 = 0,
+};
+
+/// A Markdown footnote definition (`[^label]:` extension): the (exact,
+/// case-sensitive) label and the `.footnote` container node holding the
+/// definition's blocks. Definitions never appear in the document body;
+/// they are registered here and rendered at the end of the document when
+/// the `footnotes` render option is enabled.
+pub const FootnoteDef = struct {
+    label: []const u8,
+    node: *Node,
 };
 
 /// The payload of a `.code_block` leaf. `content` uses `\n` line endings and
@@ -482,6 +527,9 @@ pub const Document = struct {
     /// Borrowed input; text payloads slice into it.
     src: source.Source,
     root: *Node,
+    /// Markdown footnote definitions, in definition order. Arena-owned;
+    /// the arena reset releases them with everything else.
+    footnotes: std.ArrayList(FootnoteDef) = .empty,
 
     pub fn init(backing: std.mem.Allocator, src: source.Source) !Document {
         var arena = std.heap.ArenaAllocator.init(backing);

--- a/src/html.zig
+++ b/src/html.zig
@@ -148,10 +148,14 @@ pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Docu
     var stack = std.ArrayList(Frame).empty;
     defer stack.deinit(gpa);
 
+    // The footnote-numbering table is always allocated: `deinit` runs on
+    // every path, so an `undefined` map here would be freed while uninitialized
+    // (the managed HashMap's pointer-stability mutex is garbage) — a crash
+    // that only manifests on some platforms/stack states.
     var fn_ctx = if (options.footnotes and doc.footnotes.items.len > 0)
         try Footnotes.init(gpa, doc)
     else
-        Footnotes{ .numbers = undefined };
+        Footnotes{ .numbers = std.StringHashMap(u32).init(gpa) };
     defer fn_ctx.deinit(gpa);
 
     try stack.append(gpa, .{ .enter = .{
@@ -1682,6 +1686,51 @@ test "html: footnote refs and section render in first-reference order" {
     var out2 = try renderDoc(&doc);
     defer out2.deinit(testing.allocator);
     try testing.expect(std.mem.indexOf(u8, out2.items, "footnote-ref") == null);
+}
+
+test "html: render without footnote context never frees an uninitialized map" {
+    // Regression: the footnote-numbering table was left `undefined` whenever
+    // the footnotes option was off (or on with no definitions), yet `deinit`
+    // ran unconditionally. Freeing an uninitialized managed HashMap reads the
+    // garbage `pointer_stability` mutex and aborts on platforms/stack states
+    // where that garbage is non-zero (observed on Linux CI; benign on macOS).
+    // Every render path must construct the map with a real allocator.
+    {
+        // Default options, no footnotes anywhere.
+        var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+        defer doc.deinit();
+        const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+        try doc.appendChild(doc.root, p);
+        try addText(&doc, p, "No footnotes here.");
+        var out = try renderDoc(&doc);
+        defer out.deinit(testing.allocator);
+        try testing.expectEqualStrings("<p>No footnotes here.</p>\n", out.items);
+    }
+    {
+        // Option enabled but the document defines no footnotes.
+        var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+        defer doc.deinit();
+        const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+        try doc.appendChild(doc.root, p);
+        try addText(&doc, p, "Plain paragraph.");
+        var out = try renderDocOpts(&doc, .{ .footnotes = true });
+        defer out.deinit(testing.allocator);
+        try testing.expectEqualStrings("<p>Plain paragraph.</p>\n", out.items);
+    }
+    {
+        // Definitions present but the option off: refs render literally and
+        // the numbering table is still the empty-initialized path.
+        var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+        defer doc.deinit();
+        const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+        try doc.appendChild(doc.root, p);
+        try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "x" } }));
+        const def = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+        try doc.footnotes.append(doc.allocator(), .{ .label = "x", .node = def });
+        var out = try renderDoc(&doc);
+        defer out.deinit(testing.allocator);
+        try testing.expect(std.mem.indexOf(u8, out.items, "footnote-ref") == null);
+    }
 }
 
 test "html: definition lists render dl/dt/dd with tight single paragraphs" {

--- a/src/html.zig
+++ b/src/html.zig
@@ -80,6 +80,53 @@ pub const RenderOptions = struct {
     void_trailing_slash: bool = true,
     /// The output profile: `.html` (default) or `.xhtml`.
     profile: OutputProfile = .html,
+    /// Emit GFM-style auto-generated `id` attributes on headings (the
+    /// Markdown `heading_ids` extension, docs/MARKDOWN-EXTENSIONS.md): a
+    /// heading without an explicit IAL id gets a slug of its plain-text
+    /// content (lowercased ASCII, non-word bytes dropped, whitespace runs
+    /// collapsed to `-`, leading/trailing `-` trimmed). Off by default so
+    /// the CommonMark corpus stays byte-exact.
+    heading_ids: bool = false,
+    /// Render Markdown footnotes (the `footnotes` parse extension): each
+    /// `[^label]` reference becomes a footnote-ref link numbered in
+    /// first-reference order, and a `<section class="footnotes">` block is
+    /// appended at the end of the document with the used definitions and
+    /// their back-references. Off by default.
+    footnotes: bool = false,
+};
+
+/// Footnote rendering context: label → number (first-reference order) and
+/// the used labels in that order. Built by a pre-pass over the document
+/// when the `footnotes` render option is enabled.
+const Footnotes = struct {
+    numbers: std.StringHashMap(u32) = undefined,
+    used: std.ArrayList([]const u8) = .empty,
+
+    fn init(gpa: std.mem.Allocator, doc: *const document.Document) !Footnotes {
+        var self = Footnotes{
+            .numbers = std.StringHashMap(u32).init(gpa),
+            .used = .empty,
+        };
+        var it = try document.Document.Iterator.init(gpa, doc.root);
+        defer it.deinit();
+        while (try it.next()) |n| {
+            if (n.tag != .footnote_ref or n.data.footnote_ref.label.len == 0) continue;
+            const label = n.data.footnote_ref.label;
+            if (self.numbers.contains(label)) continue;
+            try self.numbers.put(label, @intCast(self.used.items.len + 1));
+            try self.used.append(gpa, label);
+        }
+        return self;
+    }
+
+    fn deinit(self: *Footnotes, gpa: std.mem.Allocator) void {
+        self.numbers.deinit();
+        self.used.deinit(gpa);
+    }
+
+    fn number(self: *const Footnotes, label: []const u8) ?u32 {
+        return self.numbers.get(label);
+    }
 };
 
 /// A document contains verbatim source bytes (Markdown raw HTML leaves or
@@ -95,26 +142,48 @@ pub const RawHtmlNotXmlWellFormed = error.RawHtmlNotXmlWellFormed;
 /// pass a pointer to it. In Zig 0.16, `std.Io.Writer` values (e.g. from
 /// `std.Io.Writer.Allocating` or `std.Io.File.writer`) satisfy this.
 ///
-/// `gpa` is used only for the temporary traversal stack; nothing is retained.
+/// `gpa` is used only for the temporary traversal stack, footnote numbering
+/// tables, and heading-slug scratch; nothing is retained.
 pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Document, options: RenderOptions) !void {
     var stack = std.ArrayList(Frame).empty;
     defer stack.deinit(gpa);
+
+    var fn_ctx = if (options.footnotes and doc.footnotes.items.len > 0)
+        try Footnotes.init(gpa, doc)
+    else
+        Footnotes{ .numbers = undefined };
+    defer fn_ctx.deinit(gpa);
 
     try stack.append(gpa, .{ .enter = .{
         .node = doc.root,
         .tight_item = false,
         .suppress_p = false,
         .prefix_newline = false,
+        .footnote_backref = 0,
     } });
     while (stack.pop()) |frame| {
         switch (frame) {
             .enter => |f| {
                 if (f.prefix_newline) try writer.writeByte('\n');
-                try writeOpen(gpa, writer, &stack, f.node, f.suppress_p, options, doc.src.bytes);
+                try writeOpen(gpa, writer, &stack, f.node, f.suppress_p, f.footnote_backref, options, doc.src.bytes, &fn_ctx);
                 try pushChildren(gpa, &stack, f.node, f.tight_item);
             },
             .marker => |text| try writer.writeAll(text),
-            .exit => |f| try writeClose(writer, f.node, f.suppress_p, options),
+            .backref => |n| try writeBackref(writer, n),
+            .li_open => |n| {
+                var buf: [32]u8 = undefined;
+                const tag = try std.fmt.bufPrint(&buf, "<li id=\"fn-{d}\">\n", .{n});
+                try writer.writeAll(tag);
+            },
+            .exit => |f| {
+                // The document's exit pops last: everything else is already
+                // rendered, so the footnotes section is pushed now and
+                // renders in document order after the body.
+                if (f.node.tag == .document and fn_ctx.used.items.len > 0) {
+                    try pushFootnotesSection(gpa, &stack, doc, &fn_ctx);
+                }
+                try writeClose(writer, f.node, f.suppress_p, options, f.footnote_backref);
+            },
         }
     }
 }
@@ -134,13 +203,25 @@ const Frame = union(enum) {
         /// a following nested block supplies that separator here; the first
         /// block in a loose item also starts on the line after `<li>`.
         prefix_newline: bool,
+        /// Footnote number whose back-reference anchor is appended inside
+        /// this paragraph's close (a footnote definition's last paragraph,
+        /// or 0 for none).
+        footnote_backref: u32,
     },
     /// Literal output emitted when popped, used for the `<thead>`/`<tbody>`
-    /// transitions between a table's header row and its body rows.
+    /// transitions between a table's header row and its body rows and for
+    /// the footnotes section scaffolding.
     marker: []const u8,
+    /// A footnote back-reference anchor, emitted when popped (the anchor is
+    /// not a static string).
+    backref: u32,
+    /// A footnote `<li id="fn-N">` opener, emitted when popped (the number
+    /// is not a static string).
+    li_open: u32,
     /// `suppress_p` mirrors the decision made at open time, so the close
-    /// tag matches.
-    exit: struct { node: *const document.Node, suppress_p: bool },
+    /// tag matches; `footnote_backref` carries the paragraph-attached
+    /// footnote back-reference to the close.
+    exit: struct { node: *const document.Node, suppress_p: bool, footnote_backref: u32 },
 };
 
 fn pushChildren(
@@ -167,6 +248,7 @@ fn pushChildren(
                     .tight_item = false,
                     .suppress_p = false,
                     .prefix_newline = false,
+                    .footnote_backref = 0,
                 } });
             }
             return;
@@ -180,6 +262,7 @@ fn pushChildren(
                 .tight_item = false,
                 .suppress_p = false,
                 .prefix_newline = false,
+                .footnote_backref = 0,
             } });
         }
         try stack.append(gpa, .{ .marker = if (has_body) "</thead>\n<tbody>\n" else "</thead>\n" });
@@ -188,8 +271,36 @@ fn pushChildren(
             .tight_item = false,
             .suppress_p = false,
             .prefix_newline = false,
+            .footnote_backref = 0,
         } });
         try stack.append(gpa, .{ .marker = "<thead>\n" });
+        return;
+    }
+    // A definition body renders its direct paragraphs like a tight list
+    // item: a single-paragraph body is `<dd>text</dd>` (no `<p>`), while a
+    // multi-block body keeps `<p>` wrappers (docs/MARKDOWN-EXTENSIONS.md).
+    if (node.tag == .definition_body) {
+        const tight = node.children.items.len == 1 and node.children.items[0].tag == .paragraph;
+        var di = node.children.items.len;
+        while (di > 0) {
+            di -= 1;
+            const c = node.children.items[di];
+            const suppress = tight and c.tag == .paragraph;
+            var prefix_newline = false;
+            if (c.tag == .paragraph) {
+                prefix_newline = !tight and di == 0;
+            } else {
+                prefix_newline = di == 0 or
+                    (tight and di > 0 and node.children.items[di - 1].tag == .paragraph);
+            }
+            try stack.append(gpa, .{ .enter = .{
+                .node = c,
+                .tight_item = false,
+                .suppress_p = suppress,
+                .prefix_newline = prefix_newline,
+                .footnote_backref = 0,
+            } });
+        }
         return;
     }
     var i = node.children.items.len;
@@ -222,6 +333,7 @@ fn pushChildren(
             .tight_item = tight,
             .suppress_p = suppress,
             .prefix_newline = prefix_newline,
+            .footnote_backref = 0,
         } });
     }
 }
@@ -232,12 +344,14 @@ fn writeOpen(
     stack: *std.ArrayList(Frame),
     node: *const document.Node,
     suppress_p: bool,
+    footnote_backref: u32,
     options: RenderOptions,
     src: []const u8,
+    fn_ctx: *const Footnotes,
 ) !void {
     switch (node.tag) {
         .document => {
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .block_quote => {
             try writer.writeAll("<blockquote");
@@ -250,7 +364,7 @@ fn writeOpen(
             }
             try writeAttrs(writer, node.data.block_quote.attrs);
             try writer.writeAll(">\n");
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .table => {
             try writer.writeAll("<table");
@@ -258,13 +372,13 @@ fn writeOpen(
             try writer.writeAll(">\n");
             // Children (rows with thead/tbody markers) are pushed by
             // `pushChildren`; only the exit frame is set here.
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .table_row => {
             try writer.writeAll("<tr");
             try writeAttrs(writer, node.data.table_row.attrs);
             try writer.writeByte('>');
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .table_cell => {
             const cell = node.data.table_cell;
@@ -290,7 +404,7 @@ fn writeOpen(
                 .right => try writer.writeAll(" align=\"right\""),
             }
             try writer.writeByte('>');
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .list => {
             const list = node.data.list;
@@ -314,7 +428,7 @@ fn writeOpen(
                     try writer.writeAll(">\n");
                 },
             }
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .list_item => {
             // Textile definition-list items carry their role (term →
@@ -323,7 +437,7 @@ fn writeOpen(
                 .list_item => |li| try writer.writeAll(if (li.role == .definition) "<dd>" else "<dt>"),
                 else => try writer.writeAll("<li>"),
             }
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .paragraph => {
             // §5.3: a paragraph directly in a tight list's item renders
@@ -333,16 +447,58 @@ fn writeOpen(
                 try writeAttrs(writer, node.data.paragraph.attrs);
                 try writer.writeByte('>');
             }
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = suppress_p } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = suppress_p, .footnote_backref = footnote_backref } });
         },
         .heading => {
             const level = clampHeading(node.data.heading.level);
             var buf: [8]u8 = undefined;
             const tag = try std.fmt.bufPrint(&buf, "<h{d}", .{level});
             try writer.writeAll(tag);
-            try writeAttrs(writer, node.data.heading.attrs);
+            const h = node.data.heading;
+            if (h.id) |id| {
+                try writer.writeAll(" id=\"");
+                try writeEscaped(writer, id);
+                try writer.writeByte('"');
+            } else if (options.heading_ids) {
+                // GFM auto-id: a slug of the heading's plain-text content
+                // (its inline children).
+                var text_buf = std.ArrayList(u8).empty;
+                defer text_buf.deinit(gpa);
+                for (node.children.items) |c| try collectHeadingText(gpa, c, &text_buf);
+                const slug = try slugify(gpa, text_buf.items);
+                defer gpa.free(slug);
+                if (slug.len > 0) {
+                    try writer.writeAll(" id=\"");
+                    try writeEscaped(writer, slug);
+                    try writer.writeByte('"');
+                }
+            }
+            if (h.class) |cls| {
+                try writer.writeAll(" class=\"");
+                try writeEscaped(writer, cls);
+                try writer.writeByte('"');
+            }
+            try writeAttrs(writer, h.attrs);
             try writer.writeByte('>');
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
+        },
+        .definition_list => {
+            try writer.writeAll("<dl>\n");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
+        },
+        .definition_term => {
+            try writer.writeAll("<dt>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
+        },
+        .definition_body => {
+            try writer.writeAll("<dd>");
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
+        },
+        .footnote => {
+            // A footnote definition node is only rendered inside the
+            // footnotes section; a hand-built document that places one
+            // elsewhere renders nothing.
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .thematic_break => {
             try writer.writeAll(if (voidSlash(options)) "<hr />\n" else "<hr>\n");
@@ -397,19 +553,36 @@ fn writeOpen(
             try writer.writeAll(phraseTagName(node.tag));
             try writeAttrs(writer, phraseAttrs(node));
             try writer.writeByte('>');
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .footnote_ref => {
-            // Textile `[N]` reference (Textile 2 "Footnotes"):
-            // `<sup class="footnote"><a href="#fnN">N</a></sup>`.
-            const n = node.data.footnote_ref;
-            var buf: [16]u8 = undefined;
-            const num = try std.fmt.bufPrint(&buf, "{d}", .{n});
-            try writer.writeAll("<sup class=\"footnote\"><a href=\"#fn");
-            try writer.writeAll(num);
-            try writer.writeAll("\">");
-            try writer.writeAll(num);
-            try writer.writeAll("</a></sup>");
+            const fr = node.data.footnote_ref;
+            if (fr.label.len == 0) {
+                // Textile `[N]` reference (Textile 2 "Footnotes"):
+                // `<sup class="footnote"><a href="#fnN">N</a></sup>`.
+                var buf: [16]u8 = undefined;
+                const num = try std.fmt.bufPrint(&buf, "{d}", .{fr.number});
+                try writer.writeAll("<sup class=\"footnote\"><a href=\"#fn");
+                try writer.writeAll(num);
+                try writer.writeAll("\">");
+                try writer.writeAll(num);
+                try writer.writeAll("</a></sup>");
+            } else if (fn_ctx.number(fr.label)) |n| {
+                // Markdown `[^label]` (extension), numbered in
+                // first-reference order.
+                var buf: [16]u8 = undefined;
+                const num = try std.fmt.bufPrint(&buf, "{d}", .{n});
+                try writer.writeAll("<sup class=\"footnote-ref\"><a href=\"#fn-");
+                try writer.writeAll(num);
+                try writer.writeAll("\" id=\"fnref-");
+                try writer.writeAll(num);
+                try writer.writeAll("\" data-footnote-ref>");
+                try writer.writeAll(num);
+                try writer.writeAll("</a></sup>");
+            } else {
+                // A hand-built document with an undefined label: literal.
+                try writeEscaped(writer, fr.label);
+            }
         },
         .span => {
             // Textile `%x%` renders `<span>`; the phrase-attribute forms
@@ -419,14 +592,14 @@ fn writeOpen(
             try writer.writeAll("<span");
             try writeAttrs(writer, node.data.span.attrs);
             try writer.writeByte('>');
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .code_span => {
             try writer.writeAll("<code>");
             // Leaf tag: the (normalized) content is escaped like text
             // (& < > " and NUL -> U+FFFD), written on enter.
             try writeEscaped(writer, node.data.code_span);
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .link => {
             try writer.writeAll("<a href=\"");
@@ -438,7 +611,7 @@ fn writeOpen(
                 try writer.writeByte('\"');
             }
             try writer.writeByte('>');
-            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false } });
+            try stack.append(gpa, .{ .exit = .{ .node = node, .suppress_p = false, .footnote_backref = 0 } });
         },
         .autolink => {
             // Leaf tag: one <a> with the raw label as its text. The href
@@ -510,10 +683,10 @@ fn writeOpen(
     }
 }
 
-fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, options: RenderOptions) !void {
+fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, options: RenderOptions, footnote_backref: u32) !void {
     _ = options;
     switch (node.tag) {
-        .document => {},
+        .document, .footnote => {},
         .block_quote => try writer.writeAll("</blockquote>\n"),
         .table => {
             // The thead/tbody split is emitted by marker frames between the
@@ -539,11 +712,15 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
                 else => try writer.writeAll("</li>\n"),
             }
         },
+        .definition_list => try writer.writeAll("</dl>\n"),
+        .definition_term => try writer.writeAll("</dt>\n"),
+        .definition_body => try writer.writeAll("</dd>\n"),
         .paragraph => {
             if (suppress_p) {
                 // Tight-list paragraphs are inline content of `<li>`; a
                 // following block gets its own leading newline in its frame.
             } else {
+                if (footnote_backref > 0) try writeBackref(writer, footnote_backref);
                 try writer.writeAll("</p>\n");
             }
         },
@@ -570,6 +747,145 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
         // These tags never push exit frames.
         .thematic_break, .code_block, .html_block, .text, .image, .autolink, .raw_html, .soft_break, .hard_break, .footnote_ref, .acronym => unreachable,
     }
+}
+
+/// Writes a footnote back-reference anchor (with a leading space so it
+/// reads as `note body <a ...>↩</a>` inside a paragraph).
+fn writeBackref(writer: anytype, n: u32) !void {
+    var buf: [256]u8 = undefined;
+    const text = try std.fmt.bufPrint(
+        &buf,
+        " <a href=\"#fnref-{d}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{d}\" aria-label=\"Back to reference {d}\">↩</a>",
+        .{ n, n, n },
+    );
+    try writer.writeAll(text);
+}
+
+/// Finds the registered footnote definition for a label (linear scan;
+/// definitions are few).
+fn findFootnoteDef(doc: *const document.Document, label: []const u8) ?document.FootnoteDef {
+    for (doc.footnotes.items) |fd| {
+        if (std.mem.eql(u8, fd.label, label)) return fd;
+    }
+    return null;
+}
+
+/// Pushes the frames for the footnotes `<section>` onto the stack. Called
+/// when the document's exit frame pops, so the whole body is already
+/// rendered; the pushed frames then render in document order after it.
+/// Frames are pushed in reverse pop order: the closing markers first, each
+/// `<li>`'s close before its blocks, and the section/ol markers last.
+fn pushFootnotesSection(
+    gpa: std.mem.Allocator,
+    stack: *std.ArrayList(Frame),
+    doc: *const document.Document,
+    fn_ctx: *const Footnotes,
+) !void {
+    try stack.append(gpa, .{ .marker = "</section>\n" });
+    try stack.append(gpa, .{ .marker = "</ol>\n" });
+    // Frames pop LIFO, so the last-used footnote is pushed first.
+    var u = fn_ctx.used.items.len;
+    while (u > 0) {
+        u -= 1;
+        const label = fn_ctx.used.items[u];
+        const n = fn_ctx.number(label) orelse continue;
+        const def = findFootnoteDef(doc, label) orelse continue;
+        const children = def.node.children.items;
+        try stack.append(gpa, .{ .marker = "</li>\n" });
+        var i = children.len;
+        while (i > 0) {
+            i -= 1;
+            const c = children[i];
+            const backref: u32 = if (i == children.len - 1 and c.tag == .paragraph) n else 0;
+            try stack.append(gpa, .{ .enter = .{
+                .node = c,
+                .tight_item = false,
+                .suppress_p = false,
+                .prefix_newline = false,
+                .footnote_backref = backref,
+            } });
+        }
+        if (children.len == 0 or children[children.len - 1].tag != .paragraph) {
+            // No trailing paragraph to carry the back-reference: emit the
+            // anchor on its own before the `</li>`.
+            try stack.append(gpa, .{ .backref = n });
+        }
+        try stack.append(gpa, .{ .li_open = n });
+    }
+    try stack.append(gpa, .{ .marker = "<ol>\n" });
+    try stack.append(gpa, .{ .marker = "<section class=\"footnotes\" data-footnotes>\n" });
+}
+
+/// Collects the plain-text projection of a heading's inline content: text
+/// (entity-decoded, escapes already split into their own text nodes),
+/// code-span content, image alt, autolink labels, and the text of nested
+/// inline containers. Soft/hard breaks become spaces; raw HTML is skipped.
+fn collectHeadingText(gpa: std.mem.Allocator, node: *const document.Node, out: *std.ArrayList(u8)) !void {
+    switch (node.tag) {
+        .text => try writeDecodedText(gpa, out, node.data.text),
+        .code_span => try out.appendSlice(gpa, node.data.code_span),
+        .image => try out.appendSlice(gpa, node.data.image.alt),
+        .autolink => try out.appendSlice(gpa, node.data.autolink.label),
+        .soft_break, .hard_break => try out.append(gpa, ' '),
+        .raw_html => {},
+        .link, .emphasis, .strong, .bold, .italic, .deleted, .inserted, .superscript, .subscript, .span => {
+            for (node.children.items) |c| try collectHeadingText(gpa, c, out);
+        },
+        else => {},
+    }
+}
+
+/// Appends the entity-decoded bytes of `text` (no HTML escaping) — the
+/// plain-text projection used for heading slugs. A backslash-escaped `&`
+/// is its own text node (the escape split), so it has no trailing `;` and
+/// stays literal here.
+fn writeDecodedText(gpa: std.mem.Allocator, out: *std.ArrayList(u8), text: []const u8) !void {
+    var start: usize = 0;
+    var i: usize = 0;
+    while (i < text.len) {
+        if (text[i] == '&') {
+            if (entities.decodeAt(text, i)) |dec| {
+                try out.appendSlice(gpa, text[start..i]);
+                try out.appendSlice(gpa, dec.bytes[0..dec.len]);
+                i = dec.next;
+                start = i;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    try out.appendSlice(gpa, text[start..]);
+}
+
+/// GFM-style heading slug (docs/MARKDOWN-EXTENSIONS.md): lowercase ASCII
+/// letters; keep `a-z 0-9 _ -`; collapse every whitespace run into one `-`;
+/// drop everything else (including non-ASCII bytes); trim leading/trailing
+/// `-`. This is the §5.3 algorithm applied byte-wise, which reproduces the
+/// observed GitHub behavior for `Café résumé` → `caf-rsum` (accented bytes
+/// are not ASCII letters and are dropped).
+fn slugify(gpa: std.mem.Allocator, text: []const u8) ![]u8 {
+    var buf = std.ArrayList(u8).empty;
+    var pending_space = false;
+    for (text) |b| {
+        const c: u8 = switch (b) {
+            'A'...'Z' => b + 32,
+            'a'...'z', '0'...'9', '_', '-' => b,
+            ' ', '\t', '\n', '\r' => {
+                pending_space = true;
+                continue;
+            },
+            else => continue,
+        };
+        if (pending_space) {
+            if (buf.items.len > 0) try buf.append(gpa, '-');
+            pending_space = false;
+        }
+        try buf.append(gpa, c);
+    }
+    var end = buf.items.len;
+    while (end > 0 and buf.items[end - 1] == '-') end -= 1;
+    buf.shrinkRetainingCapacity(end);
+    return buf.toOwnedSlice(gpa);
 }
 
 /// Heading levels are clamped to 1..6 so hand-built documents with invalid
@@ -1266,4 +1582,126 @@ test "html: code block escapes content and uses the first info word" {
         "<pre><code class=\"language-zig&amp;lang\">&lt;x&gt;\u{FFFD}\n</code></pre>\n",
         out.items,
     );
+}
+
+fn renderDocOpts(doc: *document.Document, options: RenderOptions) !std.ArrayList(u8) {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    try render(testing.allocator, &aw.writer, doc, options);
+    return aw.toArrayList();
+}
+
+fn addHeadingText(doc: *document.Document, h: *document.Node, text: []const u8) !void {
+    try addText(doc, h, text);
+}
+
+test "html: heading ids slug the plain-text content and honor IAL ids" {
+    {
+        // Auto id from the heading's text (a code span contributes its
+        // content; an entity decodes before slugging).
+        var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+        defer doc.deinit();
+        const h = try doc.createNode(.heading, .{ .start = 0, .end = 0 }, .{ .heading = .{ .level = 1 } });
+        try doc.appendChild(doc.root, h);
+        try addText(&doc, h, "Hello, ");
+        try doc.appendChild(h, try doc.createNode(.code_span, .{ .start = 0, .end = 0 }, .{ .code_span = "World" }));
+        try addText(&doc, h, " &amp; Co!");
+        var out = try renderDocOpts(&doc, .{ .heading_ids = true });
+        defer out.deinit(testing.allocator);
+        try testing.expectEqualStrings("<h1 id=\"hello-world-co\">Hello, <code>World</code> &amp; Co!</h1>\n", out.items);
+    }
+    {
+        // An explicit IAL id wins over the slug; class is emitted.
+        var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+        defer doc.deinit();
+        const h = try doc.createNode(.heading, .{ .start = 0, .end = 0 }, .{
+            .heading = .{ .level = 2, .id = "explicit", .class = "cls" },
+        });
+        try doc.appendChild(doc.root, h);
+        try addHeadingText(&doc, h, "Whatever");
+        var out = try renderDocOpts(&doc, .{ .heading_ids = true });
+        defer out.deinit(testing.allocator);
+        try testing.expectEqualStrings("<h2 id=\"explicit\" class=\"cls\">Whatever</h2>\n", out.items);
+    }
+    {
+        // Without the option, no ids at all.
+        var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+        defer doc.deinit();
+        const h = try doc.createNode(.heading, .{ .start = 0, .end = 0 }, .{ .heading = .{ .level = 1 } });
+        try doc.appendChild(doc.root, h);
+        try addHeadingText(&doc, h, "Hello");
+        var out = try renderDoc(&doc);
+        defer out.deinit(testing.allocator);
+        try testing.expectEqualStrings("<h1>Hello</h1>\n", out.items);
+    }
+}
+
+test "html: footnote refs and section render in first-reference order" {
+    var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+    defer doc.deinit();
+
+    const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(doc.root, p);
+    try addText(&doc, p, "Hi");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "second" } }));
+    try addText(&doc, p, " and ");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "syntax" } }));
+    try addText(&doc, p, ".");
+
+    // Definitions, in definition order (rendered in first-reference order).
+    const def1 = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+    const p1 = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(def1, p1);
+    try addText(&doc, p1, "First body");
+    try doc.footnotes.append(doc.allocator(), .{ .label = "syntax", .node = def1 });
+
+    const def2 = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+    const p2 = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(def2, p2);
+    try addText(&doc, p2, "Second body");
+    try doc.footnotes.append(doc.allocator(), .{ .label = "second", .node = def2 });
+
+    var out = try renderDocOpts(&doc, .{ .footnotes = true });
+    defer out.deinit(testing.allocator);
+    try testing.expectEqualStrings(
+        "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup> and <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup>.</p>\n" ++
+            "<section class=\"footnotes\" data-footnotes>\n" ++
+            "<ol>\n" ++
+            "<li id=\"fn-1\">\n" ++
+            "<p>Second body <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" ++
+            "</li>\n" ++
+            "<li id=\"fn-2\">\n" ++
+            "<p>First body <a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" ++
+            "</li>\n" ++
+            "</ol>\n" ++
+            "</section>\n",
+        out.items,
+    );
+
+    // Without the option, refs with labels render literally.
+    var out2 = try renderDoc(&doc);
+    defer out2.deinit(testing.allocator);
+    try testing.expect(std.mem.indexOf(u8, out2.items, "footnote-ref") == null);
+}
+
+test "html: definition lists render dl/dt/dd with tight single paragraphs" {
+    var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+    defer doc.deinit();
+
+    const dl = try doc.createNode(.definition_list, .{ .start = 0, .end = 0 }, .none);
+    try doc.appendChild(doc.root, dl);
+
+    const dt = try doc.createNode(.definition_term, .{ .start = 0, .end = 0 }, .none);
+    try doc.appendChild(dl, dt);
+    try addText(&doc, dt, "Term");
+
+    const dd = try doc.createNode(.definition_body, .{ .start = 0, .end = 0 }, .none);
+    try doc.appendChild(dl, dd);
+    const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(dd, p);
+    try addText(&doc, p, "Definition");
+
+    var out = try renderDoc(&doc);
+    defer out.deinit(testing.allocator);
+    try testing.expectEqualStrings("<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n", out.items);
 }

--- a/src/html.zig
+++ b/src/html.zig
@@ -101,11 +101,17 @@ pub const RenderOptions = struct {
 const Footnotes = struct {
     numbers: std.StringHashMap(u32) = undefined,
     used: std.ArrayList([]const u8) = .empty,
+    /// label → number of references to that footnote rendered so far,
+    /// incremented as each reference renders (issue #44): the second
+    /// reference to a footnote gets id `fnref-N-2`, the third `fnref-N-3`,
+    /// and the footnote body emits one backref per reference.
+    ref_counts: std.StringHashMap(u32) = undefined,
 
     fn init(gpa: std.mem.Allocator, doc: *const document.Document) !Footnotes {
         var self = Footnotes{
             .numbers = std.StringHashMap(u32).init(gpa),
             .used = .empty,
+            .ref_counts = std.StringHashMap(u32).init(gpa),
         };
         var it = try document.Document.Iterator.init(gpa, doc.root);
         defer it.deinit();
@@ -122,6 +128,7 @@ const Footnotes = struct {
     fn deinit(self: *Footnotes, gpa: std.mem.Allocator) void {
         self.numbers.deinit();
         self.used.deinit(gpa);
+        self.ref_counts.deinit();
     }
 
     fn number(self: *const Footnotes, label: []const u8) ?u32 {
@@ -155,7 +162,7 @@ pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Docu
     var fn_ctx = if (options.footnotes and doc.footnotes.items.len > 0)
         try Footnotes.init(gpa, doc)
     else
-        Footnotes{ .numbers = std.StringHashMap(u32).init(gpa) };
+        Footnotes{ .numbers = std.StringHashMap(u32).init(gpa), .ref_counts = std.StringHashMap(u32).init(gpa) };
     defer fn_ctx.deinit(gpa);
 
     try stack.append(gpa, .{ .enter = .{
@@ -173,7 +180,7 @@ pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Docu
                 try pushChildren(gpa, &stack, f.node, f.tight_item);
             },
             .marker => |text| try writer.writeAll(text),
-            .backref => |n| try writeBackref(writer, n),
+            .backref => |n| try writeBackrefs(writer, &fn_ctx, n),
             .li_open => |n| {
                 var buf: [32]u8 = undefined;
                 const tag = try std.fmt.bufPrint(&buf, "<li id=\"fn-{d}\">\n", .{n});
@@ -186,7 +193,7 @@ pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Docu
                 if (f.node.tag == .document and fn_ctx.used.items.len > 0) {
                     try pushFootnotesSection(gpa, &stack, doc, &fn_ctx);
                 }
-                try writeClose(writer, f.node, f.suppress_p, options, f.footnote_backref);
+                try writeClose(writer, f.node, f.suppress_p, options, f.footnote_backref, &fn_ctx);
             },
         }
     }
@@ -351,7 +358,7 @@ fn writeOpen(
     footnote_backref: u32,
     options: RenderOptions,
     src: []const u8,
-    fn_ctx: *const Footnotes,
+    fn_ctx: *Footnotes,
 ) !void {
     switch (node.tag) {
         .document => {
@@ -573,13 +580,25 @@ fn writeOpen(
                 try writer.writeAll("</a></sup>");
             } else if (fn_ctx.number(fr.label)) |n| {
                 // Markdown `[^label]` (extension), numbered in
-                // first-reference order.
-                var buf: [16]u8 = undefined;
-                const num = try std.fmt.bufPrint(&buf, "{d}", .{n});
+                // first-reference order. Repeated references to the same
+                // footnote get distinct ids: the first is `fnref-N`, the
+                // second `fnref-N-2`, the third `fnref-N-3`, and so on
+                // (issue #44) so each reference is individually
+                // addressable and duplicate ids are impossible.
+                const ord = (fn_ctx.ref_counts.get(fr.label) orelse 0) + 1;
+                try fn_ctx.ref_counts.put(fr.label, ord);
+                var num_buf: [16]u8 = undefined;
+                const num = try std.fmt.bufPrint(&num_buf, "{d}", .{n});
                 try writer.writeAll("<sup class=\"footnote-ref\"><a href=\"#fn-");
                 try writer.writeAll(num);
                 try writer.writeAll("\" id=\"fnref-");
-                try writer.writeAll(num);
+                if (ord == 1) {
+                    try writer.writeAll(num);
+                } else {
+                    var id_buf: [48]u8 = undefined;
+                    const id = try std.fmt.bufPrint(&id_buf, "{d}-{d}", .{ n, ord });
+                    try writer.writeAll(id);
+                }
                 try writer.writeAll("\" data-footnote-ref>");
                 try writer.writeAll(num);
                 try writer.writeAll("</a></sup>");
@@ -687,7 +706,7 @@ fn writeOpen(
     }
 }
 
-fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, options: RenderOptions, footnote_backref: u32) !void {
+fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, options: RenderOptions, footnote_backref: u32, fn_ctx: *const Footnotes) !void {
     _ = options;
     switch (node.tag) {
         .document, .footnote => {},
@@ -724,7 +743,7 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
                 // Tight-list paragraphs are inline content of `<li>`; a
                 // following block gets its own leading newline in its frame.
             } else {
-                if (footnote_backref > 0) try writeBackref(writer, footnote_backref);
+                if (footnote_backref > 0) try writeBackrefs(writer, fn_ctx, footnote_backref);
                 try writer.writeAll("</p>\n");
             }
         },
@@ -753,16 +772,32 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
     }
 }
 
-/// Writes a footnote back-reference anchor (with a leading space so it
-/// reads as `note body <a ...>↩</a>` inside a paragraph).
-fn writeBackref(writer: anytype, n: u32) !void {
-    var buf: [256]u8 = undefined;
-    const text = try std.fmt.bufPrint(
-        &buf,
-        " <a href=\"#fnref-{d}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{d}\" aria-label=\"Back to reference {d}\">↩</a>",
-        .{ n, n, n },
-    );
-    try writer.writeAll(text);
+/// Writes the footnote back-reference anchors for footnote `n` (each with
+/// a leading space so they read as `note body <a ...>↩</a>` inside a
+/// paragraph). One anchor per reference to the footnote, in reference
+/// order: the first points at `#fnref-N`, the second at `#fnref-N-2`, and
+/// so on (issue #44) — so a reader who followed any reference can get
+/// back to it, and each anchor has its own target.
+fn writeBackrefs(writer: anytype, fn_ctx: *const Footnotes, n: u32) !void {
+    const label = fn_ctx.used.items[n - 1]; // numbers are 1-based, used is 0-based
+    const count = fn_ctx.ref_counts.get(label) orelse 1;
+    var ord: u32 = 1;
+    while (ord <= count) : (ord += 1) {
+        var buf: [256]u8 = undefined;
+        const text = if (ord == 1)
+            try std.fmt.bufPrint(
+                &buf,
+                " <a href=\"#fnref-{d}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{d}\" aria-label=\"Back to reference {d}\">↩</a>",
+                .{ n, n, n },
+            )
+        else
+            try std.fmt.bufPrint(
+                &buf,
+                " <a href=\"#fnref-{d}-{d}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{d}-{d}\" aria-label=\"Back to reference {d}-{d}\">↩</a>",
+                .{ n, ord, n, ord, n, ord },
+            );
+        try writer.writeAll(text);
+    }
 }
 
 /// Finds the registered footnote definition for a label (linear scan;
@@ -1686,6 +1721,72 @@ test "html: footnote refs and section render in first-reference order" {
     var out2 = try renderDoc(&doc);
     defer out2.deinit(testing.allocator);
     try testing.expect(std.mem.indexOf(u8, out2.items, "footnote-ref") == null);
+}
+
+test "html: repeated footnote references get unique ids and one backref each" {
+    // Regression (issue #44): every reference to the same footnote used
+    // to emit the same `id="fnref-N"` (invalid HTML: duplicate ids break
+    // getElementById and fragment navigation), and only the first
+    // reference got a backref. The second reference to a footnote is now
+    // `fnref-N-2`, the third `fnref-N-3`, and the footnote body emits one
+    // backref per reference, each pointing at its own reference id.
+    var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+    defer doc.deinit();
+
+    const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(doc.root, p);
+    try addText(&doc, p, "Alpha claim ");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "a" } }));
+    try addText(&doc, p, ". Beta claim ");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "a" } }));
+    try addText(&doc, p, ". Gamma claim ");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "a" } }));
+    try addText(&doc, p, ".");
+
+    const p2 = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(doc.root, p2);
+    try addText(&doc, p2, "Delta claim ");
+    try doc.appendChild(p2, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "b" } }));
+    try addText(&doc, p2, ". Epsilon claim ");
+    try doc.appendChild(p2, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "b" } }));
+    try addText(&doc, p2, ".");
+
+    const def_a = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+    const pa = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(def_a, pa);
+    try addText(&doc, pa, "First source");
+    try doc.footnotes.append(doc.allocator(), .{ .label = "a", .node = def_a });
+
+    const def_b = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+    const pb = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(def_b, pb);
+    try addText(&doc, pb, "Second source");
+    try doc.footnotes.append(doc.allocator(), .{ .label = "b", .node = def_b });
+
+    var out = try renderDocOpts(&doc, .{ .footnotes = true });
+    defer out.deinit(testing.allocator);
+    try testing.expectEqualStrings(
+        "<p>Alpha claim <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup>. Beta claim <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1-2\" data-footnote-ref>1</a></sup>. Gamma claim <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1-3\" data-footnote-ref>1</a></sup>.</p>\n" ++
+            "<p>Delta claim <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup>. Epsilon claim <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2-2\" data-footnote-ref>2</a></sup>.</p>\n" ++
+            "<section class=\"footnotes\" data-footnotes>\n" ++
+            "<ol>\n" ++
+            "<li id=\"fn-1\">\n" ++
+            "<p>First source <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-1-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\">↩</a> <a href=\"#fnref-1-3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-3\" aria-label=\"Back to reference 1-3\">↩</a></p>\n" ++
+            "</li>\n" ++
+            "<li id=\"fn-2\">\n" ++
+            "<p>Second source <a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a> <a href=\"#fnref-2-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2-2\" aria-label=\"Back to reference 2-2\">↩</a></p>\n" ++
+            "</li>\n" ++
+            "</ol>\n" ++
+            "</section>\n",
+        out.items,
+    );
+
+    // Every reference id is unique: the fnref- prefix never repeats.
+    var count: usize = 0;
+    for (out.items, 0..) |_, i| {
+        if (std.mem.startsWith(u8, out.items[i..], "id=\"fnref-")) count += 1;
+    }
+    try testing.expectEqual(@as(usize, 5), count);
 }
 
 test "html: render without footnote context never frees an uninitialized map" {

--- a/src/markdown.zig
+++ b/src/markdown.zig
@@ -120,6 +120,11 @@ pub const Options = struct {
     /// `{#id .class}` on ATX and Setext headings, consumed as the heading's
     /// explicit `id`/`class`.
     heading_attributes: bool = false,
+    /// GFM strikethrough: a run of exactly two tildes (`~~text~~`) renders
+    /// as `<del>text</del>`; runs of one or three-plus tildes stay literal.
+    /// Flanking follows the CommonMark emphasis rules (GFM spec §6.5
+    /// "Strikethrough (extension)").
+    strikethrough: bool = false,
 };
 
 const tab_stop: u32 = 4;
@@ -2487,7 +2492,7 @@ fn parseMultilineBlockInlines(
         const has_following_content_line = i + 1 < lines.len;
         const end = analyzeLineEnd(doc.src.bytes, ref.content, has_following_content_line);
         const start = skipLeadingWhitespace(doc.src.bytes, ref.content);
-        try scanLine(doc, &items, ref.content, .{ .start = start, .end = end.content_end }, constructs.items, &exclude);
+        try scanLine(doc, &items, ref.content, .{ .start = start, .end = end.content_end }, constructs.items, &exclude, options);
         if (has_following_content_line) {
             // A line ending inside a construct (code span content — §6.1
             // "line endings are converted to spaces" — or a raw HTML tag)
@@ -2689,7 +2694,7 @@ fn parseTableCellInlines(
     defer constructs.deinit(doc.allocator());
     try mergeConstructs(doc, spans.items, tags.items, &constructs);
     var exclude: u32 = 0;
-    try scanLine(doc, &items, content, content, constructs.items, &exclude);
+    try scanLine(doc, &items, content, content, constructs.items, &exclude, options);
     try discoverLinksAndImages(doc, &items, content.end, defs, options);
     try matchInlines(doc, node, items.items);
     try fixCellCodeSpans(doc, node);
@@ -2762,7 +2767,7 @@ fn parseHeadingInlines(
     defer constructs.deinit(doc.allocator());
     try mergeConstructs(doc, spans.items, tags.items, &constructs);
     var exclude: u32 = 0;
-    try scanLine(doc, &items, content, content, constructs.items, &exclude);
+    try scanLine(doc, &items, content, content, constructs.items, &exclude, options);
     try discoverLinksAndImages(doc, &items, content.end, defs, options);
     try matchInlines(doc, node, items.items);
 }
@@ -3988,6 +3993,7 @@ fn scanLine(
     emit: source.Span,
     constructs: []const Construct,
     exclude: *u32,
+    options: Options,
 ) ParseError!void {
     const bytes = doc.src.bytes;
     var i = raw.start;
@@ -4060,6 +4066,25 @@ fn scanLine(
             });
             i = e - 1; // loop increments past the run
             run_start = e;
+        } else if (b == '~' and options.strikethrough) {
+            if (isEscaped(bytes, i)) continue; // literal text, not a delimiter
+            // GFM strikethrough: only a run of exactly two tildes is a
+            // delimiter (GFM spec §6.5); runs of one or three-plus tildes
+            // stay literal text. A non-delimiter run is consumed whole so
+            // its middle cannot re-scan as a two-tilde delimiter.
+            var e = i + 1;
+            while (e < raw.end and bytes[e] == '~' and !isEscaped(bytes, e)) : (e += 1) {}
+            if (e - i != 2) {
+                i = e - 1; // loop increments past the whole run
+                continue;
+            }
+            try appendTextItem(doc, items, .{ .start = run_start, .end = i }, emit);
+            const span = source.Span{ .start = @intCast(i), .end = @intCast(e) };
+            try items.append(doc.allocator(), .{
+                .delimiter = classifyRun(bytes, span, raw),
+            });
+            i = e - 1; // loop increments past the run
+            run_start = e;
         } else if (b == '<' and !isEscaped(bytes, i)) {
             // §6.8 autolink: `<scheme:...>` or `<user@host>`. The scan is
             // per-line and the content excludes line endings, so scanning
@@ -4120,14 +4145,14 @@ fn classifyRun(bytes: []const u8, span: source.Span, line: source.Span) Delimite
     const left_flanking = !next_ws and (!next_punct or (next_punct and (prev_ws or prev_punct)));
     const right_flanking = !prev_ws and (!prev_punct or (prev_punct and (next_ws or next_punct)));
 
-    // Rules 1–8. For `*`, opening/closing needs only the corresponding
-    // flanking; for `_`, the stricter intraword rules with the
-    // punctuation-adjacent (b) clauses.
+    // Rules 1–8. For `*` (and GFM strikethrough `~`), opening/closing needs
+    // only the corresponding flanking; for `_`, the stricter intraword
+    // rules with the punctuation-adjacent (b) clauses.
     const ch = bytes[span.start];
     const can_open = left_flanking and
-        (ch == '*' or !right_flanking or (right_flanking and prev_punct));
+        (ch != '_' or !right_flanking or (right_flanking and prev_punct));
     const can_close = right_flanking and
-        (ch == '*' or !left_flanking or (left_flanking and next_punct));
+        (ch != '_' or !left_flanking or (left_flanking and next_punct));
 
     return .{
         .ch = ch,
@@ -4152,7 +4177,7 @@ const Match = struct {
     opener_seg: source.Span,
     closer_seg: source.Span,
 
-    const Kind = enum { em, strong };
+    const Kind = enum { em, strong, strikethrough };
 };
 
 /// `openers_bottom` table: for each (delimiter character, closer length
@@ -4166,10 +4191,10 @@ const Match = struct {
 /// the reference behavior on inputs like `*****Hello*world****` (see
 /// docs/FEATURE-MATRIX.md, "emphasis" row) and every verified spec example.
 const Bottoms = struct {
-    inner: [2][3]usize = .{ .{ 0, 0, 0 }, .{ 0, 0, 0 } },
+    inner: [3][3]usize = .{ .{ 0, 0, 0 }, .{ 0, 0, 0 }, .{ 0, 0, 0 } },
 
     fn idx(ch: u8) usize {
-        return if (ch == '*') 0 else 1;
+        return if (ch == '*') 0 else if (ch == '~') 2 else 1;
     }
 
     fn get(self: *const Bottoms, ch: u8, m: usize) usize {
@@ -4222,13 +4247,14 @@ fn processDelimiter(
             const o_idx = stack.items[j];
             const o = &items[o_idx].delimiter;
             if (o.ch != c.ch) continue;
-            if (!o.can_open or !mod3Allowed(o, c)) continue;
+            if (!o.can_open or (o.ch != '~' and !mod3Allowed(o, c))) continue;
 
             // Consume from the opener's back and the closer's front (the
-            // ends adjacent to the matched content); strong if both have at
-            // least 2 delimiters left.
-            const kind: Match.Kind = if (o.len() >= 2 and c.len() >= 2) .strong else .em;
-            const take: u32 = if (kind == .strong) 2 else 1;
+            // ends adjacent to the matched content). Strong pairs take two
+            // delimiters from each side; GFM strikethrough pairs take the
+            // whole two-tilde run from each side.
+            const kind: Match.Kind = if (o.ch == '~') .strikethrough else if (o.len() >= 2 and c.len() >= 2) .strong else .em;
+            const take: u32 = if (kind == .strikethrough) 2 else if (kind == .strong) 2 else 1;
             const o_seg = source.Span{
                 .start = o.span.end - o.back_used - take,
                 .end = o.span.end - o.back_used,
@@ -4499,7 +4525,11 @@ fn emitInlines(
                     for (obucket) |k| {
                         const m = matches[k];
                         const node = try doc.createNode(
-                            if (m.kind == .strong) .strong else .emphasis,
+                            switch (m.kind) {
+                                .em => .emphasis,
+                                .strong => .strong,
+                                .strikethrough => .deleted,
+                            },
                             .{ .start = m.opener_seg.start, .end = m.closer_seg.end },
                             .none,
                         );
@@ -7040,4 +7070,64 @@ test "markdown: definition lists are literal text when disabled" {
     defer result.deinit();
     // One ordinary paragraph containing both lines.
     try testing.expectEqual(document.Tag.paragraph, result.document.root.children.items[0].tag);
+}
+
+test "markdown: GFM strikethrough renders as deleted (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "~~Hi~~ Hello, world!",
+        .markdown,
+        ext_parse(.{ .strikethrough = true }),
+    );
+    defer result.deinit();
+    const p = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.paragraph, p.tag);
+    try testing.expectEqual(@as(usize, 2), p.children.items.len);
+    try testing.expectEqual(document.Tag.deleted, p.children.items[0].tag);
+    try testing.expectEqualStrings("Hi", p.children.items[0].children.items[0].data.text);
+    try testing.expectEqualStrings(" Hello, world!", p.children.items[1].data.text);
+}
+
+test "markdown: strikethrough delimiters are exactly two tildes (extension)" {
+    const oliver = @import("oliver.zig");
+    // Single and triple tildes stay literal; two-tilde pairs strike.
+    var result = try oliver.parse(
+        testing.allocator,
+        "~single~ ~~two~~ ~~~three~~~",
+        .markdown,
+        ext_parse(.{ .strikethrough = true }),
+    );
+    defer result.deinit();
+    const p = result.document.root.children.items[0];
+    try testing.expectEqual(@as(usize, 3), p.children.items.len);
+    try testing.expectEqualStrings("~single~ ", p.children.items[0].data.text);
+    try testing.expectEqual(document.Tag.deleted, p.children.items[1].tag);
+    try testing.expectEqualStrings(" ~~~three~~~", p.children.items[2].data.text);
+}
+
+test "markdown: strikethrough does not span paragraphs (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "This ~~has a\n\nnew paragraph~~.",
+        .markdown,
+        ext_parse(.{ .strikethrough = true }),
+    );
+    defer result.deinit();
+    try testing.expectEqual(@as(usize, 2), result.document.root.children.items.len);
+    const p1 = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.paragraph, p1.tag);
+    try testing.expectEqualStrings("This ~~has a", p1.children.items[0].data.text);
+    const p2 = result.document.root.children.items[1];
+    try testing.expectEqualStrings("new paragraph~~.", p2.children.items[0].data.text);
+}
+
+test "markdown: strikethrough is literal text when disabled" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(testing.allocator, "~~Hi~~", .markdown, .{});
+    defer result.deinit();
+    const p = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.paragraph, p.tag);
+    try testing.expectEqualStrings("~~Hi~~", p.children.items[0].data.text);
 }

--- a/src/markdown.zig
+++ b/src/markdown.zig
@@ -104,6 +104,24 @@ pub const ParseError = error{OutOfMemory};
 /// Tab stop width for block-structure indentation (§2.1): tabs behave as if
 /// replaced by spaces with a tab stop of 4 characters when whitespace helps
 /// define block structure. Content bytes are never expanded.
+/// Markdown dialect extensions. All are **off by default**: the Markdown
+/// frontend is byte-exact CommonMark 0.31.2 unless a consumer opts in, so
+/// the CommonMark conformance corpus stays green. Each extension is a
+/// documented, principled addition with its own contract doc and tests
+/// (docs/MARKDOWN-EXTENSIONS.md).
+pub const Options = struct {
+    /// Pandoc-style footnotes: `[^label]` references plus `[^label]:`
+    /// definitions, rendered as a footnotes section with back-references.
+    footnotes: bool = false,
+    /// Pandoc-style definition lists: a term paragraph immediately followed
+    /// by `:` (or `~`) definition lines, rendered as `<dl><dt><dd>`.
+    definition_lists: bool = false,
+    /// Kramdown/MultiMarkdown-style heading attribute lists: a trailing
+    /// `{#id .class}` on ATX and Setext headings, consumed as the heading's
+    /// explicit `id`/`class`.
+    heading_attributes: bool = false,
+};
+
 const tab_stop: u32 = 4;
 
 /// A line view during the block pass: the remaining `line` plus the
@@ -293,7 +311,7 @@ fn removeTrailingBlankLines(out: *std.ArrayList(u8)) void {
 /// Parses `doc.src` as Markdown, appending block nodes under `doc.root`.
 /// The caller (`oliver.parse`) guarantees
 /// `doc.src.bytes.len <= source.max_input_len`, so all offsets fit in `u32`.
-pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnostic)) ParseError!void {
+pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnostic), options: Options) ParseError!void {
     _ = diags;
 
     // Two-phase parse (spec appendix "A parsing strategy"): phase 1 builds
@@ -320,6 +338,10 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
     var indented: ?IndentedCode = null;
     var html: ?HtmlBlock = null;
     var table: ?TableBlock = null;
+    // Markdown definition-list state (extension): the open `.definition_list`
+    // node and its current `.definition_body` node, null when inactive.
+    var def_list: ?*document.Node = null;
+    var def_body: ?*document.Node = null;
 
     var lines = source.Lines.init(doc.src.bytes);
     while (lines.next()) |line| {
@@ -484,7 +506,12 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
         // is deferred until the next line shows whether the blank separated
         // blocks inside an item or two items (§5.3).
         if (isBlank(view.line.text)) {
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+            // A definition body's paragraph closes into its `<dd>`, not the
+            // document root.
+            const close_parent = if (def_body != null) def_body.? else leafParent(doc, &containers);
+            try closeParagraph(doc, &paragraph, close_parent, &defs, &pending, options);
+            def_list = null;
+            def_body = null;
             noteListBlankLines(&containers, matched);
             containers.shrinkRetainingCapacity(matched);
             // A blank line with only a dead item on the stack (an inert
@@ -494,6 +521,65 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
             }
             extendContainerSpans(&containers, view.line);
             continue;
+        }
+
+        // B2. Markdown definition lists (extension): a `:`/`~` definition
+        // marker directly after a term paragraph, or a continuation line
+        // (1–3 columns indented) of an open definition body. Only runs when
+        // every open container matched (a def marker that fails its
+        // container is a lazy paragraph continuation, decided in C). A
+        // marker line closes the previous body (if any), or turns the open
+        // paragraph into a term under the (possibly new) `<dl>`; an
+        // unindented or 4+-column line ends the open body while the list
+        // stays open for a following term.
+        if (options.definition_lists and matched == containers.items.len and
+            (paragraph != null or def_list != null))
+        {
+            if (tryDefListMarker(view)) |rest| {
+                if (paragraph == null and def_body == null) {
+                    // A stale open list with no pending term (a block
+                    // interrupted it): reset and fall through, so the
+                    // marker stays ordinary text.
+                    def_list = null;
+                    def_body = null;
+                } else if (def_body != null) {
+                    // The open paragraph (if any) belongs to the previous
+                    // definition; close it there.
+                    try closeParagraph(doc, &paragraph, def_body.?, &defs, &pending, options);
+                } else {
+                    // The open paragraph is a term.
+                    if (def_list == null) {
+                        const list_node = try doc.createNode(.definition_list, .{
+                            .start = paragraph.?.start,
+                            .end = @intCast(view.line.content_end),
+                        }, .none);
+                        try doc.appendChild(leafParent(doc, &containers), list_node);
+                        def_list = list_node;
+                    }
+                    try closeParagraphAs(doc, &paragraph, def_list.?, &defs, &pending, options, .definition_term);
+                }
+                const body = try doc.createNode(.definition_body, .{
+                    .start = @intCast(view.line.start),
+                    .end = @intCast(view.line.content_end),
+                }, .none);
+                try doc.appendChild(def_list.?, body);
+                def_body = body;
+                try appendParagraphLine(doc, &paragraph, rest);
+                extendContainerSpans(&containers, view.line);
+                continue;
+            }
+            if (def_body != null) {
+                // A non-marker line: continuation of the definition body's
+                // paragraph (1–3 columns), or the end of the body.
+                const indent = viewIndent(view);
+                if (indent >= 1 and indent < 4 and paragraph != null) {
+                    try appendParagraphLine(doc, &paragraph, view);
+                    extendContainerSpans(&containers, view.line);
+                    continue;
+                }
+                try closeParagraph(doc, &paragraph, def_body.?, &defs, &pending, options);
+                def_body = null;
+            }
         }
 
         // C. Lazy continuation (§5.1 rule 2, §5.2 rule 5): a line that
@@ -510,7 +596,9 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
                 extendContainerSpans(&containers, view.line);
                 continue;
             }
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+            def_list = null;
+            def_body = null;
             containers.shrinkRetainingCapacity(matched);
             if (containers.items.len > 0 and containers.items[containers.items.len - 1].node.tag == .list) {
                 const top_list = containers.items[containers.items.len - 1].node;
@@ -532,7 +620,9 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
         // rule 1 exceptions); otherwise the line is paragraph text.
         while (true) {
             if (tryStripBlockQuoteMarker(view)) |stripped| {
-                try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+                try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+                def_list = null;
+                def_body = null;
                 const node = try doc.createNode(.block_quote, stripped.line.contentSpan(), .{ .block_quote = .{} });
                 try doc.appendChild(leafParent(doc, &containers), node);
                 try containers.append(doc.allocator(), .{ .node = node });
@@ -546,7 +636,9 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
             }
             if (tryListMarker(view)) |m| {
                 if (paragraph != null and !m.can_interrupt) break;
-                try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+                try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+                def_list = null;
+                def_body = null;
                 // Reuse an open same-type list, or close a different-type
                 // list, or open a new list under the current parent.
                 var list_node: *document.Node = undefined;
@@ -582,12 +674,19 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
         // consumed, or a blank-start list item) is a blank line inside the
         // container, not an empty paragraph.
         if (isBlank(view.line.text)) {
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+            // A definition body's paragraph closes into its `<dd>`, not the
+            // document root.
+            const close_parent = if (def_body != null) def_body.? else leafParent(doc, &containers);
+            try closeParagraph(doc, &paragraph, close_parent, &defs, &pending, options);
+            def_list = null;
+            def_body = null;
             extendContainerSpans(&containers, view.line);
             continue;
         }
         if (tryFenceOpen(view)) |opening| {
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+            def_list = null;
+            def_body = null;
             const info = if (opening.info.isEmpty())
                 null
             else
@@ -615,13 +714,18 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
                 leafParent(doc, &containers),
                 &defs,
                 &pending,
+                options,
             )) {
+                def_list = null;
+                def_body = null;
                 extendContainerSpans(&containers, view.line);
                 continue;
             }
         }
         if (isThematicBreak(view, &thematic_facts)) {
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+            def_list = null;
+            def_body = null;
             // A failed list item can leave its list as the deepest matched
             // container. A thematic break is not a sibling item: it belongs
             // beside that list, never directly under the `.list` node.
@@ -634,8 +738,10 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
             continue;
         }
         if (tryAtxHeading(view)) |heading| {
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
-            try emitHeading(doc, view, heading, leafParent(doc, &containers), &pending);
+            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+            def_list = null;
+            def_body = null;
+            try emitHeading(doc, view, heading, leafParent(doc, &containers), &pending, options);
             extendContainerSpans(&containers, view.line);
             continue;
         }
@@ -647,7 +753,9 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
         // that line), types 6/7 at a blank line or the end of their
         // container.
         if (tryHtmlBlockStart(doc, view, paragraph == null)) |block_type| {
-            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+            try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending, options);
+            def_list = null;
+            def_body = null;
             const node = try doc.createNode(.html_block, view.line.contentSpan(), .{
                 .html_block = &.{},
             });
@@ -671,6 +779,8 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
         // open so container order is fixed; content accumulates incrementally
         // and trailing blank lines are dropped at close.
         if (paragraph == null and viewIndent(view) >= 4) {
+            def_list = null;
+            def_body = null;
             const node = try doc.createNode(.code_block, view.line.contentSpan(), .{
                 .code_block = .{ .content = &.{}, .info = null },
             });
@@ -691,6 +801,8 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
         // current line is a matching delimiter row. Otherwise the line is
         // ordinary paragraph text.
         if (try tryEmitTable(doc, &paragraph, view, leafParent(doc, &containers), containers.items.len, &table, &pending)) {
+            def_list = null;
+            def_body = null;
             extendContainerSpans(&containers, view.line);
             continue;
         }
@@ -701,15 +813,17 @@ pub fn parse(doc: *document.Document, diags: *std.ArrayList(diagnostic.Diagnosti
     try finishIndentedCode(doc, &indented);
     finishHtmlBlock(&html);
     finishTable(&table);
-    try closeParagraph(doc, &paragraph, leafParent(doc, &containers), &defs, &pending);
+    // A trailing definition body's paragraph closes into its `<dd>`.
+    const close_parent = if (def_body != null) def_body.? else leafParent(doc, &containers);
+    try closeParagraph(doc, &paragraph, close_parent, &defs, &pending, options);
 
     // Phase 2: inline pass, with the full definitions map available.
     for (pending.items) |job| {
         switch (job) {
-            .paragraph => |pp| try parseParagraphInlines(doc, pp.node, pp.lines, &defs),
-            .heading => |hh| try parseHeadingInlines(doc, hh.node, hh.span, &defs),
-            .setext_heading => |hh| try parseSetextHeadingInlines(doc, hh.node, hh.lines, &defs),
-            .table_cell => |tc| try parseTableCellInlines(doc, tc.node, tc.span, &defs),
+            .paragraph => |pp| try parseParagraphInlines(doc, pp.node, pp.lines, &defs, options),
+            .heading => |hh| try parseHeadingInlines(doc, hh.node, hh.span, &defs, options),
+            .setext_heading => |hh| try parseSetextHeadingInlines(doc, hh.node, hh.lines, &defs, options),
+            .table_cell => |tc| try parseTableCellInlines(doc, tc.node, tc.span, &defs, options),
         }
     }
 }
@@ -780,6 +894,22 @@ fn tryStripBlockQuoteMarker(view: View) ?View {
         }
     }
     return view.after(i, col);
+}
+
+/// Recognizes a definition-list marker line (extension): `:` or `~`
+/// preceded by at most three columns of indentation and followed by a
+/// space/tab. Returns the view after the marker and its single separator
+/// (further whitespace stays as content; the inline pass trims it).
+fn tryDefListMarker(view: View) ?View {
+    const skipped = skipIndent(view, 3) orelse return null;
+    const t = view.line.text;
+    var i = skipped.i;
+    if (i >= t.len) return null;
+    if (t[i] != ':' and t[i] != '~') return null;
+    i += 1;
+    if (i >= t.len or (t[i] != ' ' and t[i] != '\t')) return null;
+    i += 1;
+    return view.after(i, skipped.cols + 2);
 }
 
 /// A list marker recognized on a line (§5.2): a bullet character (`-`,
@@ -1760,6 +1890,7 @@ fn emitSetextHeading(
     parent: *document.Node,
     defs: *Definitions,
     pending: *std.ArrayList(PendingInline),
+    options: Options,
 ) ParseError!bool {
     const k = setextContentIndex(doc, paragraph.*) orelse return false;
     const p = paragraph.*.?;
@@ -1772,10 +1903,21 @@ fn emitSetextHeading(
     }
 
     const content = p.lines.items[k..];
+    var heading_data = document.Heading{ .level = underline.level };
+    if (options.heading_attributes) {
+        // A trailing `{#id .class}` on the last content line is consumed as
+        // the heading's explicit id/class (mutating the LineRef before the
+        // phase-2 job reads it).
+        const last = &content[content.len - 1];
+        const stripped = stripHeadingAttributes(doc.src.bytes, last.content);
+        last.content = stripped.content;
+        heading_data.id = stripped.id;
+        heading_data.class = stripped.class;
+    }
     const node = try doc.createNode(.heading, .{
         .start = content[0].content.start,
         .end = @intCast(underline_line.line.content_end),
-    }, .{ .heading = .{ .level = underline.level } });
+    }, .{ .heading = heading_data });
     try doc.appendChild(parent, node);
     try pending.append(doc.allocator(), .{
         .setext_heading = .{ .node = node, .lines = content },
@@ -2136,21 +2278,47 @@ fn encodeCp(out: []u8, cp: u21) usize {
 /// partially or wholly a definition — so extraction stops at the first
 /// non-definition line. Inline parsing is deferred to phase 2, where the
 /// complete definitions map is available.
+/// Closes the open paragraph as a normal `.paragraph` block.
 fn closeParagraph(
     doc: *document.Document,
     paragraph: *?Paragraph,
     parent: *document.Node,
     defs: *Definitions,
     pending: *std.ArrayList(PendingInline),
+    options: Options,
+) ParseError!void {
+    return closeParagraphAs(doc, paragraph, parent, defs, pending, options, .paragraph);
+}
+
+/// Closes the open paragraph as a block with the given tag. `.paragraph`
+/// and `.definition_term` are the two supported tags; both take inline
+/// children in phase 2, so the pending job shape is identical.
+fn closeParagraphAs(
+    doc: *document.Document,
+    paragraph: *?Paragraph,
+    parent: *document.Node,
+    defs: *Definitions,
+    pending: *std.ArrayList(PendingInline),
+    options: Options,
+    node_tag: document.Tag,
 ) ParseError!void {
     const p = paragraph.* orelse return;
     paragraph.* = null;
 
     const lines = p.lines.items;
 
-    // Extract leading link reference definitions.
+    // Extract leading footnote definitions (Markdown extension) and link
+    // reference definitions (§4.7). Either kind may lead a paragraph; the
+    // first non-definition line ends the extraction loop.
     var k: usize = 0;
     while (k < lines.len) {
+        if (options.footnotes) {
+            if (tryParseFootnoteDefinition(doc, lines[k..])) |fd| {
+                try registerFootnoteDefinition(doc, fd, lines[k..], pending);
+                k += fd.consumed_lines;
+                continue;
+            }
+        }
         const def = tryParseDefinition(doc, lines[k..]) orelse break;
         try registerDefinition(doc, defs, def);
         k += def.consumed_lines;
@@ -2162,9 +2330,101 @@ fn closeParagraph(
         .start = remaining[0].content.start,
         .end = remaining[remaining.len - 1].content.end,
     };
-    const node = try doc.createNode(.paragraph, span, .{ .paragraph = .{} });
+    const data: document.Data = if (node_tag == .paragraph) .{ .paragraph = .{} } else .none;
+    const node = try doc.createNode(node_tag, span, data);
     try doc.appendChild(parent, node);
     try pending.append(doc.allocator(), .{ .paragraph = .{ .node = node, .lines = remaining } });
+}
+
+/// A parsed Markdown footnote definition (`[^label]:` extension): the label
+/// content span (between `[^` and `]`), the content span of the definition
+/// line (after `]: `), and the number of paragraph lines consumed (the
+/// definition line plus any following lines indented 1–3 columns).
+const ParsedFootnoteDefinition = struct {
+    label: source.Span,
+    content: source.Span,
+    consumed_lines: usize,
+};
+
+/// Recognizes a Markdown footnote definition line at the start of a
+/// paragraph: `[^label]:` with at most three columns of indentation,
+/// followed by optional whitespace and the definition content. Continuation
+/// lines indented 1–3 columns join the definition's paragraph. Any other
+/// shape returns null, so the line stays ordinary paragraph text.
+fn tryParseFootnoteDefinition(doc: *document.Document, lines: []const Paragraph.LineRef) ?ParsedFootnoteDefinition {
+    const bytes = doc.src.bytes;
+    const first = lines[0].content;
+    const t = bytes;
+    var i = first.start;
+    var indent: usize = 0;
+    while (i < first.end) : (i += 1) {
+        if (t[i] == ' ') {
+            indent += 1;
+            if (indent > 3) return null;
+        } else if (t[i] == '\t') {
+            return null; // a leading tab never opens a footnote definition
+        } else break;
+    }
+    if (i + 1 >= first.end or t[i] != '[' or t[i + 1] != '^') return null;
+    var j = i + 2;
+    while (j < first.end and t[j] != ']') : (j += 1) {}
+    if (j >= first.end or j == i + 2) return null; // unclosed or empty label
+    var k = j + 1;
+    if (k >= first.end or t[k] != ':') return null;
+    k += 1;
+    while (k < first.end and (t[k] == ' ' or t[k] == '\t')) : (k += 1) {}
+
+    var consumed: usize = 1;
+    while (consumed < lines.len) {
+        const l = lines[consumed].content;
+        var li = l.start;
+        var lin: usize = 0;
+        while (li < l.end) : (li += 1) {
+            if (t[li] == ' ') {
+                lin += 1;
+            } else if (t[li] == '\t') {
+                return null; // tabs in continuation indent are out of scope
+            } else break;
+        }
+        if (lin >= 1 and lin <= 3) {
+            consumed += 1;
+        } else break;
+    }
+    return .{
+        .label = .{ .start = @intCast(i + 2), .end = @intCast(j) },
+        .content = .{ .start = @intCast(k), .end = first.end },
+        .consumed_lines = consumed,
+    };
+}
+
+/// Registers a footnote definition: creates the `.footnote` container with
+/// one `.paragraph` child (whose lines are the definition content plus its
+/// indented continuations), appends it to `doc.footnotes`, and queues the
+/// paragraph for the phase-2 inline pass.
+fn registerFootnoteDefinition(
+    doc: *document.Document,
+    fd: ParsedFootnoteDefinition,
+    lines: []const Paragraph.LineRef,
+    pending: *std.ArrayList(PendingInline),
+) ParseError!void {
+    const alloc = doc.allocator();
+    const n = fd.consumed_lines;
+    const span = source.Span{ .start = lines[0].content.start, .end = lines[n - 1].content.end };
+    const fnode = try doc.createNode(.footnote, span, .none);
+    const pnode = try doc.createNode(.paragraph, span, .{ .paragraph = .{} });
+    try doc.appendChild(fnode, pnode);
+
+    // The definition paragraph's first line is the content after `]: `; the
+    // following lines are the indented continuations, verbatim (the inline
+    // pass trims leading whitespace).
+    const refs = try alloc.alloc(Paragraph.LineRef, n);
+    refs[0] = .{ .content = fd.content, .terminator = lines[0].terminator };
+    for (1..n) |t| refs[t] = lines[t];
+    try pending.append(alloc, .{ .paragraph = .{ .node = pnode, .lines = refs } });
+    try doc.footnotes.append(alloc, .{
+        .label = doc.src.bytes[fd.label.start..fd.label.end],
+        .node = fnode,
+    });
 }
 
 /// Phase 2 inline pass for a paragraph: discovery -> scan -> link discovery
@@ -2174,8 +2434,9 @@ fn parseParagraphInlines(
     node: *document.Node,
     lines: []const Paragraph.LineRef,
     defs: *Definitions,
+    options: Options,
 ) ParseError!void {
-    return parseMultilineBlockInlines(doc, node, lines, defs);
+    return parseMultilineBlockInlines(doc, node, lines, defs, options);
 }
 
 /// Phase 2 inline pass for Setext content. The underline itself is never part
@@ -2186,8 +2447,9 @@ fn parseSetextHeadingInlines(
     node: *document.Node,
     lines: []const Paragraph.LineRef,
     defs: *Definitions,
+    options: Options,
 ) ParseError!void {
-    return parseMultilineBlockInlines(doc, node, lines, defs);
+    return parseMultilineBlockInlines(doc, node, lines, defs, options);
 }
 
 fn parseMultilineBlockInlines(
@@ -2195,6 +2457,7 @@ fn parseMultilineBlockInlines(
     node: *document.Node,
     lines: []const Paragraph.LineRef,
     defs: *Definitions,
+    options: Options,
 ) ParseError!void {
     var items = std.ArrayList(InlineItem).empty;
     defer items.deinit(doc.allocator());
@@ -2238,7 +2501,7 @@ fn parseMultilineBlockInlines(
     // Second discovery pass: inline links, images, and reference links
     // (§6.3/§6.4), before emphasis matching.
     const para_end = lines[lines.len - 1].content.end;
-    try discoverLinksAndImages(doc, &items, para_end, defs);
+    try discoverLinksAndImages(doc, &items, para_end, defs, options);
     try matchInlines(doc, node, items.items);
 }
 
@@ -2315,19 +2578,88 @@ fn tryAtxHeading(view: View) ?AtxHeading {
     };
 }
 
+/// Strips a trailing heading attribute list (`{#id .class}`, extension)
+/// from an ATX or Setext heading's content span. The attribute list must be
+/// the last thing on the line, preceded by whitespace; `#id` becomes the
+/// heading's explicit id and `.class` its class (first token wins; values
+/// are raw source slices). Returns the reduced content span and the parsed
+/// attributes, or the input unchanged when no valid list is present.
+fn stripHeadingAttributes(bytes: []const u8, content: source.Span) struct {
+    content: source.Span,
+    id: ?[]const u8,
+    class: ?[]const u8,
+} {
+    if (content.len() < 3 or bytes[content.end - 1] != '}') return .{ .content = content, .id = null, .class = null };
+
+    // Find the `{` opening the trailing brace group (the last unescaped
+    // `{` before the final `}`, with no `}` between it and the end).
+    var open: ?usize = null;
+    var i = content.end - 1;
+    while (i > content.start) {
+        i -= 1;
+        if (bytes[i] == '}') break;
+        if (bytes[i] == '{' and !isEscaped(bytes, i)) {
+            open = i;
+            break;
+        }
+    }
+    const o = open orelse return .{ .content = content, .id = null, .class = null };
+    if (o > content.start and bytes[o - 1] != ' ' and bytes[o - 1] != '\t') return .{ .content = content, .id = null, .class = null };
+    // Parse `#id` and `.class` tokens separated by whitespace.
+    var id: ?[]const u8 = null;
+    var cls: ?[]const u8 = null;
+    var idx = o + 1;
+    while (idx < content.end - 1) {
+        if (bytes[idx] == ' ' or bytes[idx] == '\t') {
+            idx += 1;
+            continue;
+        }
+        if (bytes[idx] == '#' or bytes[idx] == '.') {
+            const is_id = bytes[idx] == '#';
+            var j = idx + 1;
+            while (j < content.end - 1 and bytes[j] != ' ' and bytes[j] != '\t') : (j += 1) {}
+            if (j == idx + 1) return .{ .content = content, .id = null, .class = null }; // empty token
+            if (is_id) {
+                if (id == null) id = bytes[idx + 1 .. j];
+            } else {
+                if (cls == null) cls = bytes[idx + 1 .. j];
+            }
+            idx = j;
+            continue;
+        }
+        return .{ .content = content, .id = null, .class = null }; // unknown token shape: not an IAL
+    }
+
+    // Strip the IAL (and the whitespace before it) from the content.
+    var new_end = o;
+    while (new_end > content.start and (bytes[new_end - 1] == ' ' or bytes[new_end - 1] == '\t')) new_end -= 1;
+    return .{
+        .content = .{ .start = content.start, .end = @intCast(new_end) },
+        .id = id,
+        .class = cls,
+    };
+}
+
 fn emitHeading(
     doc: *document.Document,
     view: View,
     heading: AtxHeading,
     parent: *document.Node,
     pending: *std.ArrayList(PendingInline),
+    options: Options,
 ) ParseError!void {
-    const node = try doc.createNode(.heading, view.line.contentSpan(), .{
-        .heading = .{ .level = heading.level },
-    });
+    var heading_data = document.Heading{ .level = heading.level };
+    var content = heading.content;
+    if (options.heading_attributes) {
+        const stripped = stripHeadingAttributes(doc.src.bytes, content);
+        content = stripped.content;
+        heading_data.id = stripped.id;
+        heading_data.class = stripped.class;
+    }
+    const node = try doc.createNode(.heading, view.line.contentSpan(), .{ .heading = heading_data });
     try doc.appendChild(parent, node);
-    if (!heading.content.isEmpty()) {
-        try pending.append(doc.allocator(), .{ .heading = .{ .node = node, .span = heading.content } });
+    if (!content.isEmpty()) {
+        try pending.append(doc.allocator(), .{ .heading = .{ .node = node, .span = content } });
     }
 }
 
@@ -2343,6 +2675,7 @@ fn parseTableCellInlines(
     node: *document.Node,
     content: source.Span,
     defs: *Definitions,
+    options: Options,
 ) ParseError!void {
     var items = std.ArrayList(InlineItem).empty;
     defer items.deinit(doc.allocator());
@@ -2357,11 +2690,12 @@ fn parseTableCellInlines(
     try mergeConstructs(doc, spans.items, tags.items, &constructs);
     var exclude: u32 = 0;
     try scanLine(doc, &items, content, content, constructs.items, &exclude);
-    try discoverLinksAndImages(doc, &items, content.end, defs);
+    try discoverLinksAndImages(doc, &items, content.end, defs, options);
     try matchInlines(doc, node, items.items);
     try fixCellCodeSpans(doc, node);
 }
 
+/// Returns a copy of `s` with the backslash dropped from every `\|` pair
 /// Reproduces the §4.10 pipe escape in the one place the inline pass
 /// cannot resolve it: code-span content is opaque, so a backslash directly
 /// before a pipe survives there and must be dropped (`` `\|` `` →
@@ -2414,6 +2748,7 @@ fn parseHeadingInlines(
     node: *document.Node,
     content: source.Span,
     defs: *Definitions,
+    options: Options,
 ) ParseError!void {
     var items = std.ArrayList(InlineItem).empty;
     defer items.deinit(doc.allocator());
@@ -2428,7 +2763,7 @@ fn parseHeadingInlines(
     try mergeConstructs(doc, spans.items, tags.items, &constructs);
     var exclude: u32 = 0;
     try scanLine(doc, &items, content, content, constructs.items, &exclude);
-    try discoverLinksAndImages(doc, &items, content.end, defs);
+    try discoverLinksAndImages(doc, &items, content.end, defs, options);
     try matchInlines(doc, node, items.items);
 }
 
@@ -2529,6 +2864,16 @@ const InlineItem = union(enum) {
     /// link discovery, and break processing (docs/RAW-HTML.md §2); the
     /// renderer writes the source bytes verbatim.
     raw_html: RawHtmlItem,
+    /// A Markdown footnote reference (`[^label]`, extension): `span` covers
+    /// the whole construct and `label` the bytes between `^` and `]`.
+    /// Leaf item: opaque to the delimiter stack.
+    footnote: FootnoteItem,
+};
+
+/// A Markdown footnote reference item (extension). See `InlineItem.footnote`.
+const FootnoteItem = struct {
+    span: source.Span,
+    label: source.Span,
 };
 
 /// A raw HTML tag item (§6.6): the whole construct span. The tag's bytes
@@ -2566,6 +2911,7 @@ fn itemSpan(item: InlineItem) source.Span {
         .image => |im| im.span,
         .autolink => |a| a.span,
         .raw_html => |h| h.span,
+        .footnote => |fn_| fn_.span,
     };
 }
 
@@ -2581,6 +2927,7 @@ fn setItemSpan(item: *InlineItem, span: source.Span) void {
         .image => |*im| im.span = span,
         .autolink => |*a| a.span = span,
         .raw_html => |*h| h.span = span,
+        .footnote => |*fn_| fn_.span = span,
     }
 }
 
@@ -3138,7 +3485,13 @@ const max_link_scan: usize = 2048;
 /// stack, and their children are matched separately (link text as a fresh
 /// inline scope; image descriptions flattened to the alt string at emit
 /// time).
-fn discoverLinksAndImages(doc: *document.Document, items: *std.ArrayList(InlineItem), para_end: u32, defs: *Definitions) ParseError!void {
+fn discoverLinksAndImages(
+    doc: *document.Document,
+    items: *std.ArrayList(InlineItem),
+    para_end: u32,
+    defs: *Definitions,
+    options: Options,
+) ParseError!void {
     const bytes = doc.src.bytes;
     var out = std.ArrayList(InlineItem).empty;
     var stack = std.ArrayList(usize).empty;
@@ -3177,6 +3530,21 @@ fn discoverLinksAndImages(doc: *document.Document, items: *std.ArrayList(InlineI
             // starts past the bang. Used for collapsed/shortcut labels and
             // as the link text for image alt-flattening inputs.
             const text = source.Span{ .start = open_start + (if (is_image) @as(u32, 2) else 1), .end = close_end - 1 };
+
+            // 0. Markdown footnote reference (extension): `[^label]` whose
+            // label names a registered definition. Consumes the bracket
+            // pair; like an image, a footnote ref inactivates nothing.
+            if (options.footnotes and !is_image and text.len() > 1 and bytes[text.start] == '^') {
+                const label = source.Span{ .start = text.start + 1, .end = text.end };
+                if (!label.isEmpty() and footnoteDefined(doc, label)) {
+                    out.shrinkRetainingCapacity(o);
+                    try out.append(doc.allocator(), .{
+                        .footnote = .{ .span = .{ .start = open_start, .end = close_end }, .label = label },
+                    });
+                    while (stack.items.len > 0 and stack.items[stack.items.len - 1] >= o) _ = stack.pop();
+                    continue;
+                }
+            }
 
             // 1. Inline link/image: `(` immediately after the `]`.
             if (close_end < para_end and bytes[close_end] == '(') {
@@ -3379,6 +3747,17 @@ fn discoverLinksAndImages(doc: *document.Document, items: *std.ArrayList(InlineI
     }
 
     items.* = out; // moved; the old buffer stays in the arena
+}
+
+/// Whether a footnote definition with the exact (case-sensitive) label is
+/// registered. Linear scan: definitions are few and the check runs only
+/// when a `[^...]` candidate is found.
+fn footnoteDefined(doc: *document.Document, label: source.Span) bool {
+    const bytes = doc.src.bytes;
+    for (doc.footnotes.items) |fd| {
+        if (std.mem.eql(u8, fd.label, bytes[label.start..label.end])) return true;
+    }
+    return false;
 }
 
 /// The result of scanning a reference label following a `]`.
@@ -4028,6 +4407,15 @@ fn emitInlines(
                 const node = try doc.createNode(.raw_html, h.span, .none);
                 try doc.appendChild(current, node);
             },
+            .footnote => |fn_| {
+                // Leaf node (extension): `[^label]` with a registered
+                // definition. The label payload is a source slice; the
+                // renderer numbers it in first-reference order.
+                const node = try doc.createNode(.footnote_ref, fn_.span, .{
+                    .footnote_ref = .{ .label = doc.text(fn_.label) },
+                });
+                try doc.appendChild(current, node);
+            },
             .autolink => |al| {
                 // Leaf node: the content between `<` and `>` becomes both
                 // the label and the href (with `mailto:` prepended for
@@ -4354,6 +4742,7 @@ fn flattenAlt(doc: *document.Document, items: []const InlineItem) ParseError![]c
             },
             .autolink => |al| try buf.appendSlice(doc.allocator(), doc.src.bytes[al.content.start..al.content.end]),
             .raw_html => |h| try buf.appendSlice(doc.allocator(), doc.src.bytes[h.span.start..h.span.end]),
+            .footnote => {}, // a footnote ref contributes no plain text to an alt
         }
     }
     return buf.toOwnedSlice(doc.allocator());
@@ -6467,4 +6856,176 @@ test "markdown: blank-start and empty items stay distinct" {
     try testing.expectEqual(@as(usize, 1), list.children.items[0].children.items.len);
     try testing.expectEqual(@as(usize, 0), list.children.items[1].children.items.len);
     try testing.expectEqual(@as(usize, 1), list.children.items[2].children.items.len);
+}
+
+// ---------------------------------------------------------------------------
+// Markdown extensions (docs/MARKDOWN-EXTENSIONS.md): footnotes, definition
+// lists, heading attribute lists, and GFM-style heading ids. All are opt-in
+// through `Options`; the default frontend stays byte-exact CommonMark.
+// ---------------------------------------------------------------------------
+
+const ext_parse = struct {
+    fn with(o: Options) oliver_options {
+        return .{ .markdown = o };
+    }
+}.with;
+
+const oliver_options = @import("oliver.zig").ParseOptions;
+
+test "markdown: heading attribute lists consume trailing {#id .class} (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(testing.allocator, "## Exit codes {#exit-codes}\n", .markdown, ext_parse(.{ .heading_attributes = true }));
+    defer result.deinit();
+
+    const h = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.heading, h.tag);
+    try testing.expectEqualStrings("exit-codes", h.data.heading.id.?);
+    try testing.expectEqual(@as(?[]const u8, null), h.data.heading.class);
+    // The IAL is consumed: the heading's inline text is just "Exit codes".
+    try testing.expectEqual(@as(usize, 1), h.children.items.len);
+    try testing.expectEqualStrings("Exit codes", h.children.items[0].data.text);
+}
+
+test "markdown: heading attribute lists combine id and class (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "## Custom heading id {#custom-showcase-id .showcase-heading}\n",
+        .markdown,
+        ext_parse(.{ .heading_attributes = true }),
+    );
+    defer result.deinit();
+
+    const h = result.document.root.children.items[0];
+    try testing.expectEqualStrings("custom-showcase-id", h.data.heading.id.?);
+    try testing.expectEqualStrings("showcase-heading", h.data.heading.class.?);
+}
+
+test "markdown: heading attribute lists stay literal when disabled" {
+    const oliver = @import("oliver.zig");
+    // Default options: `{#id}` is ordinary heading text.
+    var result = try oliver.parse(testing.allocator, "## Exit codes {#exit-codes}\n", .markdown, .{});
+    defer result.deinit();
+    const h = result.document.root.children.items[0];
+    try testing.expectEqual(@as(?[]const u8, null), h.data.heading.id);
+    try testing.expectEqual(@as(usize, 1), h.children.items.len);
+    try testing.expectEqualStrings("Exit codes {#exit-codes}", h.children.items[0].data.text);
+}
+
+test "markdown: Setext heading attribute list (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "Setext heading {#setext-id}\n=========================\n",
+        .markdown,
+        ext_parse(.{ .heading_attributes = true }),
+    );
+    defer result.deinit();
+    const h = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.heading, h.tag);
+    try testing.expectEqual(@as(u8, 1), h.data.heading.level);
+    try testing.expectEqualStrings("setext-id", h.data.heading.id.?);
+}
+
+test "markdown: footnotes collect definitions and references (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "Hi[^syntax] and more[^second].\n\n[^syntax]: First note body.\n[^second]: Second note body.\n",
+        .markdown,
+        ext_parse(.{ .footnotes = true }),
+    );
+    defer result.deinit();
+
+    // Two definitions registered, in definition order.
+    try testing.expectEqual(@as(usize, 2), result.document.footnotes.items.len);
+    try testing.expectEqualStrings("syntax", result.document.footnotes.items[0].label);
+    try testing.expectEqualStrings("second", result.document.footnotes.items[1].label);
+    // Each definition owns a `.footnote` container with one paragraph.
+    const f0 = result.document.footnotes.items[0].node;
+    try testing.expectEqual(document.Tag.footnote, f0.tag);
+    try testing.expectEqual(@as(usize, 1), f0.children.items.len);
+    try testing.expectEqual(document.Tag.paragraph, f0.children.items[0].tag);
+    try testing.expectEqualStrings("First note body.", f0.children.items[0].children.items[0].data.text);
+
+    // The body paragraph has two footnote refs (first-reference order).
+    const p = result.document.root.children.items[0];
+    try testing.expectEqual(@as(usize, 5), p.children.items.len);
+    try testing.expectEqual(document.Tag.footnote_ref, p.children.items[1].tag);
+    try testing.expectEqualStrings("syntax", p.children.items[1].data.footnote_ref.label);
+    try testing.expectEqual(document.Tag.footnote_ref, p.children.items[3].tag);
+    try testing.expectEqualStrings("second", p.children.items[3].data.footnote_ref.label);
+}
+
+test "markdown: footnotes are literal text when disabled" {
+    const oliver = @import("oliver.zig");
+    // `[^note]:` is not a link reference definition (its "destination"
+    // contains spaces), so with the extension disabled it is plain text.
+    var result = try oliver.parse(
+        testing.allocator,
+        "Text[^note] here.\n\n[^note]: some note text with spaces\n",
+        .markdown,
+        .{},
+    );
+    defer result.deinit();
+    try testing.expectEqual(@as(usize, 0), result.document.footnotes.items.len);
+    // The whole thing is ordinary paragraphs.
+    try testing.expectEqual(document.Tag.paragraph, result.document.root.children.items[0].tag);
+    try testing.expectEqual(document.Tag.paragraph, result.document.root.children.items[1].tag);
+}
+
+test "markdown: definition lists build dl/dt/dd structure (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "Term\n: Definition body.\n\nSatellite\n: First line.\n  Second line.\n",
+        .markdown,
+        ext_parse(.{ .definition_lists = true }),
+    );
+    defer result.deinit();
+
+    const dl0 = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.definition_list, dl0.tag);
+    try testing.expectEqual(@as(usize, 2), dl0.children.items.len);
+    const dt0 = dl0.children.items[0];
+    try testing.expectEqual(document.Tag.definition_term, dt0.tag);
+    try testing.expectEqualStrings("Term", dt0.children.items[0].data.text);
+    const dd0 = dl0.children.items[1];
+    try testing.expectEqual(document.Tag.definition_body, dd0.tag);
+    try testing.expectEqualStrings("Definition body.", dd0.children.items[0].children.items[0].data.text);
+
+    const dl1 = result.document.root.children.items[1];
+    try testing.expectEqual(document.Tag.definition_list, dl1.tag);
+    const dd1 = dl1.children.items[1];
+    // Two lines in the definition paragraph: a soft break between them.
+    try testing.expectEqual(@as(usize, 3), dd1.children.items[0].children.items.len);
+    try testing.expectEqual(document.Tag.soft_break, dd1.children.items[0].children.items[1].tag);
+    try testing.expectEqualStrings("Second line.", dd1.children.items[0].children.items[2].data.text);
+}
+
+test "markdown: consecutive term/definition pairs merge into one dl (extension)" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(
+        testing.allocator,
+        "Term one\n: First.\nTerm two\n: Second.\n",
+        .markdown,
+        ext_parse(.{ .definition_lists = true }),
+    );
+    defer result.deinit();
+    try testing.expectEqual(@as(usize, 1), result.document.root.children.items.len);
+    const dl = result.document.root.children.items[0];
+    try testing.expectEqual(document.Tag.definition_list, dl.tag);
+    try testing.expectEqual(@as(usize, 4), dl.children.items.len);
+    try testing.expectEqualStrings("Term one", dl.children.items[0].children.items[0].data.text);
+    try testing.expectEqualStrings("First.", dl.children.items[1].children.items[0].children.items[0].data.text);
+    try testing.expectEqualStrings("Term two", dl.children.items[2].children.items[0].data.text);
+    try testing.expectEqualStrings("Second.", dl.children.items[3].children.items[0].children.items[0].data.text);
+}
+
+test "markdown: definition lists are literal text when disabled" {
+    const oliver = @import("oliver.zig");
+    var result = try oliver.parse(testing.allocator, "Term\n: Definition body.\n", .markdown, .{});
+    defer result.deinit();
+    // One ordinary paragraph containing both lines.
+    try testing.expectEqual(document.Tag.paragraph, result.document.root.children.items[0].tag);
 }

--- a/src/markdown.zig
+++ b/src/markdown.zig
@@ -3560,12 +3560,15 @@ fn discoverLinksAndImages(
                     // to (not including) the closing paren. The last
                     // consumed item may extend past the closing paren (e.g.
                     // `[foo](/uri) and more`) — truncate it so its tail
-                    // stays literal text after the construct.
+                    // stays literal text after the construct. The tail is
+                    // re-appended *after* the shrink below, which otherwise
+                    // would clobber it (bug: trailing text after an inline
+                    // link was dropped).
                     var j = i + 1;
                     while (j < old.len and itemSpan(old[j]).start < lp.paren_end) : (j += 1) {}
-                    if (itemSpan(old[j - 1]).end > lp.paren_end) {
+                    const keep_tail = j > i + 1 and itemSpan(old[j - 1]).end > lp.paren_end;
+                    if (keep_tail) {
                         setItemSpan(&old[j - 1], .{ .start = lp.paren_end, .end = itemSpan(old[j - 1]).end });
-                        try out.append(doc.allocator(), old[j - 1]);
                     }
 
                     out.shrinkRetainingCapacity(o);
@@ -3591,6 +3594,9 @@ fn discoverLinksAndImages(
                         // monotone check above); record its out position so
                         // those openers are recognized as dead.
                         max_link_opener_out = @max(max_link_opener_out, o);
+                    }
+                    if (keep_tail) {
+                        try out.append(doc.allocator(), old[j - 1]);
                     }
                     // The matched opener and everything trapped above it
                     // were consumed by the construct; entries below stay
@@ -3618,9 +3624,9 @@ fn discoverLinksAndImages(
 
                         var j = i + 1;
                         while (j < old.len and itemSpan(old[j]).start < close_end + 2) : (j += 1) {}
-                        if (itemSpan(old[j - 1]).end > close_end + 2) {
+                        const keep_tail = j > i + 1 and itemSpan(old[j - 1]).end > close_end + 2;
+                        if (keep_tail) {
                             setItemSpan(&old[j - 1], .{ .start = close_end + 2, .end = itemSpan(old[j - 1]).end });
-                            try out.append(doc.allocator(), old[j - 1]);
                         }
 
                         out.shrinkRetainingCapacity(o);
@@ -3643,6 +3649,9 @@ fn discoverLinksAndImages(
                                 },
                             });
                             max_link_opener_out = @max(max_link_opener_out, o);
+                        }
+                        if (keep_tail) {
+                            try out.append(doc.allocator(), old[j - 1]);
                         }
                         while (stack.items.len > 0 and stack.items[stack.items.len - 1] >= o) _ = stack.pop();
                         i = j - 1;
@@ -3663,9 +3672,9 @@ fn discoverLinksAndImages(
                         // Consume items covering the label `[...]`.
                         var j = i + 1;
                         while (j < old.len and itemSpan(old[j]).start < lab.after) : (j += 1) {}
-                        if (itemSpan(old[j - 1]).end > lab.after) {
+                        const keep_tail = j > i + 1 and itemSpan(old[j - 1]).end > lab.after;
+                        if (keep_tail) {
                             setItemSpan(&old[j - 1], .{ .start = @intCast(lab.after), .end = itemSpan(old[j - 1]).end });
-                            try out.append(doc.allocator(), old[j - 1]);
                         }
 
                         out.shrinkRetainingCapacity(o);
@@ -3688,6 +3697,9 @@ fn discoverLinksAndImages(
                                 },
                             });
                             max_link_opener_out = @max(max_link_opener_out, o);
+                        }
+                        if (keep_tail) {
+                            try out.append(doc.allocator(), old[j - 1]);
                         }
                         while (stack.items.len > 0 and stack.items[stack.items.len - 1] >= o) _ = stack.pop();
                         i = j - 1;

--- a/src/oliver.zig
+++ b/src/oliver.zig
@@ -71,10 +71,9 @@ pub const Dialect = enum {
 /// Markdown dialect extensions. All are **off by default**: the Markdown
 /// frontend is byte-exact CommonMark 0.31.2 unless a consumer opts in, so
 /// the CommonMark conformance corpus stays green. Each extension is a
-/// documented, principled addition with its own contract doc and tests.
-/// Markdown dialect extensions (footnotes, definition lists, heading
-/// attribute lists). All are off by default; see `markdown.Options` and
-/// docs/MARKDOWN-EXTENSIONS.md.
+/// documented, principled addition with its own contract doc and tests
+/// (footnotes, definition lists, heading attribute lists, GFM
+/// strikethrough; see `markdown.Options` and docs/MARKDOWN-EXTENSIONS.md).
 pub const MarkdownOptions = markdown.Options;
 
 /// Parse options. Markdown extensions are off by default.

--- a/src/oliver.zig
+++ b/src/oliver.zig
@@ -68,9 +68,19 @@ pub const Dialect = enum {
     textile,
 };
 
-/// Parse options. Empty in the vertical slice; grows with later milestones
-/// (raw HTML policy, reference links, tab handling, ...).
-pub const ParseOptions = struct {};
+/// Markdown dialect extensions. All are **off by default**: the Markdown
+/// frontend is byte-exact CommonMark 0.31.2 unless a consumer opts in, so
+/// the CommonMark conformance corpus stays green. Each extension is a
+/// documented, principled addition with its own contract doc and tests.
+/// Markdown dialect extensions (footnotes, definition lists, heading
+/// attribute lists). All are off by default; see `markdown.Options` and
+/// docs/MARKDOWN-EXTENSIONS.md.
+pub const MarkdownOptions = markdown.Options;
+
+/// Parse options. Markdown extensions are off by default.
+pub const ParseOptions = struct {
+    markdown: MarkdownOptions = .{},
+};
 
 /// Failures that are not markup interpretation: the caller's problem.
 pub const ParseError = error{
@@ -105,7 +115,6 @@ pub fn parse(
     dialect: Dialect,
     options: ParseOptions,
 ) ParseError!ParseResult {
-    _ = options;
     if (input.len > source.max_input_len) return error.InputTooLarge;
 
     var result = try ParseResult.init(allocator, input);
@@ -115,7 +124,7 @@ pub fn parse(
     defer diags.deinit(result.document.allocator());
 
     switch (dialect) {
-        .markdown => try markdown.parse(&result.document, &diags),
+        .markdown => try markdown.parse(&result.document, &diags, options.markdown),
         .textile => try textile.parse(&result.document, &diags),
     }
     result.diagnostics = diags.items;

--- a/src/textile.zig
+++ b/src/textile.zig
@@ -3097,7 +3097,7 @@ fn emitItems(doc: *document.Document, parent: *document.Node, content: source.Sp
                     i += 1;
                 },
                 .footnote => |f| {
-                    const node = try doc.createNode(.footnote_ref, subSpan(content, f.span.start, f.span.end), .{ .footnote_ref = f.number });
+                    const node = try doc.createNode(.footnote_ref, subSpan(content, f.span.start, f.span.end), .{ .footnote_ref = .{ .number = f.number } });
                     try doc.appendChild(scope.parent, node);
                     i += 1;
                 },
@@ -5763,7 +5763,7 @@ test "textile: [N] footnote references in every inline context" {
         try std.testing.expectEqual(@as(usize, 3), p.children.items.len); // text + ref + text
         const ref = p.children.items[1];
         try std.testing.expectEqual(document.Tag.footnote_ref, ref.tag);
-        try std.testing.expectEqual(@as(u16, 1), ref.data.footnote_ref);
+        try std.testing.expectEqual(@as(u16, 1), ref.data.footnote_ref.number);
     }
     // Refs resolve in headings, list items, and table cells (the shared
     // inline seam).
@@ -5787,7 +5787,7 @@ test "textile: [N] footnote references in every inline context" {
     {
         var result = try oliver.parse(std.testing.allocator, "Note[12].\n", .textile, .{});
         defer result.deinit();
-        try std.testing.expectEqual(@as(u16, 12), result.document.root.children.items[0].children.items[1].data.footnote_ref);
+        try std.testing.expectEqual(@as(u16, 12), result.document.root.children.items[0].children.items[1].data.footnote_ref.number);
     }
 }
 
@@ -5815,7 +5815,7 @@ test "textile: footnote literal fallbacks and marker edges" {
         defer result2.deinit();
         const root = result2.document.root;
         try std.testing.expectEqual(document.Tag.footnote_ref, root.children.items[1].children.items[1].tag);
-        try std.testing.expectEqual(@as(u16, 0), root.children.items[1].children.items[1].data.footnote_ref);
+        try std.testing.expectEqual(@as(u16, 0), root.children.items[1].children.items[1].data.footnote_ref.number);
     }
 
     // A `fnN.` signature terminates an open extended quote.

--- a/tests/fixtures/markdown/ext-definition-list.html
+++ b/tests/fixtures/markdown/ext-definition-list.html
@@ -1,0 +1,11 @@
+<dl>
+<dt>Term one</dt>
+<dd>Definition one body.</dd>
+</dl>
+<dl>
+<dt>Term two</dt>
+<dd>First definition.</dd>
+<dt>Term three</dt>
+<dd>First definition.
+Second line of the definition.</dd>
+</dl>

--- a/tests/fixtures/markdown/ext-definition-list.md
+++ b/tests/fixtures/markdown/ext-definition-list.md
@@ -1,0 +1,8 @@
+Term one
+: Definition one body.
+
+Term two
+: First definition.
+Term three
+: First definition.
+  Second line of the definition.

--- a/tests/fixtures/markdown/ext-footnotes.html
+++ b/tests/fixtures/markdown/ext-footnotes.html
@@ -1,0 +1,11 @@
+<p>Hi<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup> and more<sup class="footnote-ref"><a href="#fn-2" id="fnref-2" data-footnote-ref>2</a></sup>.</p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-1">
+<p>First note body. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+<li id="fn-2">
+<p>Second note body. <a href="#fnref-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+</li>
+</ol>
+</section>

--- a/tests/fixtures/markdown/ext-footnotes.html
+++ b/tests/fixtures/markdown/ext-footnotes.html
@@ -1,11 +1,12 @@
-<p>Hi<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup> and more<sup class="footnote-ref"><a href="#fn-2" id="fnref-2" data-footnote-ref>2</a></sup>.</p>
+<p>Alpha claim <sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>. Beta claim <sup class="footnote-ref"><a href="#fn-1" id="fnref-1-2" data-footnote-ref>1</a></sup>. Gamma claim <sup class="footnote-ref"><a href="#fn-1" id="fnref-1-3" data-footnote-ref>1</a></sup>.</p>
+<p>Delta claim <sup class="footnote-ref"><a href="#fn-2" id="fnref-2" data-footnote-ref>2</a></sup>. Epsilon claim <sup class="footnote-ref"><a href="#fn-2" id="fnref-2-2" data-footnote-ref>2</a></sup>.</p>
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-1">
-<p>First note body. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+<p>First source. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩</a> <a href="#fnref-1-3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-3" aria-label="Back to reference 1-3">↩</a></p>
 </li>
 <li id="fn-2">
-<p>Second note body. <a href="#fnref-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+<p>Second source. <a href="#fnref-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a> <a href="#fnref-2-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2-2" aria-label="Back to reference 2-2">↩</a></p>
 </li>
 </ol>
 </section>

--- a/tests/fixtures/markdown/ext-footnotes.md
+++ b/tests/fixtures/markdown/ext-footnotes.md
@@ -1,4 +1,6 @@
-Hi[^syntax] and more[^second].
+Alpha claim [^a]. Beta claim [^a]. Gamma claim [^a].
 
-[^syntax]: First note body.
-[^second]: Second note body.
+Delta claim [^b]. Epsilon claim [^b].
+
+[^a]: First source.
+[^b]: Second source.

--- a/tests/fixtures/markdown/ext-footnotes.md
+++ b/tests/fixtures/markdown/ext-footnotes.md
@@ -1,0 +1,4 @@
+Hi[^syntax] and more[^second].
+
+[^syntax]: First note body.
+[^second]: Second note body.

--- a/tests/fixtures/markdown/ext-heading-ids.html
+++ b/tests/fixtures/markdown/ext-heading-ids.html
@@ -1,0 +1,5 @@
+<h1 id="hello-world">Hello, World!</h1>
+<h2 id="sub-more">Sub &amp; More</h2>
+<h2 id="caf-rsum">Café résumé</h2>
+<h2 id="exit-codes">Exit codes</h2>
+<h3 id="code-span-here">Code <code>span</code> here</h3>

--- a/tests/fixtures/markdown/ext-heading-ids.md
+++ b/tests/fixtures/markdown/ext-heading-ids.md
@@ -1,0 +1,9 @@
+# Hello, World!
+
+## Sub & More
+
+## Café résumé
+
+## Exit codes {#exit-codes}
+
+### Code `span` here

--- a/tests/fixtures/markdown/ext-strikethrough.html
+++ b/tests/fixtures/markdown/ext-strikethrough.html
@@ -1,0 +1,19 @@
+<p><del>Hi</del> Hello, world!</p>
+<p>A <del>strike</del> and a <a href="/uri">link</a> after.</p>
+<p>foo<del>bar</del>baz and ~single~ and <del>x</del>y<del>z</del>.</p>
+<p>This <del>has a
+new paragraph</del>.</p>
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><del>gone</del></td>
+<td><del>struck</del></td>
+</tr>
+</tbody>
+</table>

--- a/tests/fixtures/markdown/ext-strikethrough.md
+++ b/tests/fixtures/markdown/ext-strikethrough.md
@@ -1,0 +1,12 @@
+~~Hi~~ Hello, world!
+
+A ~~strike~~ and a [link](/uri) after.
+
+foo~~bar~~baz and ~single~ and ~~x~~y~~z~~.
+
+This ~~has a
+new paragraph~~.
+
+| a | b |
+| --- | --- |
+| ~~gone~~ | ~~struck~~ |

--- a/tests/fixtures/markdown/link-trailing-text.html
+++ b/tests/fixtures/markdown/link-trailing-text.html
@@ -1,0 +1,3 @@
+<p>A <a href="/uri">link</a> with trailing text after it.</p>
+<p><img src="/img.png" alt="alt" title="t" /> then more text.</p>
+<p><a href="/dest" title="rt">ref</a> and after.</p>

--- a/tests/fixtures/markdown/link-trailing-text.md
+++ b/tests/fixtures/markdown/link-trailing-text.md
@@ -1,0 +1,7 @@
+A [link](/uri) with trailing text after it.
+
+![alt](/img.png "t") then more text.
+
+[ref][r] and after.
+
+[r]: /dest "rt"

--- a/tests/fixtures/markdown/table-inline-content.html
+++ b/tests/fixtures/markdown/table-inline-content.html
@@ -7,7 +7,7 @@
 </thead>
 <tbody>
 <tr>
-<td><em>em</em> <a href="/u">x</a><code>c</code> <a href="/dest">y</a></td>
+<td><em>em</em> <a href="/u">x</a> <code>c</code> <a href="/dest">y</a></td>
 <td>2</td>
 </tr>
 </tbody>

--- a/tests/fixtures_test.zig
+++ b/tests/fixtures_test.zig
@@ -1478,6 +1478,11 @@ const markdown_ext_fixtures = [_]MarkdownExtFixture{
         .input = @embedFile("fixtures/markdown/ext-heading-ids.md"),
         .expected = @embedFile("fixtures/markdown/ext-heading-ids.html"),
     },
+    .{
+        .name = "ext-strikethrough",
+        .input = @embedFile("fixtures/markdown/ext-strikethrough.md"),
+        .expected = @embedFile("fixtures/markdown/ext-strikethrough.html"),
+    },
 };
 
 const TextileFixture = struct {
@@ -2399,6 +2404,7 @@ fn renderExtHtml(input: []const u8) !std.ArrayList(u8) {
             .footnotes = true,
             .definition_lists = true,
             .heading_attributes = true,
+            .strikethrough = true,
         },
     });
     defer result.deinit();

--- a/tests/fixtures_test.zig
+++ b/tests/fixtures_test.zig
@@ -1446,6 +1446,35 @@ const markdown_fixtures = [_]MarkdownFixture{
     },
 };
 
+/// Markdown-extension fixtures (footnotes, definition lists, heading
+/// attribute lists, heading ids): parsed with all extensions enabled and
+/// rendered with `heading_ids` + `footnotes` (docs/MARKDOWN-EXTENSIONS.md).
+/// These are opt-in extensions, so they live outside the byte-exact
+/// CommonMark fixture list above.
+const MarkdownExtFixture = struct {
+    name: []const u8,
+    input: []const u8,
+    expected: []const u8,
+};
+
+const markdown_ext_fixtures = [_]MarkdownExtFixture{
+    .{
+        .name = "ext-definition-list",
+        .input = @embedFile("fixtures/markdown/ext-definition-list.md"),
+        .expected = @embedFile("fixtures/markdown/ext-definition-list.html"),
+    },
+    .{
+        .name = "ext-footnotes",
+        .input = @embedFile("fixtures/markdown/ext-footnotes.md"),
+        .expected = @embedFile("fixtures/markdown/ext-footnotes.html"),
+    },
+    .{
+        .name = "ext-heading-ids",
+        .input = @embedFile("fixtures/markdown/ext-heading-ids.md"),
+        .expected = @embedFile("fixtures/markdown/ext-heading-ids.html"),
+    },
+};
+
 const TextileFixture = struct {
     name: []const u8,
     input: []const u8,
@@ -2356,6 +2385,38 @@ fn checkFixture(name: []const u8, dialect: oliver.Dialect, input: []const u8, ex
 test "markdown fixtures" {
     for (markdown_fixtures) |f| {
         try checkFixture(f.name, .markdown, f.input, f.expected);
+    }
+}
+
+fn renderExtHtml(input: []const u8) !std.ArrayList(u8) {
+    var result = try oliver.parse(std.testing.allocator, input, .markdown, .{
+        .markdown = .{
+            .footnotes = true,
+            .definition_lists = true,
+            .heading_attributes = true,
+        },
+    });
+    defer result.deinit();
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.html.render(std.testing.allocator, &aw.writer, &result.document, .{
+        .heading_ids = true,
+        .footnotes = true,
+    });
+    return aw.toArrayList();
+}
+
+test "markdown extension fixtures" {
+    for (markdown_ext_fixtures) |f| {
+        var out = try renderExtHtml(f.input);
+        defer out.deinit(std.testing.allocator);
+        if (!std.mem.eql(u8, f.expected, out.items)) {
+            std.debug.print(
+                "extension fixture [{s}] mismatch\n--- expected ({d} bytes) ---\n{s}\n--- actual ({d} bytes) ---\n{s}\n",
+                .{ f.name, f.expected.len, f.expected, out.items.len, out.items },
+            );
+            return error.FixtureMismatch;
+        }
     }
 }
 

--- a/tests/fixtures_test.zig
+++ b/tests/fixtures_test.zig
@@ -376,6 +376,11 @@ const markdown_fixtures = [_]MarkdownFixture{
     },
     // --- inline links (docs/INLINE-PARSING.md §6.6) ---
     .{
+        .name = "link-trailing-text",
+        .input = @embedFile("fixtures/markdown/link-trailing-text.md"),
+        .expected = @embedFile("fixtures/markdown/link-trailing-text.html"),
+    },
+    .{
         .name = "link-simple",
         .input = @embedFile("fixtures/markdown/link-simple.md"),
         .expected = @embedFile("fixtures/markdown/link-simple.html"),


### PR DESCRIPTION
## Markdown extensions + fixes consumed by the Boris renderer migration

This branch carries the Markdown work that Boris (drawmeanelephant/boris) depends on. It is currently **held open on purpose** — main is under an embargo — and should be merged when the embargo lifts.

**Rebased onto current main (`c8a8e06`) on 2026-08-14.** The branch was 55 commits behind main; conflicts with main's Textile milestone (XHTML profile, phrase-attr consolidation, `cite`/`acronym`, Textile dt/dd roles) were resolved by hand, preserving both sides' features.

### What's in the branch (6 commits over main)

- **`ad01000` markdown: GFM heading auto-ids, heading IALs, footnotes, definition lists** — the extension set Boris's render seam uses (`heading_ids`, `heading_attributes`, `footnotes`, `definition_lists`). Extensions are opt-in via `ParseOptions.markdown`, off by default, so the CommonMark corpus stays byte-exact.
- **`db9ba20` build: register the core module for Zig package consumers** — makes the package importable by content-hash dependency (required for Boris's pin).
- **`540556d` markdown: keep inline content after links/images (trailing-text bug)** — inline/collapsed/full reference links dropped everything after the link; fixed with regression fixtures. 652/652 CommonMark conformance intact.
- **`9cd2e03` markdown: GFM strikethrough extension (`~~text~~` → `<del>`)** — opt-in `Options.strikethrough`; matches the GFM delimiter rules (two-tilde runs, emphasis-like flanking, no paragraph spanning).
- **`be3312e` html: never deinit an uninitialized footnote-numbering map** — **critical correctness fix**: when the footnotes option was off (or on with no definitions) the numbering table was left `undefined` yet `deinit` freed it. Regression test pins the three no-context paths.
- **`42cf472` html: give repeated footnote references unique ids and one backref each — closes #44** — every Markdown `[^label]` reference previously emitted the same `id="fnref-N"` (duplicate ids, invalid HTML); now references get `fnref-N` / `fnref-N-2` / `fnref-N-3` per occurrence with one backref per reference. Pinned end-to-end in `tests/fixtures/markdown/ext-footnotes.*` (fails on the old code).

The old reconciliation commit `872b002` was dropped during the rebase as empty — its only change (adding `footnote_backref = 0` to the big/small exit frames) is fully subsumed by main's consolidated phrase-tag case.

### Merge notes

- `src/document.zig`: `Tag`/`Data` merged — main's `cite`/`acronym` plus the branch's `definition_*`/`footnote`; the branch's `FootnoteRef { label, number }` supersedes main's bare `u16` (Textile `[N]` refs adapted to the new payload).
- `src/html.zig`: main's evolved renderer (XHTML profile, phrase-attr consolidation, Textile dt/dd) combined with the branch's Markdown extensions, threading `footnote_backref` through every exit frame.
- `src/oliver.zig`: `ParseOptions.markdown` (`MarkdownOptions`) — extensions **off by default**.

### Validation (on the rebased branch)

- `zig build test --summary all`: **299/299** (Debug and ReleaseSafe)
- CommonMark 0.31.2 gate (`spec-conformance --gate`): **652/652, 0 mismatches, 0 regressions**
- Cooklang canonical conformance: **60/60**
- `zig fmt --check`: clean

### ⚠️ Boris re-pin required

Boris pins this branch by content hash. The old pin (`872b002`) no longer exists on the branch, and the merged tree is **no longer** byte-identical to it (main moved ahead 55 commits, and #44's fix is on top). Before merging, Boris must be re-pinned to the new tip `42cf472` (or the merge commit) and its integration suite re-run.

### Merge plan

When the embargo lifts: merge this PR into `main`, then re-pin Boris to the merged commit hash and re-run its integration suite.
