### PR TITLE
docs: home page, nav manifest, capabilities overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ published Cooklang specification and canonical test corpus. It
 does not study or imitate existing parser implementations. See
 [docs/CLEANROOM.md](docs/CLEANROOM.md).
 
+## Documentation
+
+The full documentation lives in `docs/` — [docs/index.md](docs/index.md)
+is the home page with a site map, and [docs/nav.json](docs/nav.json) is
+the renderer-ready navigation manifest. As a user, start with
+[docs/CAPABILITIES.md](docs/CAPABILITIES.md) (what each frontend parses
+and renders). As a contributor, start with
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md),
+[docs/DOCUMENT-MODEL.md](docs/DOCUMENT-MODEL.md),
+[docs/FEATURE-MATRIX.md](docs/FEATURE-MATRIX.md),
+[docs/TESTS.md](docs/TESTS.md), [docs/CLEANROOM.md](docs/CLEANROOM.md),
+and [docs/WORK-LEDGER.md](docs/WORK-LEDGER.md).
+
 ## Status
 
 Implemented so far: paragraphs, ATX and Setext headings, thematic breaks,

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,84 @@
+# Oliver capabilities
+
+What Oliver parses and renders today on `main`. The full design
+contracts live in the per-frontend documents (see the
+[docs home](index.md)); this page is the user-facing overview.
+
+## Frontends at a glance
+
+| frontend | parses into | entry point | conformance |
+| --- | --- | --- | --- |
+| Markdown | shared `document.Document` | `oliver.parse(..., .markdown, ...)` | CommonMark 0.31.2: **652/652**, 0 mismatches |
+| Textile | shared `document.Document` | `oliver.parse(..., .textile, ...)` | Textile fixture wall: fully green |
+| Cooklang | typed `Recipe` (own model) | `oliver.cooklang.parse(...)` | canonical corpus: **60/60** |
+
+Markdown and Textile converge into one normalized model and one
+renderer. Cooklang deliberately keeps its **own typed model** because
+recipe semantics are richer than prose markup — ingredients,
+quantities, units, cookware, and timers survive parsing as typed data,
+never as decorated text.
+
+## Markdown
+
+Full CommonMark 0.31.2 conformance. Block syntax: paragraphs, ATX and
+Setext headings, thematic breaks, fenced and indented code blocks, HTML
+blocks (§4.6, all seven types), block quotes, lists (§5.2/5.3) with
+nesting, marker-width indentation, and tight/loose tracking, GFM pipe
+tables, and link reference definitions (§4.7) with full/collapsed/
+shortcut resolution. Inline syntax: emphasis and strong emphasis (§6.2,
+the complete rule set), code spans, inline and reference-style links
+and images, autolinks (URI and email), raw HTML, hard and soft line
+breaks, backslash escapes, and entity and numeric character references
+(§2.5).
+
+## Textile
+
+The documented Textile 2 syntax through the shared model: `hN.`, `p.`,
+and `bq.` blocks with block attributes; `*`/`#` lists; `@code@`; the
+phrase-modifier family (`_x_`, `*x*`, `__x__`, `**x**`, `-x-`, `+x+`,
+`^x^`, `~x~`, `%x%`, `++x++`, `--x--`, `??x??`, `ABC(def)`) with
+attributes; links (titles, the bracket trick, aliases) and images
+(alt/title, link attachment, the alignment/size modifier set); `|a|b|`
+tables with cell modifiers, colspan, and rowspan; line attributes;
+`==` escaping; character replacements (curly quotes, dashes, ellipsis,
+symbols, macros); footnotes; `bc.`/`pre.` code blocks; extended
+`bq..`/`bc..` blocks; `dl.` definition lists; `clear.`; and
+`notextile.` raw passthrough.
+
+## Cooklang
+
+A typed `Recipe` with exact source spans and structured diagnostics:
+ingredients (name, quantity, units, preparation), recipe references
+(parsed, **never resolved** — filesystem resolution is a consumer
+concern), cookware, timers (named and unnamed), steps with forced line
+breaks, notes, sections, `--`/`[- -]` comments, and the YAML front-matter
+boundary (raw payload preserved with exact spans — Oliver never parses
+YAML). Derived operations over the same model:
+
+- **serialize** — canonical `.cook` output (semantic, idempotent;
+  not byte-identical round-tripping)
+- **scale** — exact-rational scaling by factor or servings; fixed
+  (`=`) quantities, timers, cookware, and recipe references untouched
+- **render** — a deterministic HTML policy: ingredients index,
+  timers as `<time>` with ISO-8601 durations, section-aware layout
+- **menu** — the day/meal view over parsed `.menu` files (sections as
+  days, `(YYYY-MM-DD)` dates, reference directives as source text)
+
+## Library and CLI
+
+- **Library**: `@import("oliver")`. `oliver.parse` for Markdown/Textile;
+  `oliver.cooklang.parse` plus the derived operations for Cooklang. The
+  caller supplies the allocator; results own their arenas; text payloads
+  borrow the input bytes (which must outlive the result).
+- **CLI**: `oliver render --from <markdown|textile|cooklang>`,
+  `oliver serialize --from cooklang`, `oliver scale --from cooklang
+  (--factor n[/d] | --servings n)`, `oliver menu --from cooklang` — a
+  thin stdin/stdout adapter; all semantics live in the library.
+
+## Go deeper
+
+- [Markdown docs](index.md#markdown-frontend) ·
+  [Textile docs](index.md#textile-frontend) ·
+  [Cooklang contract](COOKLANG.md)
+- [Architecture](ARCHITECTURE.md) · [Document model](DOCUMENT-MODEL.md)
+  · [Feature matrix](FEATURE-MATRIX.md) · [Tests](TESTS.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# Oliver documentation
+
+Oliver is a small, freestanding markup parsing and rendering library in
+Zig: bytes in, a typed document (or Recipe) out, deterministic HTML on
+request. This is the documentation home.
+
+The documentation is written for two audiences:
+
+- **Consumers** — applications (like Boris) that embed Oliver. Start
+  with [Capabilities](CAPABILITIES.md) and the README's library-use and
+  CLI sections, then the frontend pages that matter to you.
+- **Contributors** — anyone changing Oliver. Start with
+  [Architecture](ARCHITECTURE.md) and [Clean-room rules](CLEANROOM.md),
+  then the per-feature parsing documents and the
+  [work ledger](WORK-LEDGER.md).
+
+## Conformance status
+
+| wall | status |
+| --- | --- |
+| CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
+| Cooklang canonical corpus | **60/60** |
+| Textile fixture wall | fully green |
+| Test suite | **251/251** |
+
+Both conformance gates run in CI on every push/PR
+(`zig build spec-conformance -- spec.txt --gate` and
+`zig build cooklang-conformance`).
+
+## Site map
+
+[nav.json](nav.json) is the machine-readable manifest — sections,
+pages, titles, audiences, and summaries — that any docs renderer can
+consume directly. The map below mirrors it.
+
+### Overview
+
+- [Capabilities](CAPABILITIES.md) — what each frontend parses and
+  renders today, with conformance status (start here as a user)
+- [Architecture](ARCHITECTURE.md) — pipeline, the two document
+  families, module map, the boundaries that matter
+- [Document model](DOCUMENT-MODEL.md) — the shared normalized model and
+  its invariants
+- [Feature matrix](FEATURE-MATRIX.md) — every implemented feature
+  across the dialects, with provenance
+- [Tests and fixtures](TESTS.md) — the suites, the conformance walls,
+  and the fixture convention
+- [CommonMark expectations](COMMONMARK-EXPECTATIONS.md) — the
+  classified conformance expectation set behind the 652/652 gate
+
+### Markdown frontend
+
+- [Block parsing](BLOCKS-PARSING.md) · [Leaf blocks](LEAF-BLOCKS.md) ·
+  [Fenced code](FENCED-CODE.md) · [HTML blocks](HTML-BLOCKS.md) ·
+  [Entities](ENTITIES.md)
+- [Emphasis and strong](INLINE-PARSING.md) · [Autolinks](AUTOLINKS.md) ·
+  [Raw HTML](RAW-HTML.md) · [Images](IMAGES-PARSING.md) ·
+  [Reference images](REFERENCE-IMAGES.md) · [Tables (GFM)](TABLES.md)
+
+### Textile frontend
+
+- [Textile parity audit](TEXTILE-PARITY.md) · [Inline code
+  contract](TEXTILE-INLINE-CODE.md)
+
+### Cooklang frontend
+
+- [Cooklang design contract](COOKLANG.md) — the typed Recipe model,
+  the boundaries, and the serialize / scale / HTML / menu policies
+
+### Process
+
+- [Clean-room rules](CLEANROOM.md) · [Work ledger](WORK-LEDGER.md)
+
+## Rendering as pages
+
+`docs/nav.json` is the single source of navigation truth and is kept
+renderer-agnostic: a later docs site (mdBook, mkdocs, Docusaurus, or a
+hand-rolled generator) can consume it directly or transpile it to its
+own sidebar format. The markdown files are self-contained and
+cross-linked, so any static renderer with a markdown engine can serve
+them as-is — no repository restructuring is needed to ship pages.

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -1,0 +1,187 @@
+{
+  "title": "Oliver documentation",
+  "home": "index.md",
+  "sections": [
+    {
+      "name": "Overview",
+      "pages": [
+        {
+          "file": "index.md",
+          "title": "Home",
+          "audience": "user",
+          "summary": "Docs home, conformance status, and site map."
+        },
+        {
+          "file": "CAPABILITIES.md",
+          "title": "Capabilities",
+          "audience": "user",
+          "summary": "What the three frontends parse and render today, with conformance status."
+        },
+        {
+          "file": "../README.md",
+          "title": "README",
+          "audience": "user",
+          "summary": "Repository front door: status, build, library use, CLI."
+        },
+        {
+          "file": "ARCHITECTURE.md",
+          "title": "Architecture",
+          "audience": "dev",
+          "summary": "Pipeline, the two document families, module map, boundaries."
+        },
+        {
+          "file": "DOCUMENT-MODEL.md",
+          "title": "Document model",
+          "audience": "dev",
+          "summary": "The shared normalized Node/Tag/Data model and its invariants."
+        },
+        {
+          "file": "FEATURE-MATRIX.md",
+          "title": "Feature matrix",
+          "audience": "dev",
+          "summary": "Every implemented feature across the dialects, with provenance."
+        },
+        {
+          "file": "TESTS.md",
+          "title": "Tests and fixtures",
+          "audience": "dev",
+          "summary": "The test suites, the conformance walls, and the fixture convention."
+        },
+        {
+          "file": "COMMONMARK-EXPECTATIONS.md",
+          "title": "CommonMark expectations",
+          "audience": "dev",
+          "summary": "The classified conformance expectation set behind the 652/652 gate."
+        }
+      ]
+    },
+    {
+      "name": "Markdown frontend",
+      "pages": [
+        {
+          "file": "BLOCKS-PARSING.md",
+          "title": "Block parsing",
+          "audience": "dev",
+          "summary": "Container blocks: block quotes and lists."
+        },
+        {
+          "file": "LEAF-BLOCKS.md",
+          "title": "Leaf blocks",
+          "audience": "dev",
+          "summary": "Thematic breaks and Setext headings."
+        },
+        {
+          "file": "FENCED-CODE.md",
+          "title": "Fenced code",
+          "audience": "dev",
+          "summary": "Fenced code blocks (§4.5)."
+        },
+        {
+          "file": "HTML-BLOCKS.md",
+          "title": "HTML blocks",
+          "audience": "dev",
+          "summary": "HTML blocks (§4.6), all seven types."
+        },
+        {
+          "file": "ENTITIES.md",
+          "title": "Entities",
+          "audience": "dev",
+          "summary": "Entity and numeric character references (§2.5)."
+        },
+        {
+          "file": "INLINE-PARSING.md",
+          "title": "Emphasis and strong",
+          "audience": "dev",
+          "summary": "Emphasis and strong emphasis (§6.2)."
+        },
+        {
+          "file": "AUTOLINKS.md",
+          "title": "Autolinks",
+          "audience": "dev",
+          "summary": "Autolinks (§6.8)."
+        },
+        {
+          "file": "RAW-HTML.md",
+          "title": "Raw HTML",
+          "audience": "dev",
+          "summary": "Raw HTML inline (§6.6)."
+        },
+        {
+          "file": "REFERENCE-IMAGES.md",
+          "title": "Reference images",
+          "audience": "dev",
+          "summary": "Reference-style images (§6.4/§6.7)."
+        },
+        {
+          "file": "IMAGES-PARSING.md",
+          "title": "Images",
+          "audience": "dev",
+          "summary": "Inline images (§6.7)."
+        },
+        {
+          "file": "TABLES.md",
+          "title": "Tables (GFM)",
+          "audience": "dev",
+          "summary": "The GFM pipe-table extension."
+        },
+        {
+          "file": "IMAGES-MISSION.md",
+          "title": "Images mission brief",
+          "audience": "dev",
+          "summary": "Historical mission brief for the images milestone (delegated agent)."
+        }
+      ]
+    },
+    {
+      "name": "Textile frontend",
+      "pages": [
+        {
+          "file": "TEXTILE-PARITY.md",
+          "title": "Textile parity audit",
+          "audience": "dev",
+          "summary": "The audit of every implemented Textile feature against the references."
+        },
+        {
+          "file": "TEXTILE-INLINE-CODE.md",
+          "title": "Inline code contract",
+          "audience": "dev",
+          "summary": "Clean-room design contract for Textile @code@."
+        }
+      ]
+    },
+    {
+      "name": "Cooklang frontend",
+      "pages": [
+        {
+          "file": "COOKLANG.md",
+          "title": "Cooklang design contract",
+          "audience": "dev",
+          "summary": "The typed Recipe model, boundaries, and the serialize/scale/HTML/menu policies."
+        }
+      ]
+    },
+    {
+      "name": "Process",
+      "pages": [
+        {
+          "file": "CLEANROOM.md",
+          "title": "Clean-room rules",
+          "audience": "dev",
+          "summary": "The clean-room policy, session provenance records, and chosen behaviors."
+        },
+        {
+          "file": "WORK-LEDGER.md",
+          "title": "Engineering work ledger",
+          "audience": "dev",
+          "summary": "Every milestone card: objective, sources, seams, acceptance, state."
+        },
+        {
+          "file": "SESSION-1-REPORT.md",
+          "title": "Session 1 report",
+          "audience": "dev",
+          "summary": "Historical early-session report."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## docs site skeleton (renderer-ready)

The docs corpus is 23 dev-facing contract files with no index, no
navigation, and nothing a future docs renderer can consume. This adds:

- **docs/index.md** — the docs home: audiences (consumers vs.
  contributors), conformance status (652/652, 60/60, Textile green,
  251/251 tests), and a grouped site map.
- **docs/nav.json** — the single renderer-agnostic navigation manifest
  (sections, pages, titles, `user`/`dev` audience, summaries). Any
  later site (mdBook, mkdocs, Docusaurus, hand-rolled) can consume it
  directly or transpile it to its own sidebar format.
- **docs/CAPABILITIES.md** — the user-facing overview: what each
  frontend parses and renders, the conformance table, the derived
  Cooklang operations, and library/CLI entry points.
- README gains a `## Documentation` section pointing at the home.

Docs-only change — no code, tests, or gates touched. Validated
`nav.json` parses; the markdown is already cross-linked and
self-contained, so rendering later requires no restructuring.