### PR TITLE
feat(pages): ship GitHub Pages publication stack

### DIFF
--- a/.github/boris-pin.json
+++ b/.github/boris-pin.json
@@ -1,3 +1,3 @@
 {
-  "revision": "43216ec270ae5b42996dd11adb223e61b861c43b"
+  "revision": "30805ab83822a5378a282c4c8207701286e5cfd1"
 }

--- a/.github/boris-pin.json
+++ b/.github/boris-pin.json
@@ -1,0 +1,3 @@
+{
+  "revision": "43216ec270ae5b42996dd11adb223e61b861c43b"
+}

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -1,0 +1,89 @@
+# Docs publication gate.
+#
+# Runs the Boris prepublication validation against the docs/ tree on every
+# push and pull request, so broken links, content-local asset errors, or
+# URLs that escape the declared origin/base path fail before merge. The
+# gate uses the same pipeline as the Pages build: the same pinned Boris
+# revision (single source of truth in .github/boris-pin.json, shared with
+# .github/workflows/github-pages.yml), the same project-site location
+# (/oliver), the same theme, and the same profile/plan normalization.
+#
+# `boris validate` runs the same prepublication path as `boris compile`
+# without writing artifacts, so this job leaves the working tree clean and
+# adds no CI-side output beyond the plan check below.
+#
+# The project-site location is the canonical /oliver shape for this
+# repository. Update these flags together with
+# publication-profile.example.json if the site shape ever changes.
+
+name: Docs gate
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: docs-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate docs publication
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+
+      # The Boris revision is the single pin in .github/boris-pin.json,
+      # shared with the Pages publish workflow: this gate always validates
+      # the same toolchain that publishes.
+      - name: Resolve Boris toolchain pin
+        id: boris-pin
+        run: echo "revision=$(jq -r .revision .github/boris-pin.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned Boris toolchain
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: drawmeanelephant/boris
+          ref: ${{ steps.boris-pin.outputs.revision }}
+          path: boris
+          fetch-depth: 1
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Build Boris
+        run: cd boris && zig build -Doptimize=ReleaseSafe
+
+      # Cheap schema-drift guard: the starter profile must still plan to
+      # the /oliver project-site shape the gate and the publish workflow
+      # hard-code.
+      - name: Validate the starter publication profile
+        run: |
+          boris/zig-out/bin/boris plan --profile publication-profile.example.json > /tmp/publication-plan.json
+          test "$(jq -r '.publication.site_kind' /tmp/publication-plan.json)" = "project-site"
+          test "$(jq -r '.publication.base_path' /tmp/publication-plan.json)" = "/oliver"
+
+      # The same prepublication checks as the Pages build, without writing
+      # dist/. Fails on EPUBLICATIONLOCATION (URL escapes the declared
+      # origin/base path), EASSET, ECOMPONENT, and any other compiler
+      # finding that would fail the publish workflow.
+      - name: Validate docs against the project-site location
+        run: |
+          boris/zig-out/bin/boris validate \
+            --input docs \
+            --target public=dist \
+            --target-layout public=themes/oliver/layouts/main.html \
+            --sitemap \
+            --pages-base-url https://drawmeanelephant.github.io/oliver \
+            --pages-origin https://drawmeanelephant.github.io \
+            --pages-base-path /oliver \
+            --site-url https://drawmeanelephant.github.io/oliver

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,379 @@
+# GitHub Pages publication for Oliver's documentation.
+#
+# Adapted from drawmeanelephant/boris's official workflow
+# (.github/workflows/github-pages.yml) with three deliberate deltas:
+#
+#   1. Content root is `docs/` (the reference workflow uses the default
+#      `content`); the profile declares `input: "docs"` and the compile step
+#      passes `--input docs` explicitly.
+#   2. The layout theme is this repository's own `themes/oliver`.
+#   3. The toolchain is a Boris binary built from a PINNED Boris revision
+#      (Oliver cannot build Boris from its own source). The revision is the
+#      single pin in .github/boris-pin.json, shared with the docs gate
+#      (.github/workflows/docs-gate.yml); bump it only after locally
+#      re-validating (boris validate + compile against `docs/` with the
+#      project-site flags). The pinned revision is recorded in the retained
+#      evidence and in the build summary.
+#
+# Everything else — action pins, least-privilege permissions, concurrency,
+# profile/plan normalization, the public/evidence boundary, the evidence
+# naming, and the optional post-deploy audit — carries over verbatim.
+
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      audit_deployment:
+        description: "Run the bounded post-deploy HTTP audit and retain separate evidence"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and verify the Pages artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      # The Boris toolchain is a one-way dependency: this repo publishes its
+      # docs with a Boris binary, and the Boris revision is the single pin
+      # in .github/boris-pin.json, recorded in the retained evidence.
+      - name: Resolve Boris toolchain pin
+        id: boris-pin
+        run: echo "revision=$(jq -r .revision .github/boris-pin.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned Boris toolchain
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: drawmeanelephant/boris
+          ref: ${{ steps.boris-pin.outputs.revision }}
+          path: boris
+          fetch-depth: 1
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      # Markdown rendering inside Boris is Oliver, a pure-Zig library pinned by
+      # content hash in boris/build.zig.zon: no CMake, no host tools. jq is used
+      # below for the publication-plan and evidence JSON.
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Build Boris
+        run: cd boris && zig build -Doptimize=ReleaseSafe
+
+      # configure-pages is authoritative for the repository's Pages location.
+      # The profile parser independently cross-checks the same values offline.
+      - name: Resolve GitHub Pages location
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Create and validate the publication plan
+        env:
+          PAGES_BASE_URL: ${{ steps.pages.outputs.base_url }}
+          PAGES_ORIGIN: ${{ steps.pages.outputs.origin }}
+          PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: |
+          test -n "$PAGES_BASE_URL"
+          test -n "$PAGES_ORIGIN"
+          mkdir -p evidence
+          jq -n \
+            --arg base_url "$PAGES_BASE_URL" \
+            --arg origin "$PAGES_ORIGIN" \
+            --arg base_path "$PAGES_BASE_PATH" \
+            '{
+              format: "boris-publication-profile",
+              schema_version: 1,
+              input: "docs",
+              site: {url: $base_url},
+              publication: {
+                target: "github-pages",
+                base_url: $base_url,
+                origin: $origin,
+                base_path: $base_path
+              },
+              targets: [{
+                name: "public",
+                output: "dist",
+                public: true,
+                theme: "themes/oliver",
+                sitemap: {path: "sitemap.xml"}
+              }]
+            }' > .boris-pages-profile.json
+          boris/zig-out/bin/boris plan --profile .boris-pages-profile.json > evidence/publication-plan.json
+
+      - name: Compile the public HTML target
+        run: |
+          # Build from the normalized plan, not a second unbound URL source.
+          PAGES_BASE_URL="$(jq -r '.publication.base_url' evidence/publication-plan.json)"
+          PAGES_ORIGIN="$(jq -r '.publication.origin' evidence/publication-plan.json)"
+          PAGES_BASE_PATH="$(jq -r '.publication.base_path' evidence/publication-plan.json)"
+          test "$PAGES_BASE_URL" != "null"
+          test "$PAGES_ORIGIN" != "null"
+          test "$PAGES_BASE_PATH" != "null"
+          # --input docs is explicit: the CLI default content root is
+          # "content", but this repository publishes its docs/ tree.
+          boris/zig-out/bin/boris \
+            --input docs \
+            --target public=dist \
+            --target-layout public=themes/oliver/layouts/main.html \
+            --sitemap \
+            --pages-base-url "$PAGES_BASE_URL" \
+            --pages-origin "$PAGES_ORIGIN" \
+            --pages-base-path "$PAGES_BASE_PATH" \
+            --site-url "$PAGES_BASE_URL" \
+            --quiet
+
+      # The Pages upload contains only exact committed inventory records.
+      # _boris/proof is copied into the retained evidence artifact below.
+      - name: Prepare the public Pages tree
+        run: |
+          boris/scripts/prepare-github-pages-artifact.sh \
+            dist \
+            public-site \
+            dist/_boris/proof/artifacts.json \
+            public \
+            evidence/public-artifact-verification.json
+
+      - name: Bind retained evidence to this publication
+        env:
+          PAGES_BASE_URL: ${{ steps.pages.outputs.base_url }}
+          PAGES_ORIGIN: ${{ steps.pages.outputs.origin }}
+          PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: |
+          mkdir -p evidence/proof
+          cp -R dist/_boris/proof/. evidence/proof/
+          BORIS_VERSION="$(sed -n 's/.*\.version = "\([^"]*\)".*/\1/p' boris/build.zig.zon | head -1)"
+          OLIVER_REV="$GITHUB_SHA"
+          INVENTORY_SHA256="$(jq -r '.inventory_sha256' evidence/public-artifact-verification.json)"
+          PUBLIC_MANIFEST_SHA256="$(jq -r '.public_manifest_sha256' evidence/public-artifact-verification.json)"
+          PUBLIC_FILES="$(jq -r '.files' evidence/public-artifact-verification.json)"
+          PUBLIC_BYTES="$(jq -r '.bytes' evidence/public-artifact-verification.json)"
+          CHECK_FINDINGS="$(jq '.findings | length' dist/_boris/proof/checks.json)"
+          jq -n \
+            --arg base_url "$PAGES_BASE_URL" \
+            --arg origin "$PAGES_ORIGIN" \
+            --arg base_path "$PAGES_BASE_PATH" \
+            --arg source_commit "$GITHUB_SHA" \
+            --arg boris_version "$BORIS_VERSION" \
+            --arg boris_revision "${{ steps.boris-pin.outputs.revision }}" \
+            --arg oliver_revision "$OLIVER_REV" \
+            --arg workflow_ref "$GITHUB_WORKFLOW_REF" \
+            --arg workflow_sha "$GITHUB_WORKFLOW_SHA" \
+            --arg inventory_sha256 "$INVENTORY_SHA256" \
+            --arg public_manifest_sha256 "$PUBLIC_MANIFEST_SHA256" \
+            --argjson public_files "$PUBLIC_FILES" \
+            --argjson public_bytes "$PUBLIC_BYTES" \
+            --argjson check_findings "$CHECK_FINDINGS" \
+            '{
+              format: "boris-github-pages-evidence",
+              schema_version: 1,
+              publication: {
+                target: "github-pages",
+                base_url: $base_url,
+                origin: $origin,
+                base_path: $base_path
+              },
+              source: {commit: $source_commit},
+              toolchain: {
+                boris_version: $boris_version,
+                boris_revision: $boris_revision,
+                oliver_revision: $oliver_revision,
+                workflow_ref: $workflow_ref,
+                workflow_sha: $workflow_sha
+              },
+              public_artifact: {
+                inventory_path: "dist/_boris/proof/artifacts.json",
+                inventory_sha256: $inventory_sha256,
+                public_manifest_sha256: $public_manifest_sha256,
+                files: $public_files,
+                bytes: $public_bytes,
+                proof_paths_excluded: true
+              },
+              compiler_evidence: {
+                proof_root: "dist/_boris/proof",
+                checks_findings: $check_findings,
+                deployment_verification: "not-verified"
+              }
+            }' > evidence/github-pages-evidence.json
+          rm -f .boris-pages-profile.json
+
+      - name: Write the build summary
+        env:
+          PAGES_BASE_URL: ${{ steps.pages.outputs.base_url }}
+          PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: |
+          {
+            echo "## GitHub Pages publication"
+            echo ""
+            echo "- Target: github-pages / public"
+            echo "- Base URL: $PAGES_BASE_URL"
+            echo "- Base path: $PAGES_BASE_PATH"
+            echo "- Boris toolchain revision: ${{ steps.boris-pin.outputs.revision }}"
+            echo "- Public files: $(jq -r '.files' evidence/public-artifact-verification.json)"
+            echo "- Public bytes: $(jq -r '.bytes' evidence/public-artifact-verification.json)"
+            echo "- Inventory binding: $(jq -r '.inventory_sha256' evidence/public-artifact-verification.json)"
+            echo "- Compiler checks findings: $(jq -r '.compiler_evidence.checks_findings' evidence/github-pages-evidence.json)"
+            echo "- Deployment verification: not-verified (the deploy job publishes the artifact; post-deploy HTTP audit is a separate scope)"
+            echo ""
+            echo "The Pages artifact contains only verified inventory payloads. Boris proof reports are retained in the evidence artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the public Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          name: github-pages
+          path: public-site
+
+      - name: Upload retained evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: boris-github-pages-evidence-${{ github.run_id }}
+          path: evidence
+          if-no-files-found: error
+          retention-days: 90
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+      # This is an optional, separate observer. It consumes the exact plan and
+      # target-local inventory retained by build; it never mutates the public
+      # Pages artifact or rewrites target-local evidence.
+      - name: Checkout Oliver
+        if: ${{ inputs.audit_deployment == true }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Resolve Boris toolchain pin
+        id: boris-pin
+        if: ${{ inputs.audit_deployment == true }}
+        run: echo "revision=$(jq -r .revision .github/boris-pin.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned Boris observer source
+        if: ${{ inputs.audit_deployment == true }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: drawmeanelephant/boris
+          ref: ${{ steps.boris-pin.outputs.revision }}
+          path: boris
+          fetch-depth: 1
+
+      - name: Install Zig for deployment observer
+        if: ${{ inputs.audit_deployment == true }}
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Download target-local evidence
+        if: ${{ inputs.audit_deployment == true }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: boris-github-pages-evidence-${{ github.run_id }}
+          path: deployment-input
+
+      - name: Build deployment observer
+        if: ${{ inputs.audit_deployment == true }}
+        run: |
+          mkdir -p deployment-evidence
+          zig build --build-file boris/tools/github-pages-audit/build.zig -Doptimize=ReleaseSafe
+
+      - name: Observe deployed Pages
+        id: deployment_audit
+        if: ${{ inputs.audit_deployment == true }}
+        continue-on-error: true
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          test -n "$PAGE_URL"
+          test -f deployment-input/publication-plan.json
+          test -f deployment-input/proof/artifacts.json
+          mkdir -p deployment-evidence
+          AUDITED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          boris/tools/github-pages-audit/zig-out/bin/boris-github-pages-audit \
+            --plan deployment-input/publication-plan.json \
+            --inventory deployment-input/proof/artifacts.json \
+            --page-url "$PAGE_URL" \
+            --audited-at "$AUDITED_AT" \
+            --out deployment-evidence/github-pages-deployment-evidence.json \
+            --target public \
+            --repository "$GITHUB_REPOSITORY" \
+            --source-commit "$GITHUB_SHA" \
+            --workflow-ref "$GITHUB_WORKFLOW_REF" \
+            --workflow-sha "$GITHUB_WORKFLOW_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --public-artifact-name github-pages
+
+      - name: Upload deployment evidence
+        if: ${{ always() && inputs.audit_deployment == true }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: boris-github-pages-deployment-evidence-${{ github.run_id }}
+          path: deployment-evidence
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Write deployment audit summary
+        if: ${{ always() && inputs.audit_deployment == true }}
+        run: |
+          {
+            echo "## GitHub Pages post-deploy audit"
+            echo ""
+            echo '- Deployment status: succeeded (deploy-pages completed)'
+            if test -f deployment-evidence/github-pages-deployment-evidence.json; then
+              echo "- Audit result: $(jq -r '.audit.result' deployment-evidence/github-pages-deployment-evidence.json)"
+              echo "- Requests: $(jq -r '.audit.requests' deployment-evidence/github-pages-deployment-evidence.json)"
+              echo "- Completed observations: $(jq -r '.audit.observations | length' deployment-evidence/github-pages-deployment-evidence.json)"
+              echo "- Separate evidence: boris-github-pages-deployment-evidence-${GITHUB_RUN_ID}"
+            else
+              echo "- Audit evidence was not produced; inspect the observer setup/build logs."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Write the deployment summary
+        run: |
+          {
+            echo "## GitHub Pages deployment"
+            echo ""
+            echo '- Deployment status: succeeded (deploy-pages completed)'
+            echo "- Published URL: ${{ steps.deployment.outputs.page_url }}"
+            echo "- Deployment artifact: github-pages"
+            echo "- Post-deploy HTTP audit: optional; enable audit_deployment on manual dispatch"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ and renders). As a contributor, start with
 [docs/DOCUMENT-MODEL.md](docs/DOCUMENT-MODEL.md),
 [docs/FEATURE-MATRIX.md](docs/FEATURE-MATRIX.md),
 [docs/TESTS.md](docs/TESTS.md), [docs/CLEANROOM.md](docs/CLEANROOM.md),
-and [docs/WORK-LEDGER.md](docs/WORK-LEDGER.md).
+and [docs/WORK-LEDGER.md](docs/WORK-LEDGER.md). The docs tree itself
+publishes to GitHub Pages through `.github/workflows/github-pages.yml`;
+see [docs/github-pages.md](docs/github-pages.md) for how to enable and
+operate it.
 
 ## Status
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -2,7 +2,7 @@
 
 What Oliver parses and renders today on `main`. The full design
 contracts live in the per-frontend documents (see the
-[docs home](index.md)); this page is the user-facing overview.
+[docs home](index.html)); this page is the user-facing overview.
 
 ## Frontends at a glance
 
@@ -77,8 +77,8 @@ YAML). Derived operations over the same model:
 
 ## Go deeper
 
-- [Markdown docs](index.md#markdown-frontend) ·
-  [Textile docs](index.md#textile-frontend) ·
-  [Cooklang contract](COOKLANG.md)
-- [Architecture](ARCHITECTURE.md) · [Document model](DOCUMENT-MODEL.md)
-  · [Feature matrix](FEATURE-MATRIX.md) · [Tests](TESTS.md)
+- [Markdown docs](index.html#markdown-frontend) ·
+  [Textile docs](index.html#textile-frontend) ·
+  [Cooklang contract](COOKLANG.html)
+- [Architecture](ARCHITECTURE.html) · [Document model](DOCUMENT-MODEL.html)
+  · [Feature matrix](FEATURE-MATRIX.html) · [Tests](TESTS.html)

--- a/docs/FEATURE-MATRIX.md
+++ b/docs/FEATURE-MATRIX.md
@@ -91,7 +91,7 @@ Textile is a first-class dialect. Where the references disagree, Oliver
 records the disagreement and chooses one behavior (see "Recorded ambiguities"
 below).
 
-## Blocks
+## Blocks (Textile)
 
 | feature | status | Oliver behavior / notes |
 | --- | --- | --- |
@@ -113,7 +113,7 @@ below).
 
 | `clear` signature | implemented | `clear.` (clear both), `clear<.` (clear left), `clear>.` (clear right) — a lone marker line (only trailing whitespace after the period, or the `<`/`>` direction) that renders nothing; the next block to open carries `style="clear:both;"` (or `left`/`right`) in its attribute set, merged ahead of any style the block already has (Textile 2 "clear": "the next block should emit a CSS style attribute that clears any floating elements"). Applies to every block family — paragraphs, headings, block quotes, lists, tables, definition lists, footnotes, code blocks — and closes whatever block was open (an extended `bq..`/`bc..` or definition list ends at the marker; a single-period `bc.` owns the marker as code content). A dangling marker at end of input is dropped; any other shape — content after the marker, a different modifier, a word merely starting with "clear" — stays ordinary text. Pinned in docs/TEXTILE-PARITY.md §22. |
 
-## Inlines
+## Inlines (Textile)
 
 | feature | status | Oliver behavior / notes |
 | --- | --- | --- |

--- a/docs/RAW-HTML.md
+++ b/docs/RAW-HTML.md
@@ -66,7 +66,7 @@ pass finds maximal tags over the whole paragraph, and `scanLine` merges
 the two sorted lists by earliest start, dropping any construct that
 starts inside an already-accepted one. The drop rule is exactly
 first-come: `` `<a href="x">` `` is a code span (its `<` is inside the
-span), `<a href="`">` is a tag (its backtick is inside the tag).
+span), `` `<a href="`">` `` is a tag (its backtick is inside the tag).
 
 ### Tag vs autolink at `<`
 

--- a/docs/SESSION-1-REPORT.md
+++ b/docs/SESSION-1-REPORT.md
@@ -50,7 +50,7 @@ concept.
 ## Clean-room sources consulted
 
 Only specifications and user-facing documentation (full list with URLs in
-[docs/CLEANROOM.md](docs/CLEANROOM.md)):
+[docs/CLEANROOM.md](CLEANROOM.html)):
 
 - CommonMark specification 0.31.2 `spec.txt` (lines, blank lines, tabs, NUL,
   backslash escapes, ATX headings §4.2, setext §4.3, precedence).
@@ -63,7 +63,7 @@ No parser implementation source was consulted.
 
 ## Feature matrix
 
-Full matrix in [docs/FEATURE-MATRIX.md](docs/FEATURE-MATRIX.md).
+Full matrix in [docs/FEATURE-MATRIX.md](FEATURE-MATRIX.html).
 Implemented in the slice: paragraphs, ATX headings, plain text, soft/hard
 breaks, blank lines, Textile `p.`/`hN.` markers, Textile hard line breaks.
 Planned next: emphasis/strong, code spans, links, escapes, thematic breaks,

--- a/docs/contracts/github-pages-deployment-evidence.md
+++ b/docs/contracts/github-pages-deployment-evidence.md
@@ -1,0 +1,123 @@
+# GitHub Pages deployment evidence (schema v1)
+
+**Status:** normative post-deploy observation contract for the optional
+`boris-github-pages-audit` workflow step.
+
+This format is deliberately separate from both the target-local publication
+evidence and the public Pages artifact. It records what a bounded HTTP observer
+saw after `actions/deploy-pages` returned a `page_url`; it does not change the
+target-local checks, claims, limitations, Touch Atlas, Proof Pack, or public
+payload.
+
+## Producer and input boundary
+
+The standalone Zig tool under `tools/github-pages-audit/` consumes:
+
+- the normalized `boris-publication-plan` declaration;
+- the exact target-local `boris-publication-artifacts` inventory and its file
+  digest;
+- the `page_url` output from the successful Pages deployment step;
+- explicit workflow/source identity values when GitHub exposes them; and
+- explicit audit bounds and timestamp.
+
+It does not infer a repository path, domain, target, artifact list, or
+deployment identity from a repository name or URL. Missing deployment IDs and
+artifact IDs are recorded as `null`, not guessed.
+
+## Result vocabulary
+
+The root audit result and every check/observation use the closed vocabulary:
+
+| Result | Meaning |
+|---|---|
+| `passed` | The bounded check completed and all of its observations passed. |
+| `failed` | A response, location policy, byte comparison, or bounded parser check found a contradiction. |
+| `incomplete` | The check could not complete within a declared request/body/redirect/URL bound or because transport data was unavailable. |
+| `not-applicable` | The selected plan/inventory did not declare that projection or observation. |
+
+`failed` and `incomplete` are never collapsed into a successful deployment
+claim. A failed or incomplete audit still writes this report so the workflow
+can upload actionable evidence.
+
+## Location and request policy
+
+Before the first request, `page_url` must match the normalized plan origin and
+base path. A legitimate trailing slash is normalized for identity, while the
+raw URL is retained in the root observation so a Pages root redirect remains
+visible. Every redirect must be HTTP(S), contain no user information or
+fragment, remain inside the declared origin/base path, and stay below the
+redirect bound. Filesystem, `javascript:`, protocol-relative, credentialed,
+and cross-origin redirect targets are rejected.
+
+The observer sends `Accept-Encoding: identity`, never sends cookies,
+authorization, or user-provided headers, and compares decoded response bytes
+when the standard library reports a supported transfer encoding. It records
+stable response metadata useful for diagnosis (`Content-Type`, cache control,
+ETag, last-modified, content encoding, and content length), but headers are not
+artifact identity. A status code, route alias, or CDN header never substitutes
+for the committed SHA-256 and byte count.
+
+The default bounds are 256 total HTTP requests (including redirects), 8 MiB
+per decoded response body, 3 redirects per URL, a 10-second per-request
+timeout, and 256 parsed URLs per projection or HTML page. All are explicit in
+the report and can be tightened by the CLI/workflow. Inventory records are
+visited in their canonical bytewise order; truncation is deterministic and
+produces `incomplete` evidence.
+
+## Checks
+
+The observer always checks the deployment location precondition and the root
+route. For each committed inventory record within the request bound it checks
+reachability and compares status/body digest/byte count. HTML pages receive a
+bounded same-location URL and canonical/public metadata pass. Selected
+projection checks are:
+
+- sitemap `<loc>` URLs remain inside the declared location;
+- rendered-search `documents[].path` values are valid target-relative HTML
+  paths and are bounded;
+- RSS links, when an inventory record exists, remain inside the declared
+  location; and
+- absolute links in `llms.txt`, when an inventory record exists, agree with
+  the declared location.
+
+The observer does not claim universal browser reachability, all CDN cache
+variants, all possible redirects, or future deployment stability. Those
+limits are emitted as explicit `limitations` strings.
+
+## Evidence shape
+
+The machine-readable schema is
+[`github-pages-deployment-evidence-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/github-pages-deployment-evidence-1.schema.json).
+The fixed root format is:
+
+```json
+{
+  "format": "boris-github-pages-deployment-evidence",
+  "schema_version": 1,
+  "identity": {},
+  "deployment": {},
+  "binding": {
+    "plan": {"path": "publication-plan.json", "sha256": "..."},
+    "inventory": {"path": "proof/artifacts.json", "sha256": "..."}
+  },
+  "audit": {
+    "audited_at": "2026-08-11T00:00:00Z",
+    "result": "passed",
+    "requests": 1,
+    "completed_requests": 1,
+    "truncated": false,
+    "bounds": {},
+    "checks": [],
+    "observations": []
+  },
+  "limitations": []
+}
+```
+
+The deployment object records `provider: "github-pages"` separately from the
+target-local inventory name (`public` in the official workflow), so the
+platform identity and artifact-target identity cannot be confused.
+
+Object and array order is fixed by the Zig renderer. The report is an ordinary
+retained workflow artifact and must never be copied into the public Pages
+tree.

--- a/docs/contracts/index.md
+++ b/docs/contracts/index.md
@@ -1,0 +1,62 @@
+# Publication contracts
+
+The GitHub Pages workflow (`.github/workflows/github-pages.yml`) publishes
+this documentation tree with a Boris binary built from a pinned Boris
+revision. Boris treats publication as a set of normative contracts: the
+workflow generates a [publication profile](publication-profile.html),
+normalizes it into a [publication plan](publication-plan.html), compiles
+only inventory-verified payloads, and retains separate evidence of what
+was emitted, checked, and claimed.
+
+These documents are the Boris publication contracts, ported into Oliver so
+the publication pipeline is self-contained. The
+[GitHub Pages user guide](../github-pages.html) explains how to operate
+the workflow; the contracts below are the machine-readable shapes it
+relies on.
+
+## The declaration chain
+
+- [Publication profile](publication-profile.html) — schema v1 declaration
+  input: the GitHub Pages location slice (`base_url` / `origin` /
+  `base_path`), bounds, and fail-closed validation.
+- [Publication plan](publication-plan.html) — the normalized declaration
+  emitted by `boris plan --profile`: canonical JSON, fixed key order, no
+  publication side effects.
+
+## The publication model
+
+- [Publication model](publication-model.html) — the meta-contract that
+  classifies document facts, publication facts, migration provenance,
+  projections, and verification claims, and names the canonical owner of
+  each.
+
+## Target-local evidence
+
+Boris emits these reports into `dist/_boris/proof/`; the workflow retains
+them in the evidence artifact and never publishes them:
+
+- [Artifacts](publication-artifacts.html) — `artifacts.json`: the
+  committed inventory with byte counts and SHA-256 per emitted file.
+- [Checks](publication-checks.html) — `checks.json`: which checks ran and
+  their findings, bound to the committed inventory.
+- [Claims](publication-claims.html) — `claims.json`: the fixed claims and
+  limitations derived from the inventory and checks bytes.
+- [Touch Atlas](publication-touches.html) — `touches.json`: the
+  relationship index derived exclusively from the existing evidence
+  reports.
+- [Proof Pack](publication-proof-pack.html) — `proof-pack.json` +
+  `index.html`: the two-file presentation over the committed evidence.
+
+## Deployment evidence
+
+- [GitHub Pages deployment evidence](github-pages-deployment-evidence.html)
+  — the optional post-deploy audit report: a bounded HTTP observation bound
+  to the retained plan and inventory, with the closed result vocabulary.
+
+## Upstream contracts
+
+Contracts that govern Boris-side behavior outside the publication slice
+(for example `html-output.md`, `rss-2.0.md`, `xml-sitemap.md`, and
+`ir-schema.md`) are owned by the
+[Boris repository](https://github.com/drawmeanelephant/boris) and
+referenced from the [publication model](publication-model.html) contract.

--- a/docs/contracts/publication-artifacts.md
+++ b/docs/contracts/publication-artifacts.md
@@ -1,0 +1,149 @@
+# Publication artifact inventory (schema v1)
+
+**Status:** normative first runtime-evidence slice for one HTML target.
+
+The publication artifact inventory records the Boris-owned payload files that
+the HTML target transaction is about to commit. It is a declared inventory of
+committed bytes, not a proof pack, quality score, check report, or deployment
+manifest.
+
+## Output and scope
+
+Each selected HTML target publishes:
+
+```
+{target}/_boris/proof/artifacts.json
+```
+
+The inventory covers the current HTML transaction's:
+
+- HTML pages;
+- theme assets;
+- content-local page assets;
+- rendered search index; and
+- XML sitemap when sitemap publication is selected.
+
+When a hosted publication identity is configured, these generated HTML and
+sitemap bytes pass the pre-commit publication-location gate as part of the
+same transaction. The inventory records exact local target bytes; it does not
+add a deployment URL field or claim that the deployed host served them.
+
+The shared record vocabulary also reserves `rss` and `llms` kinds for a future
+coordinated HTML publication transaction. The current standalone `--rss` and
+`--llms` commands have separate publication transactions and do not write this
+HTML-target inventory. They remain separate projections rather than being
+silently inferred from their standalone outputs.
+
+IR, RAG, and Context Bundle outputs are not included in this first inventory.
+The current coordinator does not commit them in the same target transaction;
+their projection contracts remain independent.
+
+The inventory file does not inventory itself, nor any later proof-pack
+envelope, check, claim, limitation, or touch-map file. A later envelope may
+inventory evidence files as a separately versioned artifact.
+The target-local checks path, `_boris/proof/checks.json`, is reserved for the
+separate publication-checks report and is rejected as a producer-owned path.
+
+## Format
+
+The root object is `boris-publication-artifacts`, schema version `1`, with the
+fixed key order shown here:
+
+```json
+{
+  "format": "boris-publication-artifacts",
+  "schema_version": 1,
+  "target": "public",
+  "artifacts": [
+    {
+      "path": "guides/install.html",
+      "kind": "html-page",
+      "producer": "html-render",
+      "required": true,
+      "status": "committed",
+      "bytes": 4567,
+      "sha256": "lowercase-64-hex-digest",
+      "format_version": null
+    }
+  ]
+}
+```
+
+The published schema is [`publication-artifacts-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-artifacts-1.schema.json).
+Every first-slice record has these fields, in this order:
+
+| Field | Meaning |
+|---|---|
+| `path` | Target-relative path using `/`; never an absolute or staging path. |
+| `kind` | Closed stable kind name such as `html-page`, `theme-asset`, `content-asset`, `rendered-search`, `sitemap`, `rss`, or `llms`. |
+| `producer` | Plain stable producing phase name, not arbitrary prose. |
+| `required` | Whether the selected publication requires this payload. |
+| `status` | First-slice records are `committed`; the vocabulary also reserves `omitted-by-plan` and `not-applicable` for later plan-aware inventories. |
+| `bytes` | Exact byte length of the payload bytes read for the transaction. |
+| `sha256` | Lowercase hexadecimal SHA-256 of those exact bytes. |
+| `format_version` | A known producer format/schema version, or explicit `null` when the payload has no such version. |
+
+Records sort by target-relative `path` using bytewise ordering, then by `kind`
+when a future producer vocabulary permits multiple records at one path.
+Duplicate paths are rejected. Object key order, array order, path separators,
+and lowercase digest encoding are deterministic.
+
+## Authoritative collection
+
+The inventory is assembled from producer facts already held by the compiler:
+
+| Payload | Authoritative source | Byte source | Producer |
+|---|---|---|---|
+| HTML page | PageDb `output_path` | staged page, or live target for a valid incremental cache hit | `html-render` |
+| Theme asset | loaded theme asset inventory | newly staged asset | `theme-assets` |
+| Content-local asset | loaded sibling-asset inventory | newly staged asset | `content-assets` |
+| Rendered search | `search_index.output_path` | newly staged search file | `rendered-search` |
+| Sitemap | selected sitemap path | newly staged sitemap file | `sitemap` |
+
+The collector does not crawl the target directory, parse human reports, infer
+artifacts from directory names, or claim unrelated deployment-owned files.
+Generated projections and copied assets are stage-only inputs: a stale live
+file cannot satisfy a new selected record. Cached HTML is the deliberate
+exception because incremental publication reuses the exact live page bytes.
+
+Removed pages and stale assets are absent because the inventory is built from
+the current PageDb and current producer inventories, not from the previous
+target tree.
+
+## Transaction and failure behavior
+
+The inventory is collected after selected producers have staged their bytes and
+before `publishStageTree` commits the target. `artifacts.json` is itself
+atomically staged under the target-owned `_boris/proof/` namespace and then
+committed last by the same target transaction, after every other staged payload
+replacement succeeds. Therefore:
+
+- a render, asset, search, sitemap, inventory-write, or target-commit failure
+  does not replace a prior valid inventory;
+- a successful incremental build emits the complete current inventory,
+  including cached pages, rather than only dirty records;
+- a successful rebuild omits removed pages and stale assets;
+- sequential, parallel, clean, and no-change incremental builds use the same
+  producer paths and exact bytes, so their inventories are byte-identical when
+  payload bytes are identical; and
+- the inventory is deferred until the final staged payload replacement, but
+  the underlying HTML publisher is per-file rather than a whole-tree rollback
+  journal. A mid-tree target-commit failure can therefore leave an earlier
+  payload replacement visible beside the prior inventory; that failed run is
+  not a successful publication and must be rerun; and
+- the normal staged-publish and cross-volume limitations documented by the
+  [HTML output contract](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/html-output.md) continue to apply. No stronger
+  universal filesystem atomicity claim is made here.
+
+The inventory is visible with `status: "committed"` only after the surrounding
+target commit succeeds. A failed pre-commit collection or write removes only
+the current stage and leaves the previous target untouched.
+
+## Projection boundary
+
+This inventory says which Boris-owned payload bytes were committed and who
+produced them. It does not establish semantic correctness, link integrity,
+accessibility, schema conformance, deployment correctness, prose quality, or
+universal reproducibility. Those are independent checks and claims governed by
+the [publication model contract](publication-model.html) and each projection's
+own contract.

--- a/docs/contracts/publication-checks.md
+++ b/docs/contracts/publication-checks.md
@@ -1,0 +1,251 @@
+# Publication checks evidence (schema v1)
+
+**Status:** normative target-local publication evidence contract
+
+Each successful HTML target publication may emit one deterministic report at:
+
+```text
+{target}/_boris/proof/checks.json
+```
+
+The report is a bounded mechanical result for one committed target. It is not
+a proof-pack envelope, a claim engine, a limitations layer, a deployment
+check, an accessibility result, a quality score, or a reproducibility
+certificate.
+
+## Authority and transaction boundary
+
+`_boris/proof/artifacts.json` is the exclusive authority for Boris-owned
+publication payloads. Checks do not crawl the target tree, infer ownership
+from extensions or directories, or treat a deployment-owned extra file as a
+Boris subject. The report records the exact inventory bytes it parsed:
+
+```text
+path       = _boris/proof/artifacts.json
+bytes      = exact inventory byte count
+sha256     = lowercase SHA-256 of the exact inventory bytes
+format     = boris-publication-artifacts
+schema_version = 1
+target     = inventory target identity
+artifact_count = inventory record count, including non-committed records
+```
+
+The HTML publication transaction is ordered as follows:
+
+```text
+stage payloads
+→ stage artifacts.json
+→ commit payload files
+→ commit artifacts.json last
+→ run publication checks against the committed target
+→ atomically replace checks.json
+```
+
+`checks.json` is not staged with payloads and is not included in
+`artifacts.json`. A failed or incomplete check still produces a valid report.
+An inventory/parser/checker/write failure after the target commit does not
+roll back the target; it returns exit code `3` and explicitly reports that the
+publication committed but its evidence was not refreshed. Atomic report-write
+failure preserves the previous report.
+
+## Fixed report shape
+
+The root object has exactly these keys, in this order:
+
+```text
+format
+schema_version
+target
+artifact_inventory
+checks
+findings
+```
+
+The machine-readable schema is
+[`schemas/publication-checks-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-checks-1.schema.json).
+The report format is `boris-publication-checks`, with schema version `1`.
+
+`checks` contains exactly three executions, in this order:
+
+1. `artifact-integrity`
+2. `rendered-html`
+3. `rendered-search`
+
+Each execution has exactly:
+
+```text
+id
+eligible
+ran
+status
+coverage
+scope
+counts
+finding_offset
+```
+
+`status` is one of `passed`, `failed`, `incomplete`, or `not-applicable`.
+`coverage` is one of `complete`, `incomplete`, or `not-applicable`.
+
+`counts.eligible` is the number of declared subjects in the check’s selected
+scope; `counts.checked` is the number of those subjects whose bytes were read
+or whose selected check input was inspected; `counts.findings` is the number
+of root findings owned by that check. `finding_offset` is the zero-based start
+of that check’s contiguous range in the root `findings` array. Ranges appear
+in check order and do not repeat a finding.
+
+`scope` contains exactly:
+
+```text
+subject_statuses
+subject_kinds
+subject_sha256
+supporting_statuses
+supporting_kinds
+supporting_sha256
+```
+
+When both selector arrays are empty, the selected scope is empty. Otherwise an
+empty individual dimension is a wildcard for that dimension. Scope digests
+select matching records from the canonical inventory order and hash
+these exact bytes for each selected record:
+
+```text
+path NUL kind NUL bytes-decimal NUL sha256 LF
+```
+
+The selected records remain in inventory order. The SHA-256 of the empty byte
+sequence is used for an empty selected set. Complete path lists are never
+repeated inside check executions.
+
+## Check eligibility and findings
+
+### `artifact-integrity`
+
+This check is selected whenever the inventory is valid, including a valid
+zero-record inventory. Its subjects are every record with `status: committed`.
+For every subject, the checker opens the target-relative path with no-follow
+semantics, requires a regular file, compares the exact byte count, and
+compares the exact lowercase SHA-256 digest. Every successfully read mismatch
+is completely inspected and makes the check `failed`. A missing subject makes
+coverage `incomplete` and makes the check `incomplete`. Symlink, non-regular,
+unexpected access, or other system failure is a checker execution failure,
+not a normal finding.
+
+The three stable Doctor codes are:
+
+```text
+ARTIFACT_MISSING
+ARTIFACT_SIZE_MISMATCH
+ARTIFACT_DIGEST_MISMATCH
+```
+
+All three use `domain: artifact`, `severity: error`,
+`confidence: certain`, `owner: publication`, and `fixability: regenerate`.
+Every target file not named by the inventory is ignored.
+
+### `rendered-html`
+
+This check is selected for every valid inventory, including a zero-page HTML
+target. Its subjects are committed records with `kind: html-page`. The exact
+HTML bytes read by artifact integrity are passed directly to Doctor’s
+incremental `TargetAnalysisBuilder` and released after each page. Doctor keeps
+only canonical page state and derived search-document information; the checker
+does not reread or re-render HTML. The intended route-membership set is every
+committed inventory path.
+
+It reuses these Doctor findings and ownership behavior:
+
+```text
+HTML_PAGE_MISSING
+HTML_MALFORMED
+HTML_URL_MALFORMED
+HTML_LOCAL_ROUTE_MISSING
+HTML_LOCAL_ROUTE_ESCAPE
+HTML_FRAGMENT_MISSING
+HTML_DUPLICATE_ID
+```
+
+When a hosted publication location is configured, the HTML producer also runs
+the semantic publication-location gate before target commit. Its
+`EPUBLICATIONLOCATION` diagnostic covers project-site base-path omissions and
+Boris-owned canonical/public URLs with the wrong origin or path. This gate is
+part of the HTML publication transaction, not a fourth `checks` execution and
+not a new claims registry entry: a mismatch aborts target replacement, so no
+committed target-local evidence can honestly describe that output as passed.
+The three post-commit checks remain target-local and do not claim deployment or
+post-deploy HTTP behavior.
+
+A file outside the inventory cannot become a subject, create a stale finding,
+or satisfy a Boris-owned route reference. A complete scope with error or
+warning findings is `failed`; an incomplete scope is `incomplete` even when
+other findings also exist. Informational findings alone do not fail a check.
+
+### `rendered-search`
+
+This check is eligible only when the committed inventory contains exactly one
+`kind: rendered-search` record. With no such record it has:
+
+```text
+eligible: false
+ran: false
+status: not-applicable
+coverage: not-applicable
+```
+
+Search selection is not inferred from filesystem existence or the publication
+plan. Its supporting page set is every committed `html-page` record. The exact
+selected search bytes are read during integrity inspection and passed to the
+incremental Doctor analysis. It reuses:
+
+```text
+SEARCH_MISSING
+SEARCH_MALFORMED
+SEARCH_DOCUMENT_MISSING
+SEARCH_DOCUMENT_STALE
+SEARCH_CONTENT_MISMATCH
+```
+
+More than one committed `rendered-search` record is an ambiguous inventory
+selection and prevents a new report; it is not treated as a normal finding.
+
+## Status rules
+
+`passed` requires complete inspection of the entire eligible declared scope
+and no error or warning findings. `failed` means the entire eligible scope was
+inspected and at least one error or warning finding was produced. `incomplete`
+means any eligible subject could not be completely inspected; it outranks
+`failed`. `not-applicable` means the check family was not selected by the
+authoritative inventory. No findings never turns an incomplete inspection
+into `passed`.
+
+All root findings use the existing Doctor finding fields and meanings exactly:
+`code`, `domain`, `severity`, `confidence`, `owner`, `subject`, source/output/
+configuration locations, `evidence`, `remediation`, and `fixability`.
+
+## Determinism and limits
+
+For identical inventory and payload bytes, two runs produce byte-identical
+`checks.json`. The emitter uses fixed root/nested key order, fixed check order,
+canonical inventory order, existing Doctor finding order within each check,
+sorted/deduplicated related evidence, lowercase SHA-256, UTF-8 JSON, and LF
+line endings. It emits no timestamp, duration, absolute path, CWD, staging
+path, worker count, host, environment, username, PID, Git revision, or
+filesystem traversal order.
+
+Artifact payloads are processed with a fixed-size read buffer, incremental
+SHA-256, and a byte counter. At most the current HTML payload and the selected
+rendered-search payload are transiently retained; non-HTML artifacts are never
+retained as complete payloads. The inventory is parsed with a strict streaming
+parser and only canonical inventory metadata is retained. This bounds working
+memory by canonical inventory metadata, Doctor’s compact derived state, the
+selected search artifact, and report construction rather than by the sum of all
+committed payload sizes.
+
+The report establishes only what these three named checks observed within the
+declared target-local scope. It does not establish deployment behavior,
+accessibility, prose quality, universal reproducibility, or correctness of an
+omitted projection. Rendered-search `path` values are target-relative rather
+than public URLs, and IR, RAG, Context, and other non-HTML artifacts are not
+location-verified by this report unless a future contract explicitly adds a
+URL-bearing field and a named check.

--- a/docs/contracts/publication-claims.md
+++ b/docs/contracts/publication-claims.md
@@ -1,0 +1,176 @@
+# Publication claims evidence (schema v1)
+
+**Status:** normative target-local claims-and-limitations evidence contract
+
+Each successful HTML target publication may emit one deterministic report at:
+
+```text
+{target}/_boris/proof/claims.json
+```
+
+The report is a bounded mechanical derivation over the committed artifact
+inventory and publication checks evidence for one committed target. It is not
+a proof-pack envelope, a human certification, a deployment result, an
+accessibility result, a quality score, or a reproducibility certificate. It
+can only ever say what the checks observed; see
+[`publication-checks.md`](publication-checks.html) for the authority of those
+observations.
+
+## Authority and transaction boundary
+
+`_boris/proof/artifacts.json` and `_boris/proof/checks.json` are the exclusive
+inputs. The claims engine never re-reads payloads, never re-runs checks, and
+never re-derives evidence. It binds both inputs by exact bytes:
+
+```text
+artifact_inventory  : path  = _boris/proof/artifacts.json
+                      bytes = exact inventory byte count
+                      sha256 = lowercase SHA-256 of the exact inventory bytes
+                      format = boris-publication-artifacts
+                      schema_version = 1
+                      target = inventory target identity
+                      artifact_count = inventory record count
+
+publication_checks  : path  = _boris/proof/checks.json
+                      bytes = exact checks byte count
+                      sha256 = lowercase SHA-256 of the exact checks bytes
+                      format = boris-publication-checks
+                      schema_version = 1
+                      target = checks target identity
+                      check_count = check execution count
+                      finding_count = root finding count
+```
+
+The HTML publication transaction is ordered as follows:
+
+```text
+stage payloads
+→ stage artifacts.json
+→ commit payload files
+→ commit artifacts.json last
+→ run publication checks against the committed target
+→ atomically replace checks.json
+→ derive claims strictly from committed artifacts.json and checks.json bytes
+→ atomically replace claims.json
+```
+
+`claims.json` is not staged with payloads and is not included in
+`artifacts.json`. A claim derivation failure after the checks commit does not
+roll back the target or the checks report; it returns exit code `3` and
+explicitly reports that the publication committed but its claims evidence was
+not refreshed. Atomic report-write failure preserves the previous report, and
+any failure before the atomic replace leaves the prior `claims.json` untouched.
+
+Every claims derivation validates the checks report strictly before writing:
+the checks format and schema version must match the checks contract exactly,
+the checks target must equal the inventory target, the checks-embedded
+artifact digest must equal the exact current inventory bytes, the check set
+must be the fixed three in canonical order, and finding offsets and totals
+must be coherent. A stale or malformed checks report prevents a new claims
+report; it is reported as the explicit failure above, never written through.
+
+## Fixed report shape
+
+The root object has exactly these keys, in this order:
+
+```text
+format
+schema_version
+target
+artifact_inventory
+publication_checks
+claims
+limitations
+```
+
+The machine-readable schema is
+[`schemas/publication-claims-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-claims-1.schema.json).
+The report format is `boris-publication-claims`, with schema version `1`.
+
+`claims` contains exactly three derivations, in this order, each bound to the
+check of the same array position:
+
+1. `committed-artifacts-match-inventory` ← `artifact-integrity`
+2. `rendered-html-passed-declared-audit` ← `rendered-html`
+3. `rendered-search-matches-selected-html` ← `rendered-search`
+
+Each claim has exactly:
+
+```text
+id
+statement
+status
+evidence
+scope
+limitation_ids
+```
+
+`status` is one of `verified`, `failed`, or `not-verified`, derived
+mechanically from the bound check:
+
+```text
+check status      claim status    reason
+passed            verified        (absent)
+failed            failed          check-failed
+incomplete        not-verified    check-incomplete
+not-applicable    not-verified    check-not-applicable
+```
+
+`evidence` is the mechanical binding: the bound `check_id`, the check
+`status` and `coverage`, the check `counts`, the check subject and supporting
+scope digests, the SHA-256 of the exact `checks.json` bytes that the report
+was derived from, and the derivation `reason` above when the claim is not
+`verified`. `scope` repeats the check's subject/supporting status and kind
+selectors. `limitation_ids` lists every limitation that applies to the claim.
+
+`limitations` contains exactly six fixed rows, in this order:
+
+1. `target-local-only` — claims describe one selected local HTML target after
+   its commit and say nothing about any other target or environment.
+2. `no-deployment-verification` — no deployment was performed or verified.
+3. `no-accessibility-verification` — no accessibility audit was performed.
+4. `no-prose-quality-verification` — no prose, writing, or documentation
+   quality judgment was made.
+5. `no-universal-reproducibility-claim` — deterministic bytes on one recorded
+   environment are not universal reproducibility.
+6. `omitted-projections-not-certified` — an omitted or unselected projection
+   remains explicitly unverified (applies only to the rendered-search claim).
+
+Each limitation row has exactly:
+
+```text
+id
+statement
+applies_to_claims
+source
+```
+
+`source` cites the normative prose the limitation is anchored to. Claim
+`limitation_ids` and limitation `applies_to_claims` always agree: the first
+five limitations apply to every claim; the sixth applies only to
+`rendered-search-matches-selected-html`.
+
+The fixed three claims do not include a deployment-location claim. When a
+normalized hosted location is configured, `EPUBLICATIONLOCATION` is a
+pre-commit publication gate: a mismatch prevents target replacement and no
+claims report is derived for that failed output. A successful claims report
+therefore still does not certify deployment, post-deploy HTTP behavior, or
+location-free IR/RAG/Context artifacts; those artifacts currently carry no
+applicable public URL field.
+
+## Determinism and limits
+
+For identical inventory, checks, and payload bytes, two runs produce
+byte-identical `claims.json`. The emitter uses fixed root/nested key order,
+fixed claim and limitation order, canonical registry order, lowercase SHA-256,
+UTF-8 JSON, and LF line endings. It emits no timestamp, duration, absolute
+path, CWD, staging path, worker count, host, environment, username, PID, Git
+revision, or filesystem traversal order.
+
+The engine retains only canonical inventory metadata, the checks report
+vocabulary, and the report under construction; payloads are never retained.
+
+The report establishes only what the three named checks observed within the
+declared target-local scope, with the six listed limitations attached. It does
+not establish deployment behavior, accessibility, prose quality, universal
+reproducibility, or correctness of an omitted projection.

--- a/docs/contracts/publication-model.md
+++ b/docs/contracts/publication-model.md
@@ -1,0 +1,333 @@
+# Publication model: facts, provenance, projections, and claims
+
+**Status:** normative conceptual contract
+**Version:** 1 (ownership model; no artifact schema change)
+
+This is Boris’s canonical publication-model contract. It defines where a fact
+belongs and what a publication claim may mean. It complements, and does not
+replace, the artifact contracts listed in [`README.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/README.md). Those
+contracts remain authoritative for bytes, schemas, diagnostics, and producer
+behavior.
+
+This document does not define a publication-plan JSON shape, a CLI spelling, a
+new frontmatter field, a proof-pack format, or a new runtime. The current
+internal profile parser and static-plan boundary remain specified by
+[`publication-profile.md`](publication-profile.html); this contract supplies the
+semantic boundary that any profile or future coordinator must preserve.
+
+## The five vocabularies
+
+Boris keeps five kinds of statements separate:
+
+1. **Document facts** describe a document and its validated graph meaning,
+   independently of where the document is published.
+2. **Publication facts** describe one selected publication and its targets,
+   paths, settings, and output choices.
+3. **Migration provenance** records what an importer observed, proposed,
+   normalized, dropped, preserved, or sent to review.
+4. **Projections** are independently contracted artifacts derived from a
+   validated corpus and selected publication facts.
+5. **Verification claims** describe evidence and its declared limits; they are
+   not a substitute for any of the four fact owners above.
+
+Every fact has one canonical owner. A derived copy may appear in an artifact,
+report, or projection, but it must remain attributable to that owner. When two
+surfaces disagree, the canonical owner wins; a copied value is not a second
+source of truth.
+
+## Document facts
+
+Document facts are true about a document before a publication destination is
+selected. In this contract they are limited to Boris’s supported document
+grammar and graph model:
+
+- canonical entity identity and any source identity already modeled by Boris;
+- authored `title`, immediate structural `parent`, `status`, `tags`, and
+  currently supported semantic `relations`;
+- the Trunk/Satellite role derived from validated parentage;
+- the document body and validated structural references such as includes,
+  wiki-links, and other relations covered by their contracts.
+
+The exact accepted author keys and value rules remain in
+[`frontmatter.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/frontmatter.md), with identity and graph details in
+[`identity-and-paths.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/identity-and-paths.md) and [`ir-schema.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/ir-schema.md).
+This contract does not amend that grammar. In particular, it does not add
+`summary`, canonical URL, feed settings, theme selection, sitemap settings,
+deployment environment, migration confidence, source-system IDs, or arbitrary
+metadata to product frontmatter. `frontmatter.md` currently defines
+`published_at` and `summary` for existing product behavior; those fields remain
+owned by that contract and are neither added nor relocated by this change.
+
+Document facts must not vary merely because the same validated corpus is
+issued as HTML, IR, RAG, RSS, or another projection. A title may be rendered
+differently by a projection, but the projection does not become the owner of
+the title.
+
+## Publication facts
+
+Publication facts describe how a validated corpus is issued in one named
+publication. They belong to a publication profile, publication plan, target
+configuration, or equivalent coordinator-owned configuration—not to document
+frontmatter.
+
+Publication facts include:
+
+- selected content root and input format;
+- publication-profile identity and site URL, site title, and site description;
+- selected publication adapter and its resolved public location, including the
+  origin and base path used by a hosted target;
+- named HTML targets, public/non-public target status, target output roots,
+  themes, layouts, and layout rules;
+- selection and target-relative path for sitemap, RSS, and `llms.txt`;
+- selection, output root, and scope for JSON IR, RAG, and Context Bundle
+  editions;
+- target isolation, cache namespaces, staging roots, and other output-boundary
+  choices.
+
+A publication fact may change between a preview and a public issue without
+changing the document’s entity identity, parentage, or body. A site URL is
+therefore publication data even when it is later copied into a sitemap or feed.
+The copy does not make it a document fact.
+
+`PublicationPlan` is the owned semantic intent for a selected publication;
+run-only controls such as worker count, incremental mode, and quiet output
+belong to execution. The exact current parser and normalization rules are
+owned by [`publication-profile.md`](publication-profile.html). A plan may carry
+publication facts, but it must not absorb migration provenance or merge the
+schemas of the projections it selects.
+
+## Migration provenance
+
+Migration provenance explains where a proposed or converted value came from
+and how trustworthy or reviewable that conversion is. It belongs to
+migration-lab reports, ledgers, manifests, review records, or importer-owned
+sidecars.
+
+Examples include:
+
+- original source path and source-system field name;
+- original source value, source-system ID, and raw frontmatter block;
+- normalization or mapping decision and its confidence;
+- unsupported construct, dropped/preserved metadata, and manual-review reason;
+- reviewer decision and materialized-asset source/destination provenance.
+
+Provenance must not silently become product frontmatter, publication metadata,
+or graph semantics. A migration layer may propose Boris source, but it does
+not redefine Boris source grammar. Candidate Markdown is still subject to the
+closed [`frontmatter.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/frontmatter.md) and graph contracts before it is
+product input.
+
+If a migration mode writes a human-readable provenance annotation into a
+candidate body, that annotation is still lab-owned migration evidence. It is
+not a frontmatter field, a graph edge, a publication setting, or proof that the
+candidate is semantically correct. Reports and sidecars remain the authoritative
+place for structured provenance.
+
+## Projections
+
+HTML, rendered search, sitemap, RSS, IR, RAG, Context Bundle, and `llms.txt`
+are separate projections. Each consumes a validated corpus and its own
+contracted inputs. A projection may be selected or omitted without silently
+changing the contracts of the others.
+
+| Projection | Canonical artifact owner | What it establishes | What it does not establish |
+|---|---|---|---|
+| HTML site | [`html-output.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/html-output.md) | Static page/layout bytes for a target | Accessibility, deployment correctness, or quality of prose |
+| Rendered search | [`rendered-search.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/rendered-search.md) | A search artifact derived from rendered HTML | Complete site publication or semantic correctness of the HTML |
+| XML sitemap | [`xml-sitemap.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/xml-sitemap.md) | A bounded URL-discovery document for selected HTML pages | Crawling, indexing, ranking, or display by a search engine |
+| RSS 2.0 | [`rss-2.0.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/rss-2.0.md) | A feed projection for eligible dated documents | HTML availability, reader engagement, or feed submission |
+| JSON IR | [`ir-schema.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/ir-schema.md) | A versioned frozen graph and compiler report | HTML routes, theme behavior, or RAG content |
+| RAG | [`rag-export.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/rag-export.md) | A versioned retrieval-oriented corpus | Boris authoring syntax, embeddings, or answer quality |
+| Context Bundle | [`context-bundle.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/context-bundle.md) | A versioned provenance-rich context export | The HTML site, the product RAG corpus, or model judgments |
+| `llms.txt` | [`llms-txt.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/llms-txt.md) | A deterministic discovery map, with local location consistency when a hosted identity is supplied | Crawling, deployment acceptance, post-deploy HTTP behavior, or completeness |
+
+Each projection remains independently:
+
+- named and inspectable;
+- versioned where its contract requires versioning;
+- emitted only when its own selection and prerequisites permit it;
+- validated by its own rules;
+- attributable to a producing phase and input boundary; and
+- capable of being selected or omitted without being inferred from an
+  unrelated artifact.
+
+### The conductor rule
+
+The profile/plan is a conductor, not a blender. Normatively, it may select,
+order, and coordinate independently contracted projections using shared
+publication facts and a validated corpus. It must not merge their schemas,
+make one projection’s fields authoritative for another, use one artifact as
+proof that another artifact is correct, or turn an omitted projection into an
+implicit success claim.
+
+For a hosted issue, the normalized publication location is one shared
+publication fact. Applicable URL-bearing projections consume the same
+`base_url`, `origin`, and `base_path`; disagreement is a publication failure.
+This local invariant covers generated HTML/public metadata, sitemap, RSS, and
+location-aware `llms.txt` output. Rendered-search v1, IR, RAG, and Context
+currently use target-relative/source/entity paths and therefore have no public
+URL assertion to verify. None of these local checks is a post-deploy test.
+
+Standalone output modes retain their separate contracts. If a future
+coordinator composes them, composition is an orchestration boundary only; it
+does not create a new blended artifact contract unless that contract is named,
+versioned, and separately specified.
+
+### Analysis is not another publication
+
+Read-only analysis surfaces such as `check`, `impact`, generated-output link
+audits, publication checks, and Doctor are checks or reports, not publication
+projections. [`documentation-intelligence.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/documentation-intelligence.md)
+owns the shipped graph-health and impact analysis contract, while
+[`publication-checks.md`](publication-checks.html) owns target-local publication
+evidence and [`publication-claims.md`](publication-claims.html) owns the
+mechanical claims-and-limitations derivation over that evidence. An analysis
+result may be evidence for a named claim within its scope, but it does not
+become HTML, IR, RAG, or deployment metadata and it cannot silently certify an
+omitted projection.
+
+The [Publication Touch Atlas](publication-touches.html) is downstream evidence
+indexing, not another publication or verification layer. It may link only
+records already declared by `artifacts.json`, `checks.json`, and
+`claims.json`; it must not invent source, phase, runtime, deployment, or
+transformation relationships. Its first slice is implemented and derives
+`touches.json` exclusively from those committed evidence bytes.
+
+The [Publication Proof Pack](publication-proof-pack.html) is downstream
+evidence presentation, not another publication or verification layer. It may
+present only records already declared by `artifacts.json`, `checks.json`,
+`claims.json`, and `touches.json`; it must not rerun checks, reread payloads,
+or upgrade evidence status. Its first slice is implemented and emits the
+deterministic pair `proof-pack.json` and `index.html` after the Touch Atlas
+commits.
+
+## Verification vocabulary and claims
+
+The following terms describe evidence. They are vocabulary, not a proof-pack
+implementation and not a quality score.
+
+| Term | Normative meaning |
+|---|---|
+| **configured** | Selected by the publication plan or invocation; execution has not necessarily begun. |
+| **attempted** | Execution of the selected operation began. This does not mean an artifact was produced. |
+| **emitted** | The producing phase wrote an artifact to its declared output boundary. Existence alone is not semantic validation. |
+| **checked** | A named mechanical verification completed against a declared input and scope. |
+| **passed** | The named check observed no failure within its declared scope and inputs. |
+| **verified** | A specific claim is supported by named evidence from completed checks; the claim inherits their scope and limits. |
+| **not verified** | The available evidence did not establish the claim. |
+| **failed** | Evidence contradicts the claim or the named check reported a failure. |
+| **limited** | The named check passed, but a declared boundary, exception, or untested dimension remains. |
+
+Evidence for a verified claim must identify the claim, check, input/artifact
+boundary, scope, and result. Boris must never invent evidence for a check that
+did not run. A configured or attempted operation is not an emitted artifact;
+an emitted artifact is not automatically checked; a passed check is not
+automatically a universal claim.
+
+The following distinctions are mandatory:
+
+- artifact existence is not semantic correctness;
+- link integrity is not accessibility;
+- schema conformance is not prose quality;
+- deterministic bytes on one recorded environment are not universal
+  reproducibility;
+- successful generation is not proof of deployment correctness; and
+- absence of detected problems is not proof of excellence.
+
+When a check passes but its boundary remains, report the result as **limited**
+and name the boundary. Do not upgrade a limited result to verified excellence,
+and do not use a projection’s successful generation as evidence for another
+projection or for deployment.
+
+## Ownership matrix
+
+The matrix is a routing aid; the linked contract remains normative for each
+artifact or grammar detail.
+
+| Fact or decision | Canonical owner | Authored or derived | Publication-specific | Migration-only | Allowed in frontmatter | Evidence implications |
+|---|---|---|---:|---:|---:|---|
+| Entity `id` and source-path identity | [`identity-and-paths.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/identity-and-paths.md) | Authored override or path-derived | No | No | `id` only | Identity and collision checks must name the source path. |
+| `title` | [`frontmatter.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/frontmatter.md) | Authored | No | No | Yes | Parser acceptance; projections may copy it. |
+| `parent` and Trunk/Satellite role | [`frontmatter.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/frontmatter.md), [`ir-schema.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/ir-schema.md) | Parent authored; role derived | No | No | `parent` only | Graph validation and freeze establish topology. |
+| `status`, `tags`, and semantic `relations` | [`frontmatter.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/frontmatter.md), [`semantic-relations.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/semantic-relations.md) | Authored | No | No | Yes, when contracted | Eligibility and relation checks are projection-specific. |
+| Body and validated structural references | [`includes-and-wiki-links.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/includes-and-wiki-links.md), [`components.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/components.md), [`ir-schema.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/ir-schema.md) | Authored then validated/derived | No | No | Body, not frontmatter | Link/include/render checks must state their scope. |
+| Content root and input format | [`publication-profile.md`](publication-profile.html) | Configured | Yes | No | No | Configuration is not evidence of attempted publication. |
+| Selected publication adapter and resolved public location | [`publication-profile.md`](publication-profile.html), [`publication-plan.md`](publication-plan.html) | Configured/derived | Yes | No | No | Location identity is not deployment verification. |
+| Site URL, site title, and description | [`rss-2.0.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/rss-2.0.md), [`xml-sitemap.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/xml-sitemap.md), profile plan | Configured | Yes | No | No | URL/schema checks do not prove deployment. |
+| Target, public status, theme, layout, and output root | [`multi-target-isolated-output.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/multi-target-isolated-output.md), [`templating-and-themes.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/templating-and-themes.md), profile plan | Configured/derived | Yes | No | No | Isolation and render checks are target-scoped. |
+| Sitemap, RSS, `llms.txt`, IR, RAG, and Context selection | Each projection contract; profile plan for selection | Configured | Yes | No | No | Each emitted artifact needs its own check and claim. |
+| Staging, cache namespace, and target isolation | [`html-output.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/html-output.md), [`multi-target-isolated-output.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/multi-target-isolated-output.md) | Derived from publication config | Yes | No | No | Atomicity and platform limits remain qualified. |
+| Original source path, field, value, and source-system ID | Migration-lab mode/report | Observed | No | Yes | No | Preserve raw evidence and source boundary. |
+| Normalization, mapping, confidence, and unsupported construct | Migration-lab ledger/report | Derived decision | No | Yes | No | Review status and confidence are not product semantics. |
+| Dropped/preserved metadata, assets, and reviewer decision | Migration-lab report/manifest/sidecar | Reviewed decision | No | Yes | No | Record the disposition; do not infer success from omission. |
+| Deployment environment and post-deploy behavior | External host/deployment owner | Observed externally | Yes | No | No | Local generation cannot verify it. |
+| Check result and claim status | The check’s artifact contract plus this vocabulary | Derived evidence | No | No | No | Name the check, scope, result, and limitation. |
+| Touch Atlas relationships | [`publication-touches.md`](publication-touches.html) | Derived index over existing evidence | No | No | No | Links existing evidence only; it does not create a new verification claim. |
+
+## Placement examples
+
+### Correct placements
+
+1. A page title is a document fact. Author it as `title` under the closed
+   [`frontmatter.md`](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/frontmatter.md) grammar; an HTML layout, IR node, or RAG
+   row may derive a representation from it.
+2. `https://docs.example.com` is a publication fact. Put it in the selected
+   publication configuration used by the public target and its sitemap/feed
+   contracts, not on every page.
+3. “Derived from Astro `description` with medium confidence” is migration
+   provenance. Keep the source field, original value, mapping decision, and
+   confidence in the migration report/ledger or importer sidecar; review any
+   proposed Boris field against the product grammar before emission.
+
+### Anti-examples: frontmatter fondue
+
+The following undifferentiated block is invalid product frontmatter. The
+unknown keys must not be accepted merely because an importer found them:
+
+```text
+---
+title: Intro
+site_url: https://docs.example.com
+theme: dark
+rss_limit: 20
+migration_confidence: medium
+source_system_id: astro:docs:intro
+---
+```
+
+Move `site_url`, `theme`, and `rss_limit` to publication configuration;
+`migration_confidence` and `source_system_id` belong in migration provenance.
+Only the document-owned `title` belongs in this example’s frontmatter.
+
+This block is also wrong even if an importer calls every value “metadata”:
+
+```text
+---
+title: Intro
+canonical_url: https://docs.example.com/intro
+deployment: production
+source_field: description
+source_value: A short source summary
+reviewer_decision: accepted
+---
+```
+
+The canonical URL and deployment choice are publication/deployment facts; the
+source field/value and reviewer decision are migration provenance. None may be
+silently promoted into the document grammar by a migration adapter.
+
+## Change and compatibility rules
+
+- Adding or changing a document fact requires the owning frontmatter, identity,
+  graph, or semantic-relation contract and its focused fixtures.
+- Adding or changing a publication fact belongs in the profile/target contract
+  or the affected projection contract; it must not widen page frontmatter.
+- Adding migration evidence belongs in the owning lab/report contract and must
+  preserve the distinction between observed source data and proposed Boris
+  source.
+- Changing a projection’s bytes, schema, eligibility, or producer phase
+  requires that projection’s contract and any applicable version bump. A
+  coordinator change alone does not merge projection contracts.
+- Adding a verification report or proof-pack surface is separate implementation
+  work. Until it exists, documentation may describe evidence vocabulary but
+  must not claim that a proof pack, artifact inventory, or new check ran.

--- a/docs/contracts/publication-plan.md
+++ b/docs/contracts/publication-plan.md
@@ -1,0 +1,134 @@
+# Publication plan (schema v1)
+
+**Status:** normative first declaration slice. `boris plan --profile PATH`
+reads one explicitly selected local publication profile, normalizes it through
+the owned `PublicationPlan`, validates that plan with the existing profile
+validator, and writes one canonical JSON declaration to stdout. It does not
+compile or publish any projection.
+
+## CLI
+
+```text
+boris plan --profile PATH
+```
+
+`PATH` is required and is the only profile-selection mechanism. The selected
+profile is read relative to the invocation CWD when it is relative; its
+workspace is the normalized parent of the selected profile path, as defined by
+the [publication-profile contract](publication-profile.html). The profile path
+and absolute workspace are never fields in the declaration.
+
+The existing profile-mode publication overrides are available on this command:
+
+- `--input PATH` overrides the normalized content input.
+- `--textile` and `--cooklang` each override the normalized input format;
+  they are mutually exclusive, and supplying both is a usage conflict.
+- `--html-dir PATH` overrides the HTML output when the profile has exactly one
+  HTML target.
+
+The existing execution controls `--jobs`, `--incremental`, and `--quiet` may be
+accepted for grammar compatibility, but they remain `PublicationExecution`
+state and are never plan identity. Other output selectors and commands are
+usage conflicts. `--out` keeps its existing IR meaning and is not an alias for
+the plan declaration.
+
+The command emits JSON only after profile reading, normalization, override
+application, validation, and complete rendering succeed. Invalid profile
+syntax, unknown or duplicate keys, invalid paths, target conflicts, missing
+public-artifact metadata, and invalid overrides produce exit code `2` and no
+declaration on stdout. Profile read failures, allocation failures, and stdout
+I/O failures use the established exit code `3` path. This slice has no plan-file
+output flag, so it cannot replace a prior plan artifact.
+
+## Canonical artifact
+
+The JSON format is `boris-publication-plan`, schema version `1`. The published
+machine-readable schema is
+[`publication-plan-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-plan-1.schema.json).
+All root, target, projection, and edition keys are emitted in the fixed order
+shown below; object-key order in the source profile has no effect.
+
+```json
+{
+  "format": "boris-publication-plan",
+  "schema_version": 1,
+  "input": "content",
+  "input_format": "markdown",
+  "site": null,
+  "targets": [],
+  "editions": {
+    "ir": null,
+    "rag": null,
+    "context": null
+  }
+}
+```
+
+`input_format` renders as `markdown`, `textile`, or `cook`.
+
+Optional normalized values use explicit `null` so consumers can compare a
+complete plan shape without guessing whether a field was omitted. The optional
+`publication` object is emitted between `site` and `targets` when the selected
+profile declares a GitHub Pages target:
+
+```json
+"publication": {
+  "target": "github-pages",
+  "base_url": "https://owner.github.io/boris",
+  "origin": "https://owner.github.io",
+  "base_path": "/boris",
+  "site_kind": "project-site"
+}
+```
+
+The location is normalized and cross-checked by the profile parser; it is not
+a deployment result. A target is
+an HTML target (`projections.html` is always `true`) and carries normalized
+`name`, `output`, `public`, `theme`, `layout`, and ordered `layout_rules`.
+Configured sitemap, RSS, and `llms.txt` projections appear under
+`projections`; absent projections are `null`. RSS `limit` and RAG
+`bundles_only` contain the defaults established during profile normalization.
+The current profile model has no search projection field, so this artifact does
+not invent one.
+
+The `editions` object reports the selected IR, RAG, and Context configurations.
+It does not execute them and does not report their emitted files.
+
+## Normalization and determinism
+
+The renderer accepts a borrowed `PublicationPlan`, never raw `std.json` values
+or argv slices. Profile parsing owns strings and rules, applies the existing
+override precedence, sorts targets by canonical name, and keeps the established
+semantic layout-rule order. The renderer does not re-sort or infer fields.
+
+The bytes are deterministic for equivalent normalized plans: fixed UTF-8 JSON,
+LF line endings, fixed object-key order, canonical target/rule order, and
+escaping through Boris's shared `json_out` helper. No timestamps, host data,
+usernames, process IDs, environment values, absolute paths, temporary names,
+Git revisions, or publication-success claims are emitted.
+
+The declaration contains publication identity and selected projection
+configuration only. It excludes `jobs`, `quiet`, `incremental`, temporary
+staging names, and runtime worker decisions. It also excludes content scan
+results, graph compilation, artifact inventories, file digests, checks, claims,
+limitations, touch maps, quality scores, deployment status, environment URLs,
+HTTP responses, and any claim that a Pages artifact was accepted or served.
+
+The normalized publication identity is also the runtime source of truth for
+location-aware HTML, sitemap, RSS, and `llms.txt` producers when a coordinator
+executes the plan. This declaration itself does not run those producers or
+their local URL gates; it is not deployment verification. IR, RAG, Context,
+and rendered-search v1 currently have no applicable public URL field.
+
+## Side-effect and future-evidence boundary
+
+`plan` performs no content scan, graph compilation, HTML render, IR/RAG/Context
+export, sitemap/RSS/search/llms publication, network access, source mutation,
+target-directory creation, or cache creation. A successful output means only
+that Boris has a declared and statically validated normalized plan.
+
+This declaration is not proof, evidence, verification, or a success report.
+Future publication-evidence or proof-pack artifacts may refer to a plan as the
+declared configuration they assessed, but they must separately describe what
+was emitted, which checks passed, what claims were verified, and what touched
+the output. Those later artifacts must not be silently folded into this schema.

--- a/docs/contracts/publication-profile.md
+++ b/docs/contracts/publication-profile.md
@@ -1,0 +1,140 @@
+# Publication profile (schema v1, GitHub Pages declaration slice)
+
+**Status:** normative parser and static-plan contract. Boris accepts an
+explicit profile only through the stdout-only `boris plan --profile PATH`
+declaration command; profile execution is not available in this slice. The
+internal API and plan command parse and validate a selected local profile only;
+they do not discover content, create outputs, read environment variables,
+contact a network service, or invoke a publisher. See the
+[publication-plan contract](publication-plan.html) for the declaration format.
+
+## Selected profile workspace
+
+A caller explicitly selects one profile file. Its path is normalized against
+the invocation CWD and the normalized parent directory is the profile
+workspace root. Every path in the profile, and every future profile-mode CLI
+path override, is workspace-relative. Absolute paths, drive-rooted paths,
+backslashes, empty segments, `.` segments, and `..` segments are rejected.
+There is no Git-root, package-root, parent-directory, or conventional-file-name
+discovery. Legacy no-profile invocations retain their CWD-relative behavior.
+
+The parsed plan stores only canonical workspace-relative paths; the owned
+workspace root carries the absolute path used by a future coordinator.
+
+## Strict JSON and bounds
+
+The profile is UTF-8 JSON with no embedded NUL. The Boris parser rejects
+malformed JSON, comments, trailing data, coercion, duplicate keys, and unknown
+keys at every object level. Duplicate rejection is a Boris parser requirement;
+the companion JSON Schema cannot express it alone.
+
+| Bound | Value |
+|---|---:|
+| Profile bytes | 262,144 |
+| JSON nesting | 16 containers |
+| Decoded string bytes | 4,096 |
+| Path bytes | 1,024 |
+| Targets | 32 |
+| Any supported array | 256 |
+| Layout rules per target | 256 |
+| Target-name bytes | 64 |
+| Site title/description bytes | 1,024 |
+
+Crossing a bound fails before a plan is returned. `schema_version` is an exact
+non-negative integer `1`; floats, negative values, and integer overflows do
+not coerce to it.
+
+## Schema v1
+
+The root has exactly these fields:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `format` | yes | Exact string `boris-publication-profile` |
+| `schema_version` | yes | Exact integer `1` |
+| `input` | no | Content root, default `content` |
+| `input_format` | no | `markdown` (default), `textile`, or `cook` |
+| `site` | no | Closed `url`, `title`, `description` object |
+| `publication` | no | Closed publication-target declaration; currently `github-pages` only |
+| `targets` | no | Closed HTML-target array |
+| `editions` | no | Closed `ir`, `rag`, `context` object |
+
+When present, `publication` requires exactly one `public` HTML target. Its
+closed fields are:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `target` | yes | Exact string `github-pages` |
+| `base_url` | yes | Normalized public URL, including the project-site path when applicable |
+| `origin` | yes | Normalized scheme and authority with no path |
+| `base_path` | yes | `/repo` for a project site, or the empty string for a root/custom-domain site |
+
+Boris normalizes trailing slashes, requires `base_url == origin + base_path`,
+and rejects origin/path contradictions. A `github.io` origin with a non-empty
+path is classified as a project site; a pathless `github.io` origin is a root
+site; any other pathless valid origin is classified as a custom domain. Custom
+domains with a non-empty base path are rejected because this declaration does
+not guess at CNAME or host configuration. If `site.url` is supplied, it must
+equal the normalized publication `base_url`; this prevents sitemap/RSS and
+Pages metadata from silently naming different locations.
+
+Each target requires `name` and `output`; optional fields are `public`, exactly
+one of `theme`/`layout`, `layout_rules`, `sitemap`, `rss`, and `llms`.
+`layout_rules` entries contain exactly `selector` and `layout` and use the
+existing closed selector grammar and canonical ordering. A target's `sitemap`,
+`rss`, and `llms` objects respectively allow only `path`, `path`/`limit`, and
+`path`. Project editions require `output`; RAG also accepts `scope`,
+`split_size`, and `bundles_only`, while Context accepts `scope` and
+`split_size`.
+
+URL validation is the existing bounded RSS/sitemap HTTP(S) grammar. Sitemap,
+RSS, and llms paths are target-relative and use the existing compiler-owned
+namespace protections. At least one HTML target or machine edition is required.
+
+## Normalization, ownership, and overrides
+
+`PublicationPlan` is owned immutable-semantic publication intent: input,
+format, metadata, canonical targets/rules, and selected editions. It owns every
+string and rule slice; no raw JSON node, JSON key slice, or argv view crosses
+the parser boundary. `PublicationExecution` separately contains `jobs`,
+`incremental`, and `quiet`; those controls are deliberately absent from plan
+identity.
+
+Targets sort by name; layout rules sort by existing selector canonical order.
+Object-key order has no semantic effect. `ProfileOverrides` retains omitted
+versus explicit state. Precedence is compiled profile defaults, then selected
+profile values, then explicit profile-mode overrides; static validation runs
+again after overrides. A global HTML output override is rejected when a profile
+contains multiple targets. A GitHub Pages declaration remains configuration;
+it is not evidence that a deployment occurred.
+
+## Static validation and the deferred boundary
+
+Before discovery, Slice 1 validates discriminator/version, types and bounds,
+site requirements, unique target names, at most one public target, public
+artifact placement, theme/layout exclusivity, selector rules, lexical path
+containment, target/edition/input/layout/theme overlaps, machine-root
+separation, target-local public-artifact collisions, and known compiler-owned
+roots (`.boris-cache`, `_boris/search`).
+
+Dynamic ownership validation is deliberately deferred: it requires the
+discovered content, layouts, assets, routes, and staged output inventory to
+detect page/asset/derived-route collisions, actual filesystem conflicts, and
+symlink races. This slice performs no publication, so it cannot claim those
+checks or commit semantics. URL projection audits, deployment verification,
+and post-deploy HTTP checks remain outside the profile parser and plan
+declaration. Runtime HTML/RSS/llms coordinators may consume the normalized
+profile identity as one shared `{base_url, origin, base_path, site_kind}`
+value; any applicable local URL disagreement is then a publication failure,
+while artifacts with no public URL field remain explicitly not applicable.
+
+## Offline and availability boundary
+
+Profile parsing is local, deterministic, and offline. URLs are strings to
+validate, never endpoints to probe. There are no includes, aliases,
+expressions, environment substitution, network access, plugins, deployment
+settings, secrets, watch configuration, source-RAG, migration labs, or generic
+tasks in schema v1. The plan CLI is intentionally a declaration surface rather
+than a publication coordinator. Full profile execution remains deferred until
+a coordinator can execute every configured entry without silently ignoring any
+of them.

--- a/docs/contracts/publication-proof-pack.md
+++ b/docs/contracts/publication-proof-pack.md
@@ -1,0 +1,631 @@
+# Publication Proof Pack (schema v1)
+
+**Status:** implemented and shipped (first slice)
+
+The Proof Pack is the presentation and packaging layer over Boris's committed
+publication evidence. The Touch Atlas connects the evidence; the Proof Pack
+makes that evidence understandable and portable without creating new
+verification.
+
+Boris emits the deterministic pair `_boris/proof/proof-pack.json` and
+`_boris/proof/index.html` as the final presentation layer after the Touch
+Atlas commits. The runtime requirements below are enforced by compiler and
+fixture tests; see the implementation map at the end of this document.
+
+## Purpose
+
+The Proof Pack must let a human answer:
+
+```text
+What was published?
+What was checked?
+What passed, failed, remained incomplete, or was not applicable?
+Which claims are supported?
+Which limitations constrain those claims?
+How do those facts connect?
+What evidence files were used?
+```
+
+It is a presentation and packaging layer over committed evidence. It is a
+deterministic two-file target-local pair: an authoritative JSON presentation
+model and a static HTML rendering derived exclusively from that model.
+
+### Non-claims
+
+The Proof Pack must not:
+
+- rerun checks;
+- reread payloads;
+- inspect deployment state;
+- infer source provenance;
+- claim accessibility;
+- claim prose quality;
+- claim universal reproducibility;
+- repair anything; or
+- upgrade evidence status.
+
+The Proof Pack is downstream of the evidence chain. It copies, binds, and
+presents; it never re-observes. A rendered page cannot make a failed or
+incomplete check look successful, and a pretty summary is not a new
+verification claim.
+
+## Outputs
+
+Define two target-local outputs:
+
+```text
+_boris/proof/proof-pack.json
+_boris/proof/index.html
+```
+
+- `proof-pack.json` is the authoritative deterministic presentation model.
+- `index.html` is a deterministic static rendering derived exclusively from
+  that model.
+
+Neither output belongs in `artifacts.json`, because both are downstream
+evidence presentation owned by Boris. The reserved-path guard that rejects
+`_boris/proof/touches.json` as a producer-owned inventory path must also
+reject `_boris/proof/proof-pack.json` and `_boris/proof/index.html`.
+
+## Exclusive inputs
+
+The Proof Pack may read only the exact committed bytes of:
+
+```text
+_boris/proof/artifacts.json
+_boris/proof/checks.json
+_boris/proof/claims.json
+_boris/proof/touches.json
+```
+
+It must bind each by:
+
+```text
+path
+bytes
+sha256
+format
+schema_version
+target
+```
+
+The Touch Atlas binding must itself resolve to the same exact artifacts,
+checks, and claims bytes: `touches.json` embeds its own `inputs` bindings, and
+the Proof Pack must verify that those three bindings agree byte-for-byte with
+the Proof Pack's own `artifacts`, `checks`, and `claims` bindings. The four
+inputs are committed evidence reports; no payload, source, cache, deployment,
+or target-tree traversal is allowed.
+
+## `proof-pack.json` root
+
+Define this exact root order:
+
+```text
+format
+schema_version
+target
+inputs
+summary
+artifacts
+checks
+findings
+claims
+limitations
+relationships
+presentation
+```
+
+Identity:
+
+```text
+format: boris-publication-proof-pack
+schema_version: 1
+```
+
+The root object has exactly these keys. Canonical member ordering is assigned
+to the runtime serializer, exact-byte golden tests, and HTML/JSON parity
+tests; the schema enforces the exact key set and structural vocabulary, not
+object property order (JSON Schema Draft 2020-12 does not enforce member
+order). The machine-readable schema is
+[`schemas/publication-proof-pack-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-proof-pack-1.schema.json).
+
+## Input bindings
+
+`inputs` is an object with exactly these keys, in this order:
+
+```text
+artifacts
+checks
+claims
+touches
+```
+
+Each binding copies the report identity and includes the exact byte binding
+fields. The digest is lowercase SHA-256 of the exact committed report bytes,
+not of parsed or reserialized JSON.
+
+```json
+{
+  "artifacts": {
+    "path": "_boris/proof/artifacts.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-artifacts",
+    "schema_version": 1,
+    "target": "public",
+    "artifact_count": 0
+  },
+  "checks": {
+    "path": "_boris/proof/checks.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-checks",
+    "schema_version": 1,
+    "target": "public",
+    "check_count": 3,
+    "finding_count": 0
+  },
+  "claims": {
+    "path": "_boris/proof/claims.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-claims",
+    "schema_version": 1,
+    "target": "public",
+    "claim_count": 3,
+    "limitation_count": 6
+  },
+  "touches": {
+    "path": "_boris/proof/touches.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-touches",
+    "schema_version": 1,
+    "target": "public",
+    "node_count": 0,
+    "edge_count": 0
+  }
+}
+```
+
+Counts are mechanically derived from the parsed input reports and validated
+against the embedded bindings:
+
+```text
+artifact_count   = artifacts.json artifacts array length
+check_count      = checks.json checks array length
+finding_count    = checks.json findings array length
+claim_count      = claims.json claims array length
+limitation_count = claims.json limitations array length
+node_count       = touches.json nodes array length
+edge_count       = touches.json edges array length
+```
+
+They do not replace validation of the actual arrays and bindings.
+
+## Summary
+
+The summary must be entirely mechanical. Every number is derived by counting
+the presentation rows or by an ordered status comparison — never by a new
+observation.
+
+Include:
+
+```text
+artifact totals by status and kind
+check totals by status and coverage
+finding totals by severity
+claim totals by status
+limitation count
+relationship node count
+relationship edge count
+overall presentation status
+```
+
+### Overall presentation status
+
+The overall presentation status is **not** a new verification claim. It is a
+closed mechanical vocabulary:
+
+```text
+verified
+attention-required
+incomplete
+not-applicable
+```
+
+It is derived by this exact ordered rule set, using only the check and claim
+statuses copied from the committed evidence:
+
+1. If every check status is `not-applicable`, the status is `not-applicable`.
+2. Otherwise, if any check status is `incomplete`, the status is
+   `incomplete`.
+3. Otherwise, if any check status is `failed`, or any claim status is
+   `failed`, or any claim status is `not-verified`, the status is
+   `attention-required`.
+4. Otherwise, the status is `verified` (every check is `passed` and every
+   claim is `verified`).
+
+A single failed or incomplete check, or a single failed or not-verified
+claim, is sufficient to leave `verified`. The derivation never upgrades a
+claim or check, and it never invents a pass. The same derivation is used for
+both the JSON `summary` and the HTML banner; a mismatch between the two is an
+implementation defect.
+
+Under the fixed v1 check registry, the `not-applicable` overall status is
+unreachable in practice: `artifact-integrity` and `rendered-html` are always
+applicable for a valid inventory, so "every check not-applicable" cannot
+occur. The term remains part of the closed vocabulary for future registries
+and degenerate inventories, and rule 1 keeps the derivation total. A
+`not-applicable` check that produces a `not-verified` claim therefore
+resolves to `attention-required`, never to `not-applicable`.
+
+Avoid words such as:
+
+```text
+healthy
+excellent
+safe
+correct
+production-ready
+```
+
+unless they are part of an explicitly quoted upstream claim.
+
+## Artifact presentation rows
+
+For every artifact inventory record, include:
+
+```text
+inventory_index
+path
+kind
+status
+required
+bytes
+sha256
+related_check_ids
+related_claim_ids
+```
+
+For non-committed records, omit unavailable committed-byte properties exactly
+as required by the artifact contract rather than inventing zero values:
+`bytes` and `sha256` are present only for `status: committed` records and are
+omitted for `omitted-by-plan` and `not-applicable` records.
+
+Relationships must come from `touches.json`, not be independently recomputed
+from selectors:
+
+- `related_check_ids` lists the check IDs of every check the artifact is a
+  subject of or a supporting input for, via `artifact-subject-of-check` and
+  `artifact-supports-check` edges.
+- `related_claim_ids` lists the claim IDs supported by those checks via
+  `check-supports-claim` edges, restricted to the checks related to this
+  artifact.
+
+Rows keep canonical artifact-inventory order, including non-committed
+records.
+
+## Check presentation rows
+
+For each fixed check:
+
+```text
+check_index
+check_id
+status
+coverage
+eligible
+ran
+counts
+finding_ids
+subject_artifact_ids
+supporting_artifact_ids
+supported_claim_ids
+```
+
+- `counts` copies the check's `counts` object (`eligible`, `checked`,
+  `findings`).
+- `finding_ids` lists the finding node IDs in that check's contiguous
+  `finding_offset`/`counts.findings` range, in root finding order.
+- `subject_artifact_ids` and `supporting_artifact_ids` come from
+  `artifact-subject-of-check` and `artifact-supports-check` edges.
+- `supported_claim_ids` comes from `check-supports-claim` edges.
+
+Do not summarize a failed or incomplete check as successful merely because
+the Proof Pack rendered without error. Status and coverage are copied
+verbatim; no rendering success may upgrade them.
+
+## Finding presentation rows
+
+The root `findings` array appears immediately after `checks`, before `claims`.
+For each finding:
+
+```text
+finding_index
+finding_id
+check_id
+code
+severity
+subject
+```
+
+`finding_id` is the Touch Atlas node ID (`finding:<check id>:<ordinal>`), and
+`subject` is the closed subject object copied from the finding. Do not infer
+a finding-to-artifact relationship from path resemblance; v1 deliberately
+creates no finding-to-artifact edge.
+
+The ordered array must correspond exactly to root finding order in
+`checks.json`. The runtime must prove all of the following before the model
+is valid:
+
+- `findings.length` equals the `checks` input binding's `finding_count`;
+- every check's `finding_ids` exactly selects its contiguous
+  `finding_offset`/`counts.findings` range, with no overlap or omission
+  across the root array;
+- every finding row's node ID exists in the Touch Atlas `nodes`, and the
+  owning check's `check-reported-finding` edge exists in the Touch Atlas
+  `edges`; and
+- no finding row is invented (from path resemblance or any other guess) and
+  no committed finding is omitted.
+
+The check rows and the root `findings` array must agree with each other and
+with the checks evidence: root finding order is authoritative, and each
+check's `finding_ids` is a range selector, not an independent list.
+
+## Claim presentation rows
+
+For each claim:
+
+```text
+claim_index
+claim_id
+statement
+status
+evidence_check_id
+limitation_ids
+```
+
+The statement and status must be copied exactly from claims evidence. No
+rendering, summary, or presentation decision may reword a statement or
+upgrade a status.
+
+## Limitation presentation rows
+
+For each limitation:
+
+```text
+limitation_index
+limitation_id
+statement
+source
+applies_to_claim_ids
+```
+
+Limitations must remain visible even when all claims are verified. The clean
+example proves this: all six limitations are rendered in the clean case. The
+HTML must show limitations in the verified presentation, not only when
+attention is required.
+
+## Relationships
+
+Do not copy the complete Touch Atlas graph blindly. Define a compact
+presentation index that preserves exact node and edge IDs while grouping
+relationships for convenient rendering.
+
+`relationships` is an object with:
+
+```text
+node_ids
+groups
+```
+
+- `node_ids` is the ordered list of every Touch Atlas node ID, in the Touch
+  Atlas canonical node order.
+- `groups` is an array of edge-kind groups, in the fixed v1 edge-kind order
+  (`target-owns-artifact`, `artifact-subject-of-check`,
+  `artifact-supports-check`, `check-reported-finding`,
+  `check-supports-claim`, `claim-limited-by`). Each group has the edge kind
+  and its edges as `{ "from": node-id, "to": node-id }` pairs.
+
+Node IDs are the closed Touch Atlas stable-ID vocabulary: `target`,
+`artifact:<artifact path>`, `check:<check id>`,
+`finding:<owning check id>:<ordinal>`, `claim:<claim id>`, and
+`limitation:<limitation id>`. The schema constrains every `node_ids` entry
+and every edge `from`/`to` endpoint to those patterns; an arbitrary string
+fails validation.
+
+Every relationship must bind to an exact existing Touch Atlas edge — the same
+`(kind, from, to)` tuple must appear in `touches.json`. No relationship may be
+added because it seems intuitive. Groups may be empty, but every edge in
+`touches.json` must appear in exactly one group, and no edge may be invented.
+
+## HTML requirements
+
+The `_boris/proof/index.html` must be:
+
+- fully static;
+- valid UTF-8;
+- deterministic;
+- usable without JavaScript;
+- navigable by headings and anchors;
+- printable;
+- readable directly from disk;
+- free of remote fonts, scripts, images, analytics, or stylesheets;
+- styled with embedded bounded CSS;
+- clear about failed, incomplete, not-applicable, and limited evidence; and
+- honest when a section contains no applicable records.
+
+Allow progressive enhancement only when the complete content remains available
+without JavaScript. Do not create an interactive graph dependency in v1; the
+relationship section is a compact readable index, not a canvas or JS graph.
+
+The HTML is derived exclusively from `proof-pack.json`. It must render the
+same summary banner, artifact/check/finding/claim/limitation rows, and
+relationship groups; it must not add, remove, reword, or upgrade any fact.
+It must also embed the lowercase SHA-256 of the exact `proof-pack.json`
+bytes it represents (for example in a meta element or comment) so a reader
+can detect a stale partner without needing the JSON open beside it.
+
+## Transaction
+
+Define the order:
+
+```text
+payloads
+→ artifacts.json
+→ checks.json
+→ claims.json
+→ touches.json
+→ proof-pack.json
+→ index.html
+```
+
+Required behavior:
+
+- Proof Pack failure does not roll back earlier publication or evidence;
+- failure returns exit 3;
+- diagnostic states that publication and prior evidence committed but Proof
+  Pack presentation was not refreshed;
+- diagnostic appears under `--quiet`; and
+- on a handled synchronous failure, the prior `proof-pack.json` and
+  `index.html` pair is preserved (restored or never touched) when
+  restoration succeeds; when restoration itself fails, the run makes no
+  prior-pair-preservation claim (see the first-slice transaction below).
+
+### First-slice generation transaction
+
+Two files cannot be renamed by one filesystem primitive, so the first slice
+must not claim that sequential renames give concurrent readers atomic pair
+visibility. The implementable transaction is:
+
+1. Build both outputs completely from the same in-memory model, so the pair
+   is one logical generation before any disk write.
+2. Write and verify both temporary files (`proof-pack.json.tmp` and
+   `index.html.tmp`) in the same directory; fsync and byte-verify both.
+3. Embed in `index.html` the lowercase SHA-256 of the exact
+   `proof-pack.json` bytes it represents (for example in a meta element or
+   comment), so a reader can detect a stale partner.
+4. Move the current pair aside (rename `index.html` → `index.html.prev` and
+   `proof-pack.json` → `proof-pack.json.prev`) so that restoration has a
+   defined source.
+5. Rename the new `index.html` into place first.
+6. Rename the new authoritative `proof-pack.json` last, as the logical
+   commit point.
+7. On success, delete the `.prev` files.
+8. On a synchronous failure at any step, restore the prior pair by renaming
+   the `.prev` files back over any partial new files. Restoration can
+   itself fail; define that case explicitly:
+   - if restoration succeeds, the prior pair remains, the run returns exit
+     3, and the diagnostic (visible under `--quiet`) states that
+     publication and prior evidence committed but Proof Pack presentation
+     was not refreshed;
+   - if restoration fails, the run still returns exit 3 and the diagnostic
+     (visible under `--quiet`) states that presentation recovery failed and
+     the current pair may be split or absent. Preserve the `.prev` files
+     wherever possible; the next generation performs recovery or replaces
+     both files. Do not claim prior-pair preservation when restoration
+     failed.
+9. A successful return guarantees that both current files match: the
+   committed `proof-pack.json` bytes are exactly the bytes the committed
+   `index.html` was derived from.
+10. A reader that observes a mismatch between the HTML's embedded model
+    digest and the on-disk `proof-pack.json` digest can detect a split pair
+    and must not treat it as a committed generation.
+11. A crash or a concurrent reader may observe an intermediate state between
+    the two renames. The first slice makes no multi-file atomic-visibility
+    claim; genuinely atomic pair visibility would require future single-entry
+    indirection (for example a generation directory or a commit marker that
+    readers consult before reading either file), which is out of scope for
+    v1.
+
+The embedded model digest is the first-slice mechanism that avoids a
+committed split-generation pair: it is deterministic, cheap to verify, and
+requires no multi-file atomic primitive. This transaction does not claim
+whole-tree atomicity beyond the two files.
+
+## Determinism
+
+Require:
+
+- exact input-byte bindings;
+- canonical ordering inherited from upstream evidence (inventory order, fixed
+  check order, root finding order, fixed claim order, fixed limitation order,
+  Touch Atlas node/edge order);
+- stable anchors derived from stable IDs (HTML fragment ids derived from node
+  IDs and row indices);
+- lowercase SHA-256;
+- UTF-8 and LF;
+- no timestamps;
+- no durations;
+- no absolute paths;
+- no CWD;
+- no host, PID, username, Git state, or environment;
+- no filesystem traversal;
+- no payload rereads;
+- no random IDs;
+- no locale-dependent sorting; and
+- no external assets.
+
+## Schema boundary and runtime boundary
+
+[`schemas/publication-proof-pack-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-proof-pack-1.schema.json)
+enforces the exact key set and structural vocabulary: required root keys,
+constants, closed input bindings, closed row shapes, enum vocabularies,
+digest syntax, stable node ID patterns, fixed registry counts, and the
+overall-status vocabulary. JSON Schema Draft 2020-12 does not enforce object
+property order, so the schema constrains key membership and array positions
+where `prefixItems` applies, never member ordering. Canonical member ordering
+is assigned to the runtime serializer, exact-byte golden tests, and HTML/JSON
+parity tests.
+
+JSON Schema does not prove cross-report facts. Runtime validation remains
+responsible for exact input-byte digests, target equality, the Touch Atlas
+three-binding agreement, canonical member ordering, derived counts,
+selector-derived edge membership, finding offset ranges and contiguity, the
+mechanical overall-status derivation, summary totals, HTML/JSON parity, the
+first-slice generation transaction (including the embedded model digest and
+split-pair detection), exit code `3`, quiet diagnostic capture, and
+reserved-path guards. Atomic replacement and prior-pair preservation are
+runtime behavior, not schema claims.
+
+## Implementation map
+
+The shipped first slice covers:
+
+```text
+src/publication_proof_pack.zig
+strict four-report parsing and binding
+Touch Atlas edge validation
+finding-row derivation, contiguity, and Touch Atlas binding
+summary derivation
+deterministic JSON renderer
+deterministic HTML renderer
+first-slice generation transaction with embedded model digest
+reserved-path collision guards
+compile integration
+exit mapping
+quiet diagnostic capture
+schema/runtime parity tests
+fixture tests
+HTML snapshot tests
+HTML/JSON parity tests
+failure injection
+```
+
+## Non-claims (explicitly out of scope)
+
+This slice makes no claim about, and does not attempt:
+
+- rerunning checks or re-reading payloads;
+- deployment, accessibility, prose-quality, or reproducibility claims;
+- source-to-artifact provenance inference;
+- repair actions or evidence-status upgrades; and
+- any multi-file atomic pair-visibility primitive (the first-slice
+transaction makes no such claim; the embedded model digest is the
+split-pair detection mechanism).
+
+The presentation layer is implemented and shipped: Boris now emits
+`_boris/proof/proof-pack.json` and `_boris/proof/index.html` after the
+Touch Atlas commits, and the normative runtime requirements above are
+enforced by the compiler, module, and fixture tests in this PR.

--- a/docs/contracts/publication-touches.md
+++ b/docs/contracts/publication-touches.md
@@ -1,0 +1,376 @@
+# Publication Touch Atlas (schema v1)
+
+**Status:** implemented first slice
+
+The Touch Atlas is a target-local evidence index for the first
+publication-evidence chain. It answers structural questions by connecting
+records that already exist in the artifact inventory, publication checks, and
+publication claims reports:
+
+- which inventory artifacts belong to a target;
+- which artifacts are subjects or supporting inputs of each check;
+- which findings belong to each check;
+- which check supports each claim; and
+- which limitations constrain each claim.
+
+It does not create a new observation, check, claim, or limitation. The first
+implemented slice derives `touches.json` exclusively from the exact committed
+bytes of the three evidence reports; the non-claims listed at the end of this
+document remain out of scope.
+
+## Artifact and exclusive inputs
+
+The target-local artifact is:
+
+```text
+{target}/_boris/proof/touches.json
+```
+
+Its fixed identity is:
+
+```text
+format: boris-publication-touches
+schema_version: 1
+```
+
+The only inputs are the exact bytes of these three committed evidence reports:
+
+```text
+_boris/proof/artifacts.json
+_boris/proof/checks.json
+_boris/proof/claims.json
+```
+
+The Touch Atlas must not read or crawl pages, payloads, sources, deployment
+resources, caches, or the output filesystem tree. It must not trace compiler
+phases, runtime calls, individual transformations, or source provenance. Those
+relationships are not present in the v1 evidence reports and must not be
+fabricated.
+
+## Root shape and input bindings
+
+The root object has exactly these keys, in this order:
+
+```text
+format
+schema_version
+target
+inputs
+nodes
+edges
+```
+
+`inputs` is an object with exactly these keys, in this order:
+
+```text
+artifacts
+checks
+claims
+```
+
+Each input binding copies the report identity and includes the exact byte
+binding fields below. The digest is lowercase SHA-256 of the exact committed
+report bytes, not of parsed or reserialized JSON.
+
+```json
+{
+  "artifacts": {
+    "path": "_boris/proof/artifacts.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-artifacts",
+    "schema_version": 1,
+    "target": "public",
+    "artifact_count": 0
+  },
+  "checks": {
+    "path": "_boris/proof/checks.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-checks",
+    "schema_version": 1,
+    "target": "public",
+    "check_count": 3,
+    "finding_count": 0
+  },
+  "claims": {
+    "path": "_boris/proof/claims.json",
+    "bytes": 0,
+    "sha256": "lowercase-64-hex-digest",
+    "format": "boris-publication-claims",
+    "schema_version": 1,
+    "target": "public",
+    "claim_count": 3,
+    "limitation_count": 6
+  }
+}
+```
+
+The counts are mechanically derived from the parsed input reports and then
+validated against the embedded bindings:
+
+```text
+artifact_count   = artifacts.json artifacts array length
+check_count      = checks.json checks array length
+finding_count    = checks.json findings array length
+claim_count      = claims.json claims array length
+limitation_count = claims.json limitations array length
+```
+
+They do not replace validation of the actual arrays and bindings.
+
+## Nodes
+
+Every node is a closed object with exactly these keys, in this order:
+
+```text
+kind
+id
+metadata
+```
+
+`metadata` is also closed. The node `kind` identifies the Touch Atlas node
+vocabulary; metadata fields are copied references to authoritative evidence,
+not newly observed facts.
+
+The v1 node kinds are exactly:
+
+```text
+target
+artifact
+check
+finding
+claim
+limitation
+```
+
+Stable IDs and minimum metadata are:
+
+| Node kind | Stable ID | Metadata, in order |
+|---|---|---|
+| `target` | `target` | `target` |
+| `artifact` | `artifact:<artifact path>` | `inventory_index`, `path`, `kind`, `status`, `required` |
+| `check` | `check:<check id>` | `check_index`, `check_id`, `status`, `coverage` |
+| `finding` | `finding:<owning check id>:<zero-based ordinal within that check>` | `finding_index`, `check_id`, `check_finding_index`, `code`, `severity`, `subject` |
+| `claim` | `claim:<claim id>` | `claim_index`, `claim_id`, `status` |
+| `limitation` | `limitation:<limitation id>` | `limitation_index`, `limitation_id`, `source` |
+
+The `subject` value is copied as the closed checks-contract object with
+`kind`, `id`, and `target`; its `target` may be `null` when the source finding
+uses a null target. Artifact paths and all copied path values remain
+target-relative, slash-separated paths.
+
+Nodes have one canonical order:
+
+1. one `target` node;
+2. artifacts in canonical artifact-inventory order, including records whose
+   status is not `committed`;
+3. checks in the fixed publication-check order;
+4. findings in root finding order;
+5. claims in the fixed publication-claim order; and
+6. limitations in the fixed publication-limitation order.
+
+The fixed v1 registries are the three checks and claims from the existing
+contracts and the six limitations from `publication-claims.md`. Runtime
+validation must reject missing, extra, reordered, or duplicated registry
+members even where an individual object matches the JSON Schema.
+
+## Edges
+
+Every edge is a closed object with exactly these keys, in this order:
+
+```text
+kind
+from
+to
+```
+
+The v1 edge kinds are exactly:
+
+```text
+target-owns-artifact
+artifact-subject-of-check
+artifact-supports-check
+check-reported-finding
+check-supports-claim
+claim-limited-by
+```
+
+Edge direction and derivation are:
+
+| Edge | Direction | Derivation |
+|---|---|---|
+| `target-owns-artifact` | `target` → `artifact` | One edge for every inventory record, including non-committed records. |
+| `artifact-subject-of-check` | `artifact` → `check` | The artifact matches the check's declared subject selectors. |
+| `artifact-supports-check` | `artifact` → `check` | The artifact matches the check's declared supporting selectors. |
+| `check-reported-finding` | `check` → `finding` | The finding lies in the check's validated contiguous `finding_offset`/`counts.findings` range. |
+| `check-supports-claim` | `check` → `claim` | The claim's exact `evidence.check_id` binding resolves to the check; this is an evidence binding, not a statement that the check passed. |
+| `claim-limited-by` | `claim` → `limitation` | The claim's ordered `limitation_ids` resolve to the limitation nodes. |
+
+Artifact selector matching uses the publication-check contract's semantics:
+
+- when both selector arrays are empty, the selected set is empty;
+- otherwise, an empty individual dimension is a wildcard for that dimension;
+- matching retains canonical inventory order.
+
+Subject edges use `scope.subject_statuses` and `scope.subject_kinds`.
+Supporting edges use `scope.supporting_statuses` and
+`scope.supporting_kinds`. The scope SHA-256 values are evidence digests, not
+additional selectors.
+
+Edges are compared by this tuple, in order:
+
+1. edge kind order;
+2. source evidence index; then
+3. destination evidence index.
+
+For `target-owns-artifact`, the source is the single target node and the
+destination uses artifact inventory order. For artifact-to-check edges, the
+source evidence index is the artifact inventory index and the destination
+evidence index is the fixed check index. For `check-reported-finding`, the
+source is the fixed check index and the destination is the root finding order.
+For `check-supports-claim`, the source is the fixed check index and the
+destination is the fixed claim index. For `claim-limited-by`, claim order is
+first and each claim's ordered limitation list is second; limitations are not
+sorted by a separate global scan.
+
+Runtime validation must reject duplicate `(kind, from, to)` tuples and every
+dangling node reference. V1 deliberately does not create a
+`finding`-to-`artifact` edge merely because a diagnostic subject resembles an
+artifact path; exact finding-subject lineage is a separate design problem.
+
+## Cross-report validation
+
+Before a Touch Atlas is valid, a future implementation must fail closed unless
+all of the following hold:
+
+- every input format and schema version matches the v1 constants;
+- all three report targets match the requested target and the root target;
+- `checks.json` binds the exact current `artifacts.json` bytes;
+- `claims.json` binds the exact current `artifacts.json` and `checks.json`
+  bytes;
+- derived `artifact_count` must agree with
+  `checks.artifact_inventory.artifact_count` and
+  `claims.artifact_inventory.artifact_count`;
+- derived `check_count` and `finding_count` must agree with
+  `claims.publication_checks.check_count` and
+  `claims.publication_checks.finding_count`;
+- the fixed check, claim, and limitation registries are valid and in
+  canonical order;
+- finding offsets and totals are coherent and cover the root findings without
+  overlap or omission;
+- every claim-to-check binding resolves;
+- every limitation reference resolves in both directions between claim rows
+  and limitation rows;
+- every generated edge resolves to an existing node;
+- node identities are unique; and
+- edge tuples are unique.
+
+The implementation must validate derived counts and copied metadata against
+their source reports, including inventory indices, check/finding indices,
+statuses, coverage, codes, claim statuses, and limitation sources. It must
+preserve any prior
+`touches.json` when validation or writing fails.
+
+## Future publication transaction
+
+The future publication order is:
+
+```text
+commit payloads
+→ commit artifacts.json
+→ commit checks.json
+→ commit claims.json
+→ derive touches from those exact committed evidence bytes
+→ atomically replace touches.json
+```
+
+`touches.json` is downstream evidence:
+
+- it is not staged with payloads;
+- it is not included in `artifacts.json`;
+- it does not alter `checks.json` or `claims.json`;
+- its failure does not roll back payloads or earlier evidence;
+- a failure returns exit code `3` and preserves any prior Touch Atlas; and
+- the committed-target diagnostic is emitted even under `--quiet`.
+
+These are reserved implementation semantics. This PR does not emit the
+artifact, add a compiler command, or change the current publication
+transaction.
+
+## Determinism and limits
+
+For identical committed input bytes, the implementation must produce
+byte-identical output and require:
+
+- exact-byte input bindings;
+- one canonical node order and edge order;
+- lowercase SHA-256;
+- UTF-8 JSON and LF line endings;
+- no timestamps or durations;
+- no absolute paths or CWD;
+- no host, PID, username, Git revision, or environment values;
+- no filesystem traversal order;
+- no payload rereads;
+- no source-provenance claim;
+- no deployment claim; and
+- no transformation-runtime trace claim.
+
+The Touch Atlas establishes only relationships already declared by the three
+input reports. It does not upgrade a failed, incomplete, or not-applicable
+check into a pass, and it does not turn a claim into universal verification.
+
+## Schema boundary and runtime boundary
+
+[`schemas/publication-touches-1.schema.json`](https://github.com/drawmeanelephant/oliver/blob/main/docs/contracts/schemas/publication-touches-1.schema.json)
+enforces the structural boundary: exact root keys and constants, closed input
+bindings, closed node and edge object shapes, the six node kinds, the six edge
+kinds, required metadata, digest syntax, stable ID patterns, and permitted
+edge directions.
+
+JSON Schema does not prove cross-report facts. Runtime validation remains
+responsible for exact input-byte digests, target equality, report-specific
+binding equality, fixed registry order, canonical node and edge order, node
+cardinality, identity collisions, selector-derived edge membership, finding
+offset ranges, claim/limitation bidirectional agreement, duplicate edges, and
+all node references. Atomic replacement, prior-report preservation, exit code
+`3`, and quiet diagnostic capture are also runtime behavior rather than schema
+claims.
+
+## Implementation status
+
+The first slice ships:
+
+1. `src/publication_touches.zig` — strict streaming parsers for the three
+   reports, cross-report validation, canonical node/edge derivation, and
+   deterministic serialization, plus schema/runtime parity tests.
+2. `src/compile.zig` integration — derives the atlas only from the exact
+   committed evidence bytes after claims replacement, with no payload rereads.
+3. `src/main.zig` exit mapping — preserves the existing committed-target
+   diagnostic and maps Touch Atlas failure to exit `3`, including `--quiet`.
+4. Artifact-inventory reserved-path guards — reserves and rejects
+   `_boris/proof/touches.json` without inventorying it.
+5. Fixture tests — cover clean, failed/incomplete, not-applicable search,
+   stale bindings, selector wildcards, duplicate identities, dangling edges,
+   byte determinism across sequential and concurrent runs, and reserved-path
+   collision guards.
+6. Build steps — focused `test-publication-touches` and
+   `test-publication-touches-fixture` targets wired into the root test suite,
+   without changing the product build architecture.
+7. Quiet diagnostic capture — the committed-target diagnostic is retained
+   under `--quiet` and is captured by an injectable writer seam.
+
+## Non-claims (explicitly out of scope)
+
+This slice makes no claim about, and does not attempt:
+
+- source-to-artifact provenance (no source files are read);
+- runtime transformation traces (no compiler phase or call tracing);
+- a deployment graph (no deployment resources are read or verified);
+- accessibility or prose-quality inference;
+- proof-pack presentation or packaging; and
+- repair actions (the atlas never rewrites a payload, report, or claim).
+
+The status is **implemented first slice**: the normative runtime requirements
+above are enforced by `zig build test-publication-touches` and the fixture
+suite, and the atlas never rereads payloads or source bytes.

--- a/docs/contracts/schemas/github-pages-deployment-evidence-1.schema.json
+++ b/docs/contracts/schemas/github-pages-deployment-evidence-1.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris GitHub Pages deployment evidence (schema v1)",
+  "description": "A bounded post-deploy HTTP observation bound to a normalized Boris publication plan and target-local artifact inventory.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "identity", "deployment", "binding", "audit", "limitations"],
+  "properties": {
+    "format": {"const": "boris-github-pages-deployment-evidence"},
+    "schema_version": {"const": 1},
+    "identity": {"$ref": "#/$defs/identity"},
+    "deployment": {"$ref": "#/$defs/deployment"},
+    "binding": {"$ref": "#/$defs/binding"},
+    "audit": {"$ref": "#/$defs/audit"},
+    "limitations": {"type": "array", "items": {"type": "string"}}
+  },
+  "$defs": {
+    "nullable_string": {"type": ["string", "null"]},
+    "digest": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
+    "result": {"enum": ["passed", "failed", "incomplete", "not-applicable"]},
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "source_commit", "workflow_ref", "workflow_sha", "run_id", "run_attempt", "deployment_id", "public_artifact_name"],
+      "properties": {
+        "repository": {"$ref": "#/$defs/nullable_string"},
+        "source_commit": {"$ref": "#/$defs/nullable_string"},
+        "workflow_ref": {"$ref": "#/$defs/nullable_string"},
+        "workflow_sha": {"$ref": "#/$defs/nullable_string"},
+        "run_id": {"$ref": "#/$defs/nullable_string"},
+        "run_attempt": {"$ref": "#/$defs/nullable_string"},
+        "deployment_id": {"$ref": "#/$defs/nullable_string"},
+        "public_artifact_name": {"$ref": "#/$defs/nullable_string"}
+      }
+    },
+    "deployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "target", "site_kind", "base_url", "origin", "base_path", "page_url", "normalized_page_url"],
+      "properties": {
+        "provider": {"const": "github-pages"},
+        "target": {"type": "string", "minLength": 1},
+        "site_kind": {"enum": ["project-site", "root-site", "custom-domain"]},
+        "base_url": {"type": "string", "minLength": 1},
+        "origin": {"type": "string", "minLength": 1},
+        "base_path": {"type": "string"},
+        "page_url": {"type": "string", "minLength": 1},
+        "normalized_page_url": {"type": "string"}
+      }
+    },
+    "binding_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "inventory_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "format", "schema_version", "target", "artifact_count"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "format": {"const": "boris-publication-artifacts"},
+        "schema_version": {"const": 1},
+        "target": {"type": "string", "minLength": 1},
+        "artifact_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plan", "inventory"],
+      "properties": {
+        "plan": {"$ref": "#/$defs/binding_ref"},
+        "inventory": {"$ref": "#/$defs/inventory_binding"}
+      }
+    },
+    "bounds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_requests", "max_body_bytes", "max_redirects", "timeout_ms", "max_projection_urls"],
+      "properties": {
+        "max_requests": {"type": "integer", "minimum": 1},
+        "max_body_bytes": {"type": "integer", "minimum": 1},
+        "max_redirects": {"type": "integer", "minimum": 0},
+        "timeout_ms": {"type": "integer", "minimum": 1},
+        "max_projection_urls": {"type": "integer", "minimum": 1}
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "detail"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "status": {"$ref": "#/$defs/result"},
+        "detail": {"type": "string"}
+      }
+    },
+    "redirect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "url"],
+      "properties": {
+        "status": {"type": "integer", "minimum": 300, "maximum": 399},
+        "url": {"type": "string", "minLength": 1}
+      }
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["content_type", "cache_control", "etag", "last_modified", "content_encoding", "content_length"],
+      "properties": {
+        "content_type": {"$ref": "#/$defs/nullable_string"},
+        "cache_control": {"$ref": "#/$defs/nullable_string"},
+        "etag": {"$ref": "#/$defs/nullable_string"},
+        "last_modified": {"$ref": "#/$defs/nullable_string"},
+        "content_encoding": {"$ref": "#/$defs/nullable_string"},
+        "content_length": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["check_id", "kind", "path", "requested_url", "final_url", "status", "redirects", "headers", "body_bytes", "observed_sha256", "expected_sha256", "expected_bytes", "transfer_decoded", "byte_result", "result", "detail"],
+      "properties": {
+        "check_id": {"type": "string", "minLength": 1},
+        "kind": {"type": "string", "minLength": 1},
+        "path": {"type": "string", "minLength": 1},
+        "requested_url": {"type": "string", "minLength": 1},
+        "final_url": {"$ref": "#/$defs/nullable_string"},
+        "status": {"type": ["integer", "null"], "minimum": 100, "maximum": 599},
+        "redirects": {"type": "array", "items": {"$ref": "#/$defs/redirect"}},
+        "headers": {"$ref": "#/$defs/headers"},
+        "body_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "observed_sha256": {"$ref": "#/$defs/digest"},
+        "expected_sha256": {"$ref": "#/$defs/digest"},
+        "expected_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "transfer_decoded": {"type": "boolean"},
+        "byte_result": {"$ref": "#/$defs/result"},
+        "result": {"$ref": "#/$defs/result"},
+        "detail": {"type": "string"}
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audited_at", "result", "requests", "completed_requests", "truncated", "bounds", "checks", "observations"],
+      "properties": {
+        "audited_at": {"type": "string", "minLength": 1},
+        "result": {"$ref": "#/$defs/result"},
+        "requests": {"type": "integer", "minimum": 0},
+        "completed_requests": {"type": "integer", "minimum": 0},
+        "truncated": {"type": "boolean"},
+        "bounds": {"$ref": "#/$defs/bounds"},
+        "checks": {"type": "array", "items": {"$ref": "#/$defs/check"}},
+        "observations": {"type": "array", "items": {"$ref": "#/$defs/observation"}}
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/publication-artifacts-1.schema.json
+++ b/docs/contracts/schemas/publication-artifacts-1.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication artifact inventory (schema v1)",
+  "description": "Deterministic inventory of Boris-owned payload bytes committed for one HTML target. The inventory excludes itself and later proof-pack envelope files.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "target", "artifacts"],
+  "properties": {
+    "format": { "const": "boris-publication-artifacts" },
+    "schema_version": { "const": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" }
+    }
+  },
+  "$defs": {
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$)).+$"
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind", "producer", "required", "status", "bytes", "sha256", "format_version"],
+      "properties": {
+        "path": {
+          "allOf": [
+            { "$ref": "#/$defs/relative_path" },
+            { "not": { "const": "_boris/proof/checks.json" } }
+          ]
+        },
+        "kind": {
+          "enum": ["html-page", "theme-asset", "content-asset", "rendered-search", "sitemap", "rss", "llms"]
+        },
+        "producer": {
+          "enum": ["html-render", "theme-assets", "content-assets", "rendered-search", "sitemap", "rss", "llms"]
+        },
+        "required": { "type": "boolean" },
+        "status": { "enum": ["committed", "omitted-by-plan", "not-applicable"] },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "format_version": { "type": ["string", "null"], "minLength": 1 }
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/publication-checks-1.schema.json
+++ b/docs/contracts/schemas/publication-checks-1.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication checks evidence (schema v1)",
+  "description": "Deterministic target-local evidence derived from the committed Boris artifact inventory and exact payload bytes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "target", "artifact_inventory", "checks", "findings"],
+  "properties": {
+    "format": { "const": "boris-publication-checks" },
+    "schema_version": { "const": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "artifact_inventory": { "$ref": "#/$defs/inventory_binding" },
+    "checks": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/check",
+          "properties": { "id": { "const": "artifact-integrity" } }
+        },
+        {
+          "$ref": "#/$defs/check",
+          "properties": { "id": { "const": "rendered-html" } }
+        },
+        {
+          "$ref": "#/$defs/check",
+          "properties": { "id": { "const": "rendered-search" } }
+        }
+      ],
+      "items": false,
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "inventory_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "bytes", "sha256", "format", "schema_version", "target", "artifact_count"],
+      "properties": {
+        "path": { "const": "_boris/proof/artifacts.json" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "format": { "const": "boris-publication-artifacts" },
+        "schema_version": { "const": 1 },
+        "target": { "type": "string", "minLength": 1 },
+        "artifact_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_statuses", "subject_kinds", "subject_sha256", "supporting_statuses", "supporting_kinds", "supporting_sha256"],
+      "properties": {
+        "subject_statuses": { "type": "array", "items": { "$ref": "#/$defs/status" } },
+        "subject_kinds": { "type": "array", "items": { "$ref": "#/$defs/kind" } },
+        "subject_sha256": { "$ref": "#/$defs/sha256" },
+        "supporting_statuses": { "type": "array", "items": { "$ref": "#/$defs/status" } },
+        "supporting_kinds": { "type": "array", "items": { "$ref": "#/$defs/kind" } },
+        "supporting_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eligible", "checked", "findings"],
+      "properties": {
+        "eligible": { "type": "integer", "minimum": 0 },
+        "checked": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "eligible", "ran", "status", "coverage", "scope", "counts", "finding_offset"],
+      "properties": {
+        "id": { "enum": ["artifact-integrity", "rendered-html", "rendered-search"] },
+        "eligible": { "type": "boolean" },
+        "ran": { "type": "boolean" },
+        "status": { "enum": ["passed", "failed", "incomplete", "not-applicable"] },
+        "coverage": { "enum": ["complete", "incomplete", "not-applicable"] },
+        "scope": { "$ref": "#/$defs/scope" },
+        "counts": { "$ref": "#/$defs/counts" },
+        "finding_offset": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "status": {
+      "enum": ["committed", "omitted-by-plan", "not-applicable"]
+    },
+    "kind": {
+      "enum": ["html-page", "theme-asset", "content-asset", "rendered-search", "sitemap", "rss", "llms"]
+    },
+    "location": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["path", "line", "column"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "line": { "type": "integer", "minimum": 0 },
+        "column": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "domain", "severity", "confidence", "owner", "subject", "source_location", "output_location", "configuration_location", "evidence", "remediation", "fixability"],
+      "properties": {
+        "code": {
+          "enum": [
+            "ARTIFACT_MISSING", "ARTIFACT_SIZE_MISMATCH", "ARTIFACT_DIGEST_MISMATCH",
+            "HTML_PAGE_MISSING", "HTML_MALFORMED", "HTML_URL_MALFORMED",
+            "HTML_LOCAL_ROUTE_MISSING", "HTML_LOCAL_ROUTE_ESCAPE", "HTML_FRAGMENT_MISSING",
+            "HTML_DUPLICATE_ID", "SEARCH_MISSING", "SEARCH_MALFORMED",
+            "SEARCH_DOCUMENT_MISSING", "SEARCH_DOCUMENT_STALE", "SEARCH_CONTENT_MISMATCH"
+          ]
+        },
+        "domain": { "enum": ["rendered_html", "artifact"] },
+        "severity": { "enum": ["error", "warning", "info"] },
+        "confidence": { "enum": ["certain", "high", "limited"] },
+        "owner": { "enum": ["content", "theme", "publication", "configuration", "unknown"] },
+        "subject": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "target"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 },
+            "target": { "type": ["string", "null"] }
+          }
+        },
+        "source_location": { "$ref": "#/$defs/location" },
+        "output_location": { "$ref": "#/$defs/location" },
+        "configuration_location": { "$ref": "#/$defs/location" },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["observed", "expected", "related"],
+          "properties": {
+            "observed": { "type": "string" },
+            "expected": { "type": "string" },
+            "related": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "remediation": { "type": "string", "minLength": 1 },
+        "fixability": { "enum": ["source_edit", "layout_edit", "configuration_edit", "regenerate", "not_actionable"] }
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/publication-claims-1.schema.json
+++ b/docs/contracts/schemas/publication-claims-1.schema.json
@@ -1,0 +1,345 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication claims evidence (schema v1)",
+  "description": "Deterministic target-local claims and limitations derived strictly from the committed artifact inventory and publication checks evidence bytes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "target", "artifact_inventory", "publication_checks", "claims", "limitations"],
+  "properties": {
+    "format": { "const": "boris-publication-claims" },
+    "schema_version": { "const": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "artifact_inventory": { "$ref": "#/$defs/inventory_binding" },
+    "publication_checks": { "$ref": "#/$defs/checks_binding" },
+    "claims": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/claim",
+          "properties": {
+            "id": { "const": "committed-artifacts-match-inventory" },
+            "statement": { "const": "Every committed artifact record selected by the artifact-integrity check was inspected and matched its declared byte count and SHA-256 digest." },
+            "evidence": {
+              "properties": { "check_id": { "const": "artifact-integrity" } }
+            },
+            "limitation_ids": {
+              "prefixItems": [
+                { "const": "target-local-only" },
+                { "const": "no-deployment-verification" },
+                { "const": "no-accessibility-verification" },
+                { "const": "no-prose-quality-verification" },
+                { "const": "no-universal-reproducibility-claim" }
+              ],
+              "items": false,
+              "minItems": 5,
+              "maxItems": 5
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/claim",
+          "properties": {
+            "id": { "const": "rendered-html-passed-declared-audit" },
+            "statement": { "const": "Every committed HTML page selected by the rendered-html check completed the declared structural, route, fragment, and duplicate-ID audit within that check's scope." },
+            "evidence": {
+              "properties": { "check_id": { "const": "rendered-html" } }
+            },
+            "limitation_ids": {
+              "prefixItems": [
+                { "const": "target-local-only" },
+                { "const": "no-deployment-verification" },
+                { "const": "no-accessibility-verification" },
+                { "const": "no-prose-quality-verification" },
+                { "const": "no-universal-reproducibility-claim" }
+              ],
+              "items": false,
+              "minItems": 5,
+              "maxItems": 5
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/claim",
+          "properties": {
+            "id": { "const": "rendered-search-matches-selected-html" },
+            "statement": { "const": "The single selected rendered-search artifact matched the committed HTML page set and derived rendered-search content inspected by the rendered-search check." },
+            "evidence": {
+              "properties": { "check_id": { "const": "rendered-search" } }
+            },
+            "limitation_ids": {
+              "prefixItems": [
+                { "const": "target-local-only" },
+                { "const": "no-deployment-verification" },
+                { "const": "no-accessibility-verification" },
+                { "const": "no-prose-quality-verification" },
+                { "const": "no-universal-reproducibility-claim" },
+                { "const": "omitted-projections-not-certified" }
+              ],
+              "items": false,
+              "minItems": 6,
+              "maxItems": 6
+            }
+          }
+        }
+      ],
+      "items": false,
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/limitation",
+          "properties": {
+            "id": { "const": "target-local-only" },
+            "statement": { "const": "These claims describe one selected local HTML target after its commit and say nothing about any other target or environment." },
+            "source": { "const": "docs/contracts/publication-checks.md#authority-and-transaction-boundary" },
+            "applies_to_claims": {
+              "prefixItems": [
+                { "const": "committed-artifacts-match-inventory" },
+                { "const": "rendered-html-passed-declared-audit" },
+                { "const": "rendered-search-matches-selected-html" }
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/limitation",
+          "properties": {
+            "id": { "const": "no-deployment-verification" },
+            "statement": { "const": "No deployment was performed or verified; local generation cannot verify deployed behavior." },
+            "source": { "const": "docs/contracts/publication-model.md#verification-vocabulary-and-claims" },
+            "applies_to_claims": {
+              "prefixItems": [
+                { "const": "committed-artifacts-match-inventory" },
+                { "const": "rendered-html-passed-declared-audit" },
+                { "const": "rendered-search-matches-selected-html" }
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/limitation",
+          "properties": {
+            "id": { "const": "no-accessibility-verification" },
+            "statement": { "const": "No accessibility audit was performed for any page or artifact in this target." },
+            "source": { "const": "docs/contracts/publication-model.md#projections" },
+            "applies_to_claims": {
+              "prefixItems": [
+                { "const": "committed-artifacts-match-inventory" },
+                { "const": "rendered-html-passed-declared-audit" },
+                { "const": "rendered-search-matches-selected-html" }
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/limitation",
+          "properties": {
+            "id": { "const": "no-prose-quality-verification" },
+            "statement": { "const": "No prose, writing, or documentation-quality judgment was made." },
+            "source": { "const": "docs/contracts/publication-model.md#verification-vocabulary-and-claims" },
+            "applies_to_claims": {
+              "prefixItems": [
+                { "const": "committed-artifacts-match-inventory" },
+                { "const": "rendered-html-passed-declared-audit" },
+                { "const": "rendered-search-matches-selected-html" }
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/limitation",
+          "properties": {
+            "id": { "const": "no-universal-reproducibility-claim" },
+            "statement": { "const": "Deterministic bytes on one recorded environment are not universal reproducibility." },
+            "source": { "const": "docs/contracts/publication-model.md#verification-vocabulary-and-claims" },
+            "applies_to_claims": {
+              "prefixItems": [
+                { "const": "committed-artifacts-match-inventory" },
+                { "const": "rendered-html-passed-declared-audit" },
+                { "const": "rendered-search-matches-selected-html" }
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/limitation",
+          "properties": {
+            "id": { "const": "omitted-projections-not-certified" },
+            "statement": { "const": "An omitted or unselected projection remains explicitly unverified and is not certified by this report." },
+            "source": { "const": "docs/contracts/publication-model.md#the-conductor-rule" },
+            "applies_to_claims": {
+              "prefixItems": [
+                { "const": "rendered-search-matches-selected-html" }
+              ],
+              "items": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          }
+        }
+      ],
+      "items": false,
+      "minItems": 6,
+      "maxItems": 6
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "inventory_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "bytes", "sha256", "format", "schema_version", "target", "artifact_count"],
+      "properties": {
+        "path": { "const": "_boris/proof/artifacts.json" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "format": { "const": "boris-publication-artifacts" },
+        "schema_version": { "const": 1 },
+        "target": { "type": "string", "minLength": 1 },
+        "artifact_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "checks_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "bytes", "sha256", "format", "schema_version", "target", "check_count", "finding_count"],
+      "properties": {
+        "path": { "const": "_boris/proof/checks.json" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "format": { "const": "boris-publication-checks" },
+        "schema_version": { "const": 1 },
+        "target": { "type": "string", "minLength": 1 },
+        "check_count": { "type": "integer", "minimum": 0 },
+        "finding_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eligible", "checked", "findings"],
+      "properties": {
+        "eligible": { "type": "integer", "minimum": 0 },
+        "checked": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["check_id", "check_status", "coverage", "counts", "subject_sha256", "supporting_sha256", "checks_report_sha256", "reason"],
+      "properties": {
+        "check_id": { "enum": ["artifact-integrity", "rendered-html", "rendered-search"] },
+        "check_status": { "enum": ["passed", "failed", "incomplete", "not-applicable"] },
+        "coverage": { "enum": ["complete", "incomplete", "not-applicable"] },
+        "counts": { "$ref": "#/$defs/counts" },
+        "subject_sha256": { "$ref": "#/$defs/sha256" },
+        "supporting_sha256": { "$ref": "#/$defs/sha256" },
+        "checks_report_sha256": { "$ref": "#/$defs/sha256" },
+        "reason": {
+          "type": ["string", "null"],
+          "enum": [null, "check-failed", "check-incomplete", "check-not-applicable"]
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_statuses", "subject_kinds", "supporting_statuses", "supporting_kinds"],
+      "properties": {
+        "subject_statuses": { "type": "array", "items": { "$ref": "#/$defs/status" } },
+        "subject_kinds": { "type": "array", "items": { "$ref": "#/$defs/kind" } },
+        "supporting_statuses": { "type": "array", "items": { "$ref": "#/$defs/status" } },
+        "supporting_kinds": { "type": "array", "items": { "$ref": "#/$defs/kind" } }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "statement", "status", "evidence", "scope", "limitation_ids"],
+      "properties": {
+        "id": {
+          "enum": [
+            "committed-artifacts-match-inventory",
+            "rendered-html-passed-declared-audit",
+            "rendered-search-matches-selected-html"
+          ]
+        },
+        "statement": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["verified", "failed", "not-verified"] },
+        "evidence": { "$ref": "#/$defs/evidence" },
+        "scope": { "$ref": "#/$defs/scope" },
+        "limitation_ids": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "enum": [
+              "target-local-only",
+              "no-deployment-verification",
+              "no-accessibility-verification",
+              "no-prose-quality-verification",
+              "no-universal-reproducibility-claim",
+              "omitted-projections-not-certified"
+            ]
+          }
+        }
+      }
+    },
+    "status": {
+      "enum": ["committed", "omitted-by-plan", "not-applicable"]
+    },
+    "kind": {
+      "enum": ["html-page", "theme-asset", "content-asset", "rendered-search", "sitemap", "rss", "llms"]
+    },
+    "limitation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "statement", "applies_to_claims", "source"],
+      "properties": {
+        "id": {
+          "enum": [
+            "target-local-only",
+            "no-deployment-verification",
+            "no-accessibility-verification",
+            "no-prose-quality-verification",
+            "no-universal-reproducibility-claim",
+            "omitted-projections-not-certified"
+          ]
+        },
+        "statement": { "type": "string", "minLength": 1 },
+        "applies_to_claims": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "committed-artifacts-match-inventory",
+              "rendered-html-passed-declared-audit",
+              "rendered-search-matches-selected-html"
+            ]
+          }
+        },
+        "source": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/publication-plan-1.schema.json
+++ b/docs/contracts/schemas/publication-plan-1.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication plan (schema v1)",
+  "description": "Canonical normalized publication identity and selected projections. It is a declaration, not publication evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "input", "input_format", "site", "targets", "editions"],
+  "properties": {
+    "format": { "const": "boris-publication-plan" },
+    "schema_version": { "const": 1 },
+    "input": { "$ref": "#/$defs/path" },
+    "input_format": { "enum": ["markdown", "textile"] },
+    "site": { "$ref": "#/$defs/site" },
+    "publication": { "$ref": "#/$defs/publication" },
+    "targets": { "type": "array", "maxItems": 32, "items": { "$ref": "#/$defs/target" } },
+    "editions": { "$ref": "#/$defs/editions" }
+  },
+  "$defs": {
+    "path": { "type": "string", "minLength": 1, "maxLength": 1024 },
+    "nullable_path": { "type": ["string", "null"], "minLength": 1, "maxLength": 1024 },
+    "nullable_string": { "type": ["string", "null"] },
+    "site": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["url", "title", "description"],
+      "properties": {
+        "url": { "$ref": "#/$defs/nullable_string" },
+        "title": { "$ref": "#/$defs/nullable_string" },
+        "description": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "base_url", "origin", "base_path", "site_kind"],
+      "properties": {
+        "target": { "const": "github-pages" },
+        "base_url": { "type": "string", "minLength": 1, "maxLength": 2048 },
+        "origin": { "type": "string", "minLength": 1, "maxLength": 2048 },
+        "base_path": { "type": "string", "maxLength": 2048 },
+        "site_kind": { "enum": ["project-site", "root-site", "custom-domain"] }
+      }
+    },
+    "layout_rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["selector", "layout"],
+      "properties": {
+        "selector": { "type": "string" },
+        "layout": { "$ref": "#/$defs/path" }
+      }
+    },
+    "sitemap": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": { "path": { "$ref": "#/$defs/path" } }
+    },
+    "rss": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["path", "limit"],
+      "properties": {
+        "path": { "$ref": "#/$defs/path" },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 500 }
+      }
+    },
+    "llms": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": { "path": { "$ref": "#/$defs/path" } }
+    },
+    "projections": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["html", "sitemap", "rss", "llms"],
+      "properties": {
+        "html": { "const": true },
+        "sitemap": { "$ref": "#/$defs/sitemap" },
+        "rss": { "$ref": "#/$defs/rss" },
+        "llms": { "$ref": "#/$defs/llms" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "output", "public", "theme", "layout", "layout_rules", "projections"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "output": { "$ref": "#/$defs/path" },
+        "public": { "type": "boolean" },
+        "theme": { "$ref": "#/$defs/nullable_path" },
+        "layout": { "$ref": "#/$defs/nullable_path" },
+        "layout_rules": { "type": "array", "maxItems": 256, "items": { "$ref": "#/$defs/layout_rule" } },
+        "projections": { "$ref": "#/$defs/projections" }
+      }
+    },
+    "ir": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["output"],
+      "properties": { "output": { "$ref": "#/$defs/path" } }
+    },
+    "rag": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["output", "scope", "split_size", "bundles_only"],
+      "properties": {
+        "output": { "$ref": "#/$defs/path" },
+        "scope": { "$ref": "#/$defs/nullable_path" },
+        "split_size": { "type": ["integer", "null"], "minimum": 1 },
+        "bundles_only": { "type": "boolean" }
+      }
+    },
+    "context": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["output", "scope", "split_size"],
+      "properties": {
+        "output": { "$ref": "#/$defs/path" },
+        "scope": { "$ref": "#/$defs/nullable_path" },
+        "split_size": { "type": ["integer", "null"], "minimum": 1 }
+      }
+    },
+    "editions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ir", "rag", "context"],
+      "properties": {
+        "ir": { "$ref": "#/$defs/ir" },
+        "rag": { "$ref": "#/$defs/rag" },
+        "context": { "$ref": "#/$defs/context" }
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/publication-profile-1.schema.json
+++ b/docs/contracts/schemas/publication-profile-1.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication profile (schema v1)",
+  "description": "Machine-readable twin of publication-profile.md. Boris itself rejects duplicate object keys; JSON Schema cannot express that requirement.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version"],
+  "properties": {
+    "format": { "const": "boris-publication-profile" },
+    "schema_version": { "const": 1 },
+    "input": { "$ref": "#/$defs/path" },
+    "input_format": { "enum": ["markdown", "textile"] },
+    "site": { "$ref": "#/$defs/site" },
+    "publication": { "$ref": "#/$defs/publication" },
+    "targets": { "type": "array", "maxItems": 32, "items": { "$ref": "#/$defs/target" } },
+    "editions": { "$ref": "#/$defs/editions" }
+  },
+  "$defs": {
+    "path": { "type": "string", "minLength": 1, "maxLength": 1024 },
+    "site": { "type": "object", "additionalProperties": false, "properties": { "url": { "type": "string" }, "title": { "type": "string", "maxLength": 1024 }, "description": { "type": "string", "maxLength": 1024 } } },
+    "publication": { "type": "object", "additionalProperties": false, "required": ["target", "base_url", "origin", "base_path"], "properties": { "target": { "const": "github-pages" }, "base_url": { "type": "string", "minLength": 1, "maxLength": 2048 }, "origin": { "type": "string", "minLength": 1, "maxLength": 2048 }, "base_path": { "type": "string", "maxLength": 2048 } } },
+    "rule": { "type": "object", "additionalProperties": false, "required": ["selector", "layout"], "properties": { "selector": { "type": "string" }, "layout": { "$ref": "#/$defs/path" } } },
+    "path_output": { "type": "object", "additionalProperties": false, "required": ["path"], "properties": { "path": { "$ref": "#/$defs/path" } } },
+    "target": { "type": "object", "additionalProperties": false, "required": ["name", "output"], "properties": { "name": { "type": "string", "maxLength": 64 }, "output": { "$ref": "#/$defs/path" }, "public": { "type": "boolean" }, "theme": { "$ref": "#/$defs/path" }, "layout": { "$ref": "#/$defs/path" }, "layout_rules": { "type": "array", "maxItems": 256, "items": { "$ref": "#/$defs/rule" } }, "sitemap": { "$ref": "#/$defs/path_output" }, "rss": { "type": "object", "additionalProperties": false, "required": ["path"], "properties": { "path": { "$ref": "#/$defs/path" }, "limit": { "type": "integer", "minimum": 1, "maximum": 500 } } }, "llms": { "$ref": "#/$defs/path_output" } }, "allOf": [{ "not": { "required": ["theme", "layout"] } }] },
+    "edition": { "type": "object", "additionalProperties": false, "required": ["output"], "properties": { "output": { "$ref": "#/$defs/path" } } },
+    "editions": { "type": "object", "additionalProperties": false, "properties": { "ir": { "$ref": "#/$defs/edition" }, "rag": { "type": "object", "additionalProperties": false, "required": ["output"], "properties": { "output": { "$ref": "#/$defs/path" }, "scope": { "$ref": "#/$defs/path" }, "split_size": { "type": "integer", "minimum": 1 }, "bundles_only": { "type": "boolean" } } }, "context": { "type": "object", "additionalProperties": false, "required": ["output"], "properties": { "output": { "$ref": "#/$defs/path" }, "scope": { "$ref": "#/$defs/path" }, "split_size": { "type": "integer", "minimum": 1 } } } } }
+  }
+}

--- a/docs/contracts/schemas/publication-proof-pack-1.schema.json
+++ b/docs/contracts/schemas/publication-proof-pack-1.schema.json
@@ -1,0 +1,516 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication Proof Pack (schema v1)",
+  "description": "Deterministic target-local presentation model and static HTML source derived exclusively from the committed artifact, checks, claims, and Touch Atlas evidence reports.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "target", "inputs", "summary", "artifacts", "checks", "findings", "claims", "limitations", "relationships", "presentation"],
+  "properties": {
+    "format": { "const": "boris-publication-proof-pack" },
+    "schema_version": { "const": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "inputs": { "$ref": "#/$defs/inputs" },
+    "summary": { "$ref": "#/$defs/summary" },
+    "artifacts": { "type": "array", "items": { "$ref": "#/$defs/artifact_row" } },
+    "checks": {
+      "type": "array",
+      "prefixItems": [
+        { "$ref": "#/$defs/check_row", "type": "object", "properties": { "check_id": { "const": "artifact-integrity" } } },
+        { "$ref": "#/$defs/check_row", "type": "object", "properties": { "check_id": { "const": "rendered-html" } } },
+        { "$ref": "#/$defs/check_row", "type": "object", "properties": { "check_id": { "const": "rendered-search" } } }
+      ],
+      "items": false,
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding_row" }
+    },
+    "claims": {
+      "type": "array",
+      "prefixItems": [
+        { "$ref": "#/$defs/claim_row", "type": "object", "properties": { "claim_id": { "const": "committed-artifacts-match-inventory" } } },
+        { "$ref": "#/$defs/claim_row", "type": "object", "properties": { "claim_id": { "const": "rendered-html-passed-declared-audit" } } },
+        { "$ref": "#/$defs/claim_row", "type": "object", "properties": { "claim_id": { "const": "rendered-search-matches-selected-html" } } }
+      ],
+      "items": false,
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "limitations": {
+      "type": "array",
+      "prefixItems": [
+        { "$ref": "#/$defs/limitation_row", "type": "object", "properties": { "limitation_id": { "const": "target-local-only" } } },
+        { "$ref": "#/$defs/limitation_row", "type": "object", "properties": { "limitation_id": { "const": "no-deployment-verification" } } },
+        { "$ref": "#/$defs/limitation_row", "type": "object", "properties": { "limitation_id": { "const": "no-accessibility-verification" } } },
+        { "$ref": "#/$defs/limitation_row", "type": "object", "properties": { "limitation_id": { "const": "no-prose-quality-verification" } } },
+        { "$ref": "#/$defs/limitation_row", "type": "object", "properties": { "limitation_id": { "const": "no-universal-reproducibility-claim" } } },
+        { "$ref": "#/$defs/limitation_row", "type": "object", "properties": { "limitation_id": { "const": "omitted-projections-not-certified" } } }
+      ],
+      "items": false,
+      "minItems": 6,
+      "maxItems": 6
+    },
+    "relationships": { "$ref": "#/$defs/relationships" },
+    "presentation": { "$ref": "#/$defs/presentation" }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$)).+$"
+    },
+    "artifact_kind": {
+      "enum": ["html-page", "theme-asset", "content-asset", "rendered-search", "sitemap", "rss", "llms"]
+    },
+    "artifact_status": {
+      "enum": ["committed", "omitted-by-plan", "not-applicable"]
+    },
+    "check_id": {
+      "enum": ["artifact-integrity", "rendered-html", "rendered-search"]
+    },
+    "check_status": {
+      "enum": ["passed", "failed", "incomplete", "not-applicable"]
+    },
+    "coverage": {
+      "enum": ["complete", "incomplete", "not-applicable"]
+    },
+    "finding_code": {
+      "enum": [
+        "ARTIFACT_MISSING", "ARTIFACT_SIZE_MISMATCH", "ARTIFACT_DIGEST_MISMATCH",
+        "HTML_PAGE_MISSING", "HTML_MALFORMED", "HTML_URL_MALFORMED",
+        "HTML_LOCAL_ROUTE_MISSING", "HTML_LOCAL_ROUTE_ESCAPE", "HTML_FRAGMENT_MISSING",
+        "HTML_DUPLICATE_ID", "SEARCH_MISSING", "SEARCH_MALFORMED",
+        "SEARCH_DOCUMENT_MISSING", "SEARCH_DOCUMENT_STALE", "SEARCH_CONTENT_MISMATCH"
+      ]
+    },
+    "severity": {
+      "enum": ["error", "warning", "info"]
+    },
+    "claim_id": {
+      "enum": [
+        "committed-artifacts-match-inventory",
+        "rendered-html-passed-declared-audit",
+        "rendered-search-matches-selected-html"
+      ]
+    },
+    "claim_status": {
+      "enum": ["verified", "failed", "not-verified"]
+    },
+    "limitation_id": {
+      "enum": [
+        "target-local-only",
+        "no-deployment-verification",
+        "no-accessibility-verification",
+        "no-prose-quality-verification",
+        "no-universal-reproducibility-claim",
+        "omitted-projections-not-certified"
+      ]
+    },
+    "overall_status": {
+      "enum": ["verified", "attention-required", "incomplete", "not-applicable"]
+    },
+    "edge_kind": {
+      "enum": [
+        "target-owns-artifact",
+        "artifact-subject-of-check",
+        "artifact-supports-check",
+        "check-reported-finding",
+        "check-supports-claim",
+        "claim-limited-by"
+      ]
+    },
+    "node_id": {
+      "anyOf": [
+        { "const": "target" },
+        { "$ref": "#/$defs/artifact_node_id" },
+        { "$ref": "#/$defs/check_node_id" },
+        { "$ref": "#/$defs/finding_node_id" },
+        { "$ref": "#/$defs/claim_node_id" },
+        { "$ref": "#/$defs/limitation_node_id" }
+      ]
+    },
+    "artifact_node_id": {
+      "type": "string",
+      "pattern": "^artifact:.+$"
+    },
+    "check_node_id": {
+      "type": "string",
+      "pattern": "^check:(artifact-integrity|rendered-html|rendered-search)$"
+    },
+    "finding_node_id": {
+      "type": "string",
+      "pattern": "^finding:(artifact-integrity|rendered-html|rendered-search):[0-9]+$"
+    },
+    "claim_node_id": {
+      "type": "string",
+      "pattern": "^claim:(committed-artifacts-match-inventory|rendered-html-passed-declared-audit|rendered-search-matches-selected-html)$"
+    },
+    "limitation_node_id": {
+      "type": "string",
+      "pattern": "^limitation:(target-local-only|no-deployment-verification|no-accessibility-verification|no-prose-quality-verification|no-universal-reproducibility-claim|omitted-projections-not-certified)$"
+    },
+    "input_common": {
+      "type": "object",
+      "required": ["path", "bytes", "sha256", "format", "schema_version", "target"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "format": { "type": "string", "minLength": 1 },
+        "schema_version": { "const": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      }
+    },
+    "artifacts_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["artifact_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/artifacts.json" },
+            "format": { "const": "boris-publication-artifacts" },
+            "artifact_count": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "checks_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["check_count", "finding_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/checks.json" },
+            "format": { "const": "boris-publication-checks" },
+            "check_count": { "const": 3 },
+            "finding_count": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "claims_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["claim_count", "limitation_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/claims.json" },
+            "format": { "const": "boris-publication-claims" },
+            "claim_count": { "const": 3 },
+            "limitation_count": { "const": 6 }
+          }
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "touches_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["node_count", "edge_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/touches.json" },
+            "format": { "const": "boris-publication-touches" },
+            "node_count": { "type": "integer", "minimum": 0 },
+            "edge_count": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifacts", "checks", "claims", "touches"],
+      "properties": {
+        "artifacts": { "$ref": "#/$defs/artifacts_input" },
+        "checks": { "$ref": "#/$defs/checks_input" },
+        "claims": { "$ref": "#/$defs/claims_input" },
+        "touches": { "$ref": "#/$defs/touches_input" }
+      }
+    },
+    "artifact_by_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["committed", "omitted-by-plan", "not-applicable"],
+      "properties": {
+        "committed": { "type": "integer", "minimum": 0 },
+        "omitted-by-plan": { "type": "integer", "minimum": 0 },
+        "not-applicable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "artifact_by_kind": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["html-page", "theme-asset", "content-asset", "rendered-search", "sitemap", "rss", "llms"],
+      "properties": {
+        "html-page": { "type": "integer", "minimum": 0 },
+        "theme-asset": { "type": "integer", "minimum": 0 },
+        "content-asset": { "type": "integer", "minimum": 0 },
+        "rendered-search": { "type": "integer", "minimum": 0 },
+        "sitemap": { "type": "integer", "minimum": 0 },
+        "rss": { "type": "integer", "minimum": 0 },
+        "llms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "check_by_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed", "failed", "incomplete", "not-applicable"],
+      "properties": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "incomplete": { "type": "integer", "minimum": 0 },
+        "not-applicable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "check_by_coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["complete", "incomplete", "not-applicable"],
+      "properties": {
+        "complete": { "type": "integer", "minimum": 0 },
+        "incomplete": { "type": "integer", "minimum": 0 },
+        "not-applicable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "finding_by_severity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["error", "warning", "info"],
+      "properties": {
+        "error": { "type": "integer", "minimum": 0 },
+        "warning": { "type": "integer", "minimum": 0 },
+        "info": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "claim_by_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verified", "failed", "not-verified"],
+      "properties": {
+        "verified": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "not-verified": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifacts", "checks", "findings", "claims",
+        "limitation_count", "relationship_node_count", "relationship_edge_count",
+        "overall_presentation_status"
+      ],
+      "properties": {
+        "artifacts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "by_status", "by_kind"],
+          "properties": {
+            "total": { "type": "integer", "minimum": 0 },
+            "by_status": { "$ref": "#/$defs/artifact_by_status" },
+            "by_kind": { "$ref": "#/$defs/artifact_by_kind" }
+          }
+        },
+        "checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "by_status", "by_coverage"],
+          "properties": {
+            "total": { "const": 3 },
+            "by_status": { "$ref": "#/$defs/check_by_status" },
+            "by_coverage": { "$ref": "#/$defs/check_by_coverage" }
+          }
+        },
+        "findings": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "by_severity"],
+          "properties": {
+            "total": { "type": "integer", "minimum": 0 },
+            "by_severity": { "$ref": "#/$defs/finding_by_severity" }
+          }
+        },
+        "claims": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "by_status"],
+          "properties": {
+            "total": { "const": 3 },
+            "by_status": { "$ref": "#/$defs/claim_by_status" }
+          }
+        },
+        "limitation_count": { "const": 6 },
+        "relationship_node_count": { "type": "integer", "minimum": 0 },
+        "relationship_edge_count": { "type": "integer", "minimum": 0 },
+        "overall_presentation_status": { "$ref": "#/$defs/overall_status" }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eligible", "checked", "findings"],
+      "properties": {
+        "eligible": { "type": "integer", "minimum": 0 },
+        "checked": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "target"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "id": { "type": "string", "minLength": 1 },
+        "target": { "type": ["string", "null"] }
+      }
+    },
+    "artifact_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inventory_index", "path", "kind", "status", "required", "related_check_ids", "related_claim_ids"],
+      "properties": {
+        "inventory_index": { "type": "integer", "minimum": 0 },
+        "path": { "$ref": "#/$defs/relative_path" },
+        "kind": { "$ref": "#/$defs/artifact_kind" },
+        "status": { "$ref": "#/$defs/artifact_status" },
+        "required": { "type": "boolean" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "related_check_ids": { "type": "array", "items": { "$ref": "#/$defs/check_id" } },
+        "related_claim_ids": { "type": "array", "items": { "$ref": "#/$defs/claim_id" } }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+          "then": { "required": ["bytes", "sha256"] },
+          "else": { "not": { "anyOf": [ { "required": ["bytes"] }, { "required": ["sha256"] } ] } }
+        }
+      ]
+    },
+    "check_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "check_index", "check_id", "status", "coverage", "eligible", "ran", "counts",
+        "finding_ids", "subject_artifact_ids", "supporting_artifact_ids", "supported_claim_ids"
+      ],
+      "properties": {
+        "check_index": { "type": "integer", "minimum": 0 },
+        "check_id": { "$ref": "#/$defs/check_id" },
+        "status": { "$ref": "#/$defs/check_status" },
+        "coverage": { "$ref": "#/$defs/coverage" },
+        "eligible": { "type": "boolean" },
+        "ran": { "type": "boolean" },
+        "counts": { "$ref": "#/$defs/counts" },
+        "finding_ids": { "type": "array", "items": { "$ref": "#/$defs/finding_node_id" } },
+        "subject_artifact_ids": { "type": "array", "items": { "$ref": "#/$defs/artifact_node_id" } },
+        "supporting_artifact_ids": { "type": "array", "items": { "$ref": "#/$defs/artifact_node_id" } },
+        "supported_claim_ids": { "type": "array", "items": { "$ref": "#/$defs/claim_node_id" } }
+      }
+    },
+    "finding_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["finding_index", "finding_id", "check_id", "code", "severity", "subject"],
+      "properties": {
+        "finding_index": { "type": "integer", "minimum": 0 },
+        "finding_id": { "$ref": "#/$defs/finding_node_id" },
+        "check_id": { "$ref": "#/$defs/check_id" },
+        "code": { "$ref": "#/$defs/finding_code" },
+        "severity": { "$ref": "#/$defs/severity" },
+        "subject": { "$ref": "#/$defs/subject" }
+      }
+    },
+    "claim_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claim_index", "claim_id", "statement", "status", "evidence_check_id", "limitation_ids"],
+      "properties": {
+        "claim_index": { "type": "integer", "minimum": 0 },
+        "claim_id": { "$ref": "#/$defs/claim_id" },
+        "statement": { "type": "string", "minLength": 1 },
+        "status": { "$ref": "#/$defs/claim_status" },
+        "evidence_check_id": { "$ref": "#/$defs/check_id" },
+        "limitation_ids": { "type": "array", "items": { "$ref": "#/$defs/limitation_id" } }
+      }
+    },
+    "limitation_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["limitation_index", "limitation_id", "statement", "source", "applies_to_claim_ids"],
+      "properties": {
+        "limitation_index": { "type": "integer", "minimum": 0 },
+        "limitation_id": { "$ref": "#/$defs/limitation_id" },
+        "statement": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "minLength": 1 },
+        "applies_to_claim_ids": { "type": "array", "items": { "$ref": "#/$defs/claim_id" } }
+      }
+    },
+    "relationship_edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "$ref": "#/$defs/node_id" },
+        "to": { "$ref": "#/$defs/node_id" }
+      }
+    },
+    "relationship_group": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["edge_kind", "edges"],
+      "properties": {
+        "edge_kind": { "$ref": "#/$defs/edge_kind" },
+        "edges": { "type": "array", "items": { "$ref": "#/$defs/relationship_edge" } }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_ids", "groups"],
+      "properties": {
+        "node_ids": { "type": "array", "items": { "$ref": "#/$defs/node_id" } },
+        "groups": { "type": "array", "items": { "$ref": "#/$defs/relationship_group" } }
+      }
+    },
+    "presentation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["overall_status", "status_vocabulary"],
+      "properties": {
+        "overall_status": { "$ref": "#/$defs/overall_status" },
+        "status_vocabulary": {
+          "type": "array",
+          "prefixItems": [
+            { "const": "verified" },
+            { "const": "attention-required" },
+            { "const": "incomplete" },
+            { "const": "not-applicable" }
+          ],
+          "items": false,
+          "minItems": 4,
+          "maxItems": 4
+        }
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/publication-touches-1.schema.json
+++ b/docs/contracts/schemas/publication-touches-1.schema.json
@@ -1,0 +1,374 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Boris publication Touch Atlas (schema v1)",
+  "description": "Deterministic target-local relationship index derived only from the committed artifact, checks, and claims evidence reports.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "schema_version", "target", "inputs", "nodes", "edges"],
+  "properties": {
+    "format": { "const": "boris-publication-touches" },
+    "schema_version": { "const": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "inputs": { "$ref": "#/$defs/inputs" },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/target_node" },
+          { "$ref": "#/$defs/artifact_node" },
+          { "$ref": "#/$defs/check_node" },
+          { "$ref": "#/$defs/finding_node" },
+          { "$ref": "#/$defs/claim_node" },
+          { "$ref": "#/$defs/limitation_node" }
+        ]
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/target_owns_artifact" },
+          { "$ref": "#/$defs/artifact_subject_of_check" },
+          { "$ref": "#/$defs/artifact_supports_check" },
+          { "$ref": "#/$defs/check_reported_finding" },
+          { "$ref": "#/$defs/check_supports_claim" },
+          { "$ref": "#/$defs/claim_limited_by" }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$)).+$"
+    },
+    "artifact_kind": {
+      "enum": ["html-page", "theme-asset", "content-asset", "rendered-search", "sitemap", "rss", "llms"]
+    },
+    "artifact_status": {
+      "enum": ["committed", "omitted-by-plan", "not-applicable"]
+    },
+    "check_id": {
+      "enum": ["artifact-integrity", "rendered-html", "rendered-search"]
+    },
+    "check_status": {
+      "enum": ["passed", "failed", "incomplete", "not-applicable"]
+    },
+    "coverage": {
+      "enum": ["complete", "incomplete", "not-applicable"]
+    },
+    "finding_code": {
+      "enum": [
+        "ARTIFACT_MISSING", "ARTIFACT_SIZE_MISMATCH", "ARTIFACT_DIGEST_MISMATCH",
+        "HTML_PAGE_MISSING", "HTML_MALFORMED", "HTML_URL_MALFORMED",
+        "HTML_LOCAL_ROUTE_MISSING", "HTML_LOCAL_ROUTE_ESCAPE", "HTML_FRAGMENT_MISSING",
+        "HTML_DUPLICATE_ID", "SEARCH_MISSING", "SEARCH_MALFORMED",
+        "SEARCH_DOCUMENT_MISSING", "SEARCH_DOCUMENT_STALE", "SEARCH_CONTENT_MISMATCH"
+      ]
+    },
+    "severity": {
+      "enum": ["error", "warning", "info"]
+    },
+    "claim_id": {
+      "enum": [
+        "committed-artifacts-match-inventory",
+        "rendered-html-passed-declared-audit",
+        "rendered-search-matches-selected-html"
+      ]
+    },
+    "claim_status": {
+      "enum": ["verified", "failed", "not-verified"]
+    },
+    "limitation_id": {
+      "enum": [
+        "target-local-only",
+        "no-deployment-verification",
+        "no-accessibility-verification",
+        "no-prose-quality-verification",
+        "no-universal-reproducibility-claim",
+        "omitted-projections-not-certified"
+      ]
+    },
+    "artifact_id": {
+      "type": "string",
+      "pattern": "^artifact:.+$"
+    },
+    "check_node_id": {
+      "type": "string",
+      "pattern": "^check:(artifact-integrity|rendered-html|rendered-search)$"
+    },
+    "finding_id": {
+      "type": "string",
+      "pattern": "^finding:(artifact-integrity|rendered-html|rendered-search):[0-9]+$"
+    },
+    "claim_node_id": {
+      "type": "string",
+      "pattern": "^claim:(committed-artifacts-match-inventory|rendered-html-passed-declared-audit|rendered-search-matches-selected-html)$"
+    },
+    "limitation_node_id": {
+      "type": "string",
+      "pattern": "^limitation:(target-local-only|no-deployment-verification|no-accessibility-verification|no-prose-quality-verification|no-universal-reproducibility-claim|omitted-projections-not-certified)$"
+    },
+    "input_common": {
+      "type": "object",
+      "required": ["path", "bytes", "sha256", "format", "schema_version", "target"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "format": { "type": "string", "minLength": 1 },
+        "schema_version": { "const": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      }
+    },
+    "artifacts_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["artifact_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/artifacts.json" },
+            "format": { "const": "boris-publication-artifacts" },
+            "artifact_count": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "checks_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["check_count", "finding_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/checks.json" },
+            "format": { "const": "boris-publication-checks" },
+            "check_count": { "const": 3 },
+            "finding_count": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "claims_input": {
+      "allOf": [
+        { "$ref": "#/$defs/input_common" },
+        {
+          "type": "object",
+          "required": ["claim_count", "limitation_count"],
+          "properties": {
+            "path": { "const": "_boris/proof/claims.json" },
+            "format": { "const": "boris-publication-claims" },
+            "claim_count": { "const": 3 },
+            "limitation_count": { "const": 6 }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifacts", "checks", "claims"],
+      "properties": {
+        "artifacts": { "$ref": "#/$defs/artifacts_input" },
+        "checks": { "$ref": "#/$defs/checks_input" },
+        "claims": { "$ref": "#/$defs/claims_input" }
+      }
+    },
+    "target_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "metadata"],
+      "properties": {
+        "kind": { "const": "target" },
+        "id": { "const": "target" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["target"],
+          "properties": { "target": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "artifact_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "metadata"],
+      "properties": {
+        "kind": { "const": "artifact" },
+        "id": { "$ref": "#/$defs/artifact_id" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["inventory_index", "path", "kind", "status", "required"],
+          "properties": {
+            "inventory_index": { "type": "integer", "minimum": 0 },
+            "path": { "$ref": "#/$defs/relative_path" },
+            "kind": { "$ref": "#/$defs/artifact_kind" },
+            "status": { "$ref": "#/$defs/artifact_status" },
+            "required": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "check_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "metadata"],
+      "properties": {
+        "kind": { "const": "check" },
+        "id": { "$ref": "#/$defs/check_node_id" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["check_index", "check_id", "status", "coverage"],
+          "properties": {
+            "check_index": { "type": "integer", "minimum": 0 },
+            "check_id": { "$ref": "#/$defs/check_id" },
+            "status": { "$ref": "#/$defs/check_status" },
+            "coverage": { "$ref": "#/$defs/coverage" }
+          }
+        }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "target"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "id": { "type": "string", "minLength": 1 },
+        "target": { "type": ["string", "null"] }
+      }
+    },
+    "finding_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "metadata"],
+      "properties": {
+        "kind": { "const": "finding" },
+        "id": { "$ref": "#/$defs/finding_id" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["finding_index", "check_id", "check_finding_index", "code", "severity", "subject"],
+          "properties": {
+            "finding_index": { "type": "integer", "minimum": 0 },
+            "check_id": { "$ref": "#/$defs/check_id" },
+            "check_finding_index": { "type": "integer", "minimum": 0 },
+            "code": { "$ref": "#/$defs/finding_code" },
+            "severity": { "$ref": "#/$defs/severity" },
+            "subject": { "$ref": "#/$defs/subject" }
+          }
+        }
+      }
+    },
+    "claim_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "metadata"],
+      "properties": {
+        "kind": { "const": "claim" },
+        "id": { "$ref": "#/$defs/claim_node_id" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["claim_index", "claim_id", "status"],
+          "properties": {
+            "claim_index": { "type": "integer", "minimum": 0 },
+            "claim_id": { "$ref": "#/$defs/claim_id" },
+            "status": { "$ref": "#/$defs/claim_status" }
+          }
+        }
+      }
+    },
+    "limitation_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "metadata"],
+      "properties": {
+        "kind": { "const": "limitation" },
+        "id": { "$ref": "#/$defs/limitation_node_id" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["limitation_index", "limitation_id", "source"],
+          "properties": {
+            "limitation_index": { "type": "integer", "minimum": 0 },
+            "limitation_id": { "$ref": "#/$defs/limitation_id" },
+            "source": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "target_owns_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": { "const": "target-owns-artifact" },
+        "from": { "const": "target" },
+        "to": { "$ref": "#/$defs/artifact_id" }
+      }
+    },
+    "artifact_subject_of_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": { "const": "artifact-subject-of-check" },
+        "from": { "$ref": "#/$defs/artifact_id" },
+        "to": { "$ref": "#/$defs/check_node_id" }
+      }
+    },
+    "artifact_supports_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": { "const": "artifact-supports-check" },
+        "from": { "$ref": "#/$defs/artifact_id" },
+        "to": { "$ref": "#/$defs/check_node_id" }
+      }
+    },
+    "check_reported_finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": { "const": "check-reported-finding" },
+        "from": { "$ref": "#/$defs/check_node_id" },
+        "to": { "$ref": "#/$defs/finding_id" }
+      }
+    },
+    "check_supports_claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": { "const": "check-supports-claim" },
+        "from": { "$ref": "#/$defs/check_node_id" },
+        "to": { "$ref": "#/$defs/claim_node_id" }
+      }
+    },
+    "claim_limited_by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": { "const": "claim-limited-by" },
+        "from": { "$ref": "#/$defs/claim_node_id" },
+        "to": { "$ref": "#/$defs/limitation_node_id" }
+      }
+    }
+  }
+}

--- a/docs/github-pages.md
+++ b/docs/github-pages.md
@@ -1,0 +1,199 @@
+# GitHub Pages publication
+
+Oliver publishes this `docs/` tree to GitHub Pages with a Boris binary built
+from a pinned Boris revision. The official workflow lives at
+`.github/workflows/github-pages.yml`. It builds the documentation with the
+native Boris binary, resolves the Pages location through
+`actions/configure-pages`, validates that location in a Boris publication
+profile, and deploys only the verified public site tree.
+
+Oliver is the markdown rendering library *inside* Boris; the dependency is
+one-way at the toolchain level. Boris pins Oliver as a library in its own
+`build.zig.zon`, and this repository uses a Boris binary to publish its docs —
+there is no build cycle. The Boris revision is pinned in the workflow and
+recorded in the retained evidence, so the binary that produced the site is
+always identifiable.
+
+## Pipeline at a glance
+
+```text
+profile ──> plan ──> validate ──> compile ──> artifact ──> deploy ──> [audit]
+   │          │         │            │            │           │
+   │          │         │            │            │           └─ optional, opt-in
+   │          │         │            │            └─ public-site, inventory-verified only
+   │          │         │            └─ dist/ HTML + sitemap + _boris/proof/ reports
+   │          │         └─ prepublication checks; no writes (CI gate)
+   │          └─ normalized plan; the single source of URL truth
+   └─ generated from configure-pages outputs
+```
+
+Each stage is governed by a normative contract in
+[`contracts/`](contracts/index.html):
+
+| Stage | What it produces / does | Contract |
+|---|---|---|
+| Profile | `jq` builds the profile from `configure-pages`; `boris plan --profile` validates it | [publication-profile](contracts/publication-profile.html) |
+| Plan | normalized declaration with `site_kind` and the cross-checked `base_url`/`origin`/`base_path` | [publication-plan](contracts/publication-plan.html) |
+| Validate | the same prepublication path as compile, without writing artifacts | — (see compile) |
+| Compile | HTML + sitemap under `dist/`; every URL projection audited against the declared location; proof reports emitted | [publication-model](contracts/publication-model.html) · [checks](contracts/publication-checks.html) · [claims](contracts/publication-claims.html) |
+| Artifact | inventory-verified copy into `public-site/` (bytes + SHA-256, `index.html`, 1 GiB bound) | [artifacts](contracts/publication-artifacts.html) · [touches](contracts/publication-touches.html) · [proof pack](contracts/publication-proof-pack.html) |
+| Deploy | `deploy-pages` publishes the artifact to the `github-pages` environment | — (GitHub's contract) |
+| Audit (optional) | bounded HTTP observation bound to the retained plan and inventory | [deployment evidence](contracts/github-pages-deployment-evidence.html) |
+
+## Enable the target
+
+In the repository’s **Settings → Pages**, choose **GitHub Actions** as the
+source. The workflow runs for pushes to `main` and can also be started with
+**Run workflow**. The workflow uses the supported Pages action sequence:
+
+1. `actions/checkout@v6`
+2. `actions/configure-pages@v5`
+3. `actions/upload-pages-artifact@v4`
+4. `actions/deploy-pages@v4`
+
+The workflow references immutable action commits with the released major
+version in a comment. The Zig setup action is likewise pinned to the reviewed
+`v2.2.1` commit. The deploy job requires a `github-pages` environment (create
+it in **Settings → Environments** if it does not exist; add protection rules
+as desired).
+
+It grants `contents: read` and `pages: read` to the build job. The deployment
+job alone receives `pages: write` and `id-token: write`. Build and deployment
+concurrency is serialized so an older run cannot cancel a newer deployment
+halfway through.
+
+## Toolchain: the pinned Boris revision
+
+The workflow checks out the Boris repository at the workflow-level `BORIS_REV`
+environment variable into `boris/`, installs Zig 0.16.0, and builds the
+toolchain:
+
+```text
+zig build -Doptimize=ReleaseSafe      # in boris/
+```
+
+`BORIS_REV` is the single bump point for the toolchain pin; it is referenced
+from both checkouts (build and optional audit observer) and recorded in the
+retained evidence and build summary. Bump it only after locally re-validating
+against this `docs/` tree (see [Local parity](#local-parity-and-the-starter-profile))
+at the new revision. The reference workflow builds Boris from its own source;
+Oliver cannot do that, so the pinned checkout is the one genuinely new design
+decision in the adapted workflow — everything else carries over.
+
+## Location model
+
+GitHub supplies three related values to the workflow: `base_url`, `origin`, and
+`base_path`. Boris records them in the temporary profile used by
+`boris plan --profile` and rejects contradictions before the site build:
+
+| Pages shape | Example `base_url` | `origin` | `base_path` |
+|---|---|---|---|
+| Project site | `https://drawmeanelephant.github.io/oliver` | `https://drawmeanelephant.github.io` | `/oliver` |
+| User/org root site | `https://drawmeanelephant.github.io` | `https://drawmeanelephant.github.io` | empty |
+| Custom domain | `https://docs.example.com` | `https://docs.example.com` | empty |
+
+The current declaration slice does not invent a CNAME or probe the network.
+If a custom domain is configured with a non-empty path, or if `base_url` does
+not equal `origin + base_path`, the profile fails closed. The normalized
+identity is also available in the [publication profile](contracts/publication-profile.html)
+and [publication plan](contracts/publication-plan.html) contracts.
+
+The build step consumes that normalized plan identity directly:
+
+```text
+boris/zig-out/bin/boris --input docs \
+  --target public=dist \
+  --target-layout public=themes/oliver/layouts/main.html \
+  --sitemap \
+  --pages-base-url https://drawmeanelephant.github.io/oliver \
+  --pages-origin https://drawmeanelephant.github.io \
+  --pages-base-path /oliver \
+  --site-url https://drawmeanelephant.github.io/oliver \
+  --quiet
+```
+
+`--input docs` is explicit because the CLI default content root is `content`;
+this repository publishes its `docs/` tree with the `themes/oliver` theme. The
+compiler audits rendered root-relative/public metadata URLs before target
+replacement and binds sitemap URLs to the same identity. `EPUBLICATIONLOCATION`
+is an actionable publication failure. Root and custom-domain builds pass an
+explicit empty `--pages-base-path`. The check is against the local generated
+artifact; this workflow still makes no post-deploy HTTP claim.
+
+## Local parity and the starter profile
+
+Before touching Actions, run the same pipeline locally. The repository ships a
+[starter publication profile](https://github.com/drawmeanelephant/oliver/blob/main/publication-profile.example.json) declaring
+the project-site shape (`input: docs`, `theme: themes/oliver`,
+`https://drawmeanelephant.github.io/oliver`) at the repository root, so every
+path resolves workspace-relative. From the repository root:
+
+```text
+boris/zig-out/bin/boris plan --profile publication-profile.example.json > /tmp/plan.json
+boris/zig-out/bin/boris validate --input docs \
+  --target public=dist \
+  --target-layout public=themes/oliver/layouts/main.html \
+  --sitemap \
+  --pages-base-url https://drawmeanelephant.github.io/oliver \
+  --pages-origin https://drawmeanelephant.github.io \
+  --pages-base-path /oliver \
+  --site-url https://drawmeanelephant.github.io/oliver
+```
+
+`plan` writes the normalized declaration (exit 2 on an invalid profile, 3 on
+I/O failure); `validate` runs the same prepublication path as the build
+without writing artifacts. Then run the full compile command above and confirm
+exit 0 before the first CI run. The profile is the single source of URL truth —
+never re-derive the Pages location from the repository name.
+
+## Public artifact and retained evidence
+
+The workflow creates two deliberately different uploads:
+
+- The Pages artifact is copied from the exact `committed` records in
+  `dist/_boris/proof/artifacts.json`. The copier checks every byte count and
+  SHA-256, requires `index.html`, rejects symlinks and hard links, enforces the
+  supported 1 GiB Pages artifact limit, and excludes `_boris/proof` reports.
+- The retained evidence artifact contains the normalized plan, the target-local
+  proof reports, and `github-pages-evidence.json`. That binding records the
+  source commit, the pinned Boris revision and version, workflow identity,
+  inventory digest, public file count/bytes, and the exact public-tree manifest
+  digest.
+
+The build summary reports the target, resolved URL/path, public payload size,
+inventory binding, compiler finding count, the pinned Boris revision, and the
+explicit limitation that deployment verification and a post-deploy HTTP audit
+are not claimed by this workflow. A successful `deploy-pages` job means GitHub
+accepted the Pages artifact for deployment; it is not a Boris claim that every
+URL projection or browser request was audited.
+
+## Optional post-deploy audit
+
+The manual **Run workflow** form has an `audit_deployment` boolean, disabled by
+default. When enabled, the deploy job downloads the exact retained plan and
+target-local inventory from the build job, builds the standalone
+`boris-github-pages-audit` Zig tool from the same pinned Boris checkout, and
+passes it the successful `deploy-pages` `page_url`. Push-triggered runs keep
+the audit disabled unless a future workflow-level control explicitly opts in.
+
+The observer writes and uploads
+`boris-github-pages-deployment-evidence-${{ github.run_id }}` as a separate
+ordinary artifact. It is never copied into `public-site`, `_boris/proof`, or
+the Pages artifact. The deployment summary distinguishes the build artifact,
+deployment acceptance, and optional post-deploy audit. The audit step uses
+`continue-on-error` so a failed or incomplete observation still reaches the
+upload step; the JSON report carries the actionable result and limitations.
+
+The default observer bounds are 256 HTTP requests including redirects, 8 MiB
+per decoded response, three redirects per URL, a 10-second per-request
+timeout, and 256 parsed URLs per projection/page. It sends no credentials or
+cookies, accepts only HTTP(S) deployment URLs inside the normalized Pages
+location, and records body digests separately from cache/ETag metadata. See
+the [deployment evidence contract](contracts/github-pages-deployment-evidence.html)
+for the result vocabulary, evidence binding, and coverage limits.
+
+For GitHub’s workflow requirements and action behavior, see the
+[custom workflows for GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages),
+[`configure-pages`](https://github.com/actions/configure-pages),
+[`upload-pages-artifact`](https://github.com/actions/upload-pages-artifact), and
+[`deploy-pages`](https://github.com/actions/deploy-pages) documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,12 +7,12 @@ request. This is the documentation home.
 The documentation is written for two audiences:
 
 - **Consumers** — applications (like Boris) that embed Oliver. Start
-  with [Capabilities](CAPABILITIES.md) and the README's library-use and
+  with [Capabilities](CAPABILITIES.html) and the README's library-use and
   CLI sections, then the frontend pages that matter to you.
 - **Contributors** — anyone changing Oliver. Start with
-  [Architecture](ARCHITECTURE.md) and [Clean-room rules](CLEANROOM.md),
+  [Architecture](ARCHITECTURE.html) and [Clean-room rules](CLEANROOM.html),
   then the per-feature parsing documents and the
-  [work ledger](WORK-LEDGER.md).
+  [work ledger](WORK-LEDGER.html).
 
 ## Conformance status
 
@@ -29,53 +29,73 @@ Both conformance gates run in CI on every push/PR
 
 ## Site map
 
-[nav.json](nav.json) is the machine-readable manifest — sections,
+`nav.json` is the machine-readable manifest — sections,
 pages, titles, audiences, and summaries — that any docs renderer can
 consume directly. The map below mirrors it.
 
 ### Overview
 
-- [Capabilities](CAPABILITIES.md) — what each frontend parses and
+- [Capabilities](CAPABILITIES.html) — what each frontend parses and
   renders today, with conformance status (start here as a user)
-- [Architecture](ARCHITECTURE.md) — pipeline, the two document
+- [Architecture](ARCHITECTURE.html) — pipeline, the two document
   families, module map, the boundaries that matter
-- [Document model](DOCUMENT-MODEL.md) — the shared normalized model and
+- [Document model](DOCUMENT-MODEL.html) — the shared normalized model and
   its invariants
-- [Feature matrix](FEATURE-MATRIX.md) — every implemented feature
+- [Feature matrix](FEATURE-MATRIX.html) — every implemented feature
   across the dialects, with provenance
-- [Tests and fixtures](TESTS.md) — the suites, the conformance walls,
+- [Tests and fixtures](TESTS.html) — the suites, the conformance walls,
   and the fixture convention
-- [CommonMark expectations](COMMONMARK-EXPECTATIONS.md) — the
+- [CommonMark expectations](COMMONMARK-EXPECTATIONS.html) — the
   classified conformance expectation set behind the 652/652 gate
 
 ### Markdown frontend
 
-- [Block parsing](BLOCKS-PARSING.md) · [Leaf blocks](LEAF-BLOCKS.md) ·
-  [Fenced code](FENCED-CODE.md) · [HTML blocks](HTML-BLOCKS.md) ·
-  [Entities](ENTITIES.md)
-- [Emphasis and strong](INLINE-PARSING.md) · [Autolinks](AUTOLINKS.md) ·
-  [Raw HTML](RAW-HTML.md) · [Images](IMAGES-PARSING.md) ·
-  [Reference images](REFERENCE-IMAGES.md) · [Tables (GFM)](TABLES.md)
+- [Block parsing](BLOCKS-PARSING.html) · [Leaf blocks](LEAF-BLOCKS.html) ·
+  [Fenced code](FENCED-CODE.html) · [HTML blocks](HTML-BLOCKS.html) ·
+  [Entities](ENTITIES.html)
+- [Emphasis and strong](INLINE-PARSING.html) · [Autolinks](AUTOLINKS.html) ·
+  [Raw HTML](RAW-HTML.html) · [Images](IMAGES-PARSING.html) ·
+  [Reference images](REFERENCE-IMAGES.html) · [Tables (GFM)](TABLES.html)
 
 ### Textile frontend
 
-- [Textile parity audit](TEXTILE-PARITY.md) · [Inline code
-  contract](TEXTILE-INLINE-CODE.md)
+- [Textile parity audit](TEXTILE-PARITY.html) · [Inline code
+  contract](TEXTILE-INLINE-CODE.html)
 
 ### Cooklang frontend
 
-- [Cooklang design contract](COOKLANG.md) — the typed Recipe model,
+- [Cooklang design contract](COOKLANG.html) — the typed Recipe model,
   the boundaries, and the serialize / scale / HTML / menu policies
 
 ### Process
 
-- [Clean-room rules](CLEANROOM.md) · [Work ledger](WORK-LEDGER.md)
+- [Clean-room rules](CLEANROOM.html) · [Work ledger](WORK-LEDGER.html)
+
+### Publications
+
+- [GitHub Pages publication](github-pages.html) — how this docs tree
+  publishes to GitHub Pages: enable the target, the pinned Boris
+  toolchain, the `/oliver` project-site shape, the public/evidence
+  boundary, and the optional post-deploy audit
+- [Publication contracts](contracts/index.html) — the landing page for
+  the normative contract set behind the publication pipeline
+- Contracts: [model](contracts/publication-model.html) ·
+  [profile](contracts/publication-profile.html) ·
+  [plan](contracts/publication-plan.html) ·
+  [checks](contracts/publication-checks.html) ·
+  [claims](contracts/publication-claims.html) ·
+  [artifacts](contracts/publication-artifacts.html) ·
+  [touches](contracts/publication-touches.html) ·
+  [proof pack](contracts/publication-proof-pack.html) ·
+  [deployment evidence](contracts/github-pages-deployment-evidence.html)
 
 ## Rendering as pages
 
-`docs/nav.json` is the single source of navigation truth and is kept
-renderer-agnostic: a later docs site (mdBook, mkdocs, Docusaurus, or a
-hand-rolled generator) can consume it directly or transpile it to its
-own sidebar format. The markdown files are self-contained and
+This tree currently renders and publishes through the GitHub Pages
+workflow — see the [GitHub Pages publication](github-pages.html) guide.
+`docs/nav.json` remains the single source of navigation truth and is kept
+renderer-agnostic: the renderer, or any other docs generator (mdBook,
+mkdocs, Docusaurus, or a hand-rolled one), can consume it directly or
+transpile it to its own sidebar format. The markdown files are self-contained and
 cross-linked, so any static renderer with a markdown engine can serve
 them as-is — no repository restructuring is needed to ship pages.

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -182,6 +182,77 @@
           "summary": "Historical early-session report."
         }
       ]
+    },
+    {
+      "name": "Publications",
+      "pages": [
+        {
+          "file": "github-pages.md",
+          "title": "GitHub Pages publication",
+          "audience": "user",
+          "summary": "How this docs tree publishes to GitHub Pages: the workflow, the pinned Boris toolchain, the /oliver project-site shape, and the optional post-deploy audit."
+        },
+        {
+          "file": "contracts/index.md",
+          "title": "Publication contracts",
+          "audience": "dev",
+          "summary": "Landing page for the normative publication contract set Oliver's Pages pipeline relies on."
+        },
+        {
+          "file": "contracts/publication-model.md",
+          "title": "Publication model contract",
+          "audience": "dev",
+          "summary": "The meta-contract: document facts, publication facts, migration provenance, projections, and verification claims."
+        },
+        {
+          "file": "contracts/publication-profile.md",
+          "title": "Publication profile contract",
+          "audience": "dev",
+          "summary": "Schema v1 declaration input: the GitHub Pages location slice, bounds, and fail-closed validation."
+        },
+        {
+          "file": "contracts/publication-plan.md",
+          "title": "Publication plan contract",
+          "audience": "dev",
+          "summary": "The normalized declaration: boris plan --profile stdout, canonical JSON, and determinism."
+        },
+        {
+          "file": "contracts/publication-checks.md",
+          "title": "Publication checks contract",
+          "audience": "dev",
+          "summary": "Target-local checks.json: which checks ran and their findings, bound to committed inventory bytes."
+        },
+        {
+          "file": "contracts/publication-claims.md",
+          "title": "Publication claims contract",
+          "audience": "dev",
+          "summary": "Target-local claims.json: fixed claims and limitations derived from inventory and checks bytes."
+        },
+        {
+          "file": "contracts/publication-artifacts.md",
+          "title": "Publication artifacts contract",
+          "audience": "dev",
+          "summary": "The committed artifacts.json inventory: byte counts and SHA-256 for every emitted file."
+        },
+        {
+          "file": "contracts/publication-touches.md",
+          "title": "Publication Touch Atlas contract",
+          "audience": "dev",
+          "summary": "touches.json: the relationship index derived exclusively from the existing evidence reports."
+        },
+        {
+          "file": "contracts/publication-proof-pack.md",
+          "title": "Publication Proof Pack contract",
+          "audience": "dev",
+          "summary": "The two-file presentation model (proof-pack.json + index.html) over committed evidence."
+        },
+        {
+          "file": "contracts/github-pages-deployment-evidence.md",
+          "title": "Deployment evidence contract",
+          "audience": "dev",
+          "summary": "The optional post-deploy audit report: a bounded HTTP observation bound to the plan and inventory."
+        }
+      ]
     }
   ]
 }

--- a/publication-profile.example.json
+++ b/publication-profile.example.json
@@ -1,0 +1,23 @@
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "docs",
+  "site": {
+    "url": "https://drawmeanelephant.github.io/oliver"
+  },
+  "publication": {
+    "target": "github-pages",
+    "base_url": "https://drawmeanelephant.github.io/oliver",
+    "origin": "https://drawmeanelephant.github.io",
+    "base_path": "/oliver"
+  },
+  "targets": [
+    {
+      "name": "public",
+      "output": "dist",
+      "public": true,
+      "theme": "themes/oliver",
+      "sitemap": { "path": "sitemap.xml" }
+    }
+  ]
+}

--- a/themes/oliver/assets/css/oliver.css
+++ b/themes/oliver/assets/css/oliver.css
@@ -569,6 +569,151 @@ hr {
   padding-left: 20px;
 }
 
+/* Search widget (the compiler-emitted rendered-search index, client-side) */
+.site-search__label {
+  display: block;
+  font-family: var(--txp-font-sans);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--txp-text-light);
+  margin-bottom: 6px;
+}
+
+.site-search__controls input[type="search"] {
+  width: 100%;
+  padding: 8px 10px;
+  font-family: var(--txp-font-sans);
+  font-size: 0.9rem;
+  color: var(--txp-text-main);
+  background: #ffffff;
+  border: 1px solid var(--txp-border-dark);
+  border-left: 3px solid var(--txp-crimson);
+  border-radius: 2px;
+}
+
+.site-search__controls input[type="search"]:focus {
+  outline: none;
+  border-color: var(--txp-crimson);
+  box-shadow: 0 0 0 1px rgba(140, 35, 35, 0.25);
+}
+
+.site-search__status {
+  margin: 8px 0 0 0;
+  font-family: var(--txp-font-sans);
+  font-size: 0.75rem;
+  color: var(--txp-text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.site-search__results {
+  list-style: none;
+  margin: 8px 0 0 0;
+  padding: 0;
+}
+
+.site-search__result {
+  margin-bottom: 8px;
+}
+
+.site-search__result a {
+  display: block;
+  padding: 8px 10px;
+  background: #ffffff;
+  border: 1px solid var(--txp-border-color);
+  border-left: 3px solid var(--txp-crimson);
+  text-decoration: none;
+  color: var(--txp-text-main);
+}
+
+.site-search__result a:hover {
+  background: var(--txp-crimson-light);
+  border-left-color: var(--txp-crimson-hover);
+}
+
+.site-search__title {
+  display: block;
+  font-family: var(--txp-font-serif);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--txp-crimson);
+}
+
+.site-search__path {
+  display: block;
+  font-family: var(--txp-font-mono);
+  font-size: 0.7rem;
+  color: var(--txp-text-light);
+  text-transform: lowercase;
+  margin: 2px 0;
+}
+
+.site-search__excerpt {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--txp-text-muted);
+}
+
+.site-search__fallback {
+  margin: 8px 0 0 0;
+  font-size: 0.8rem;
+  color: var(--txp-text-muted);
+}
+
+/* Grouped Documentation menu subheadings */
+.txp-sidebar .site-nav li.site-nav__group {
+  margin: 14px 0 6px 0;
+  padding-bottom: 3px;
+  font-family: var(--txp-font-sans);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--txp-slate);
+  border-bottom: 1px solid var(--txp-border-dark);
+}
+
+.txp-sidebar .site-nav li.site-nav__group:first-child {
+  margin-top: 0;
+}
+
+/* Conformance status box */
+.txp-status-box {
+  background: #ffffff;
+  border: 1px solid var(--txp-border-color);
+  padding: 10px 14px;
+  margin-bottom: 8px;
+}
+
+.txp-status-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.8rem;
+  border-bottom: 1px dotted var(--txp-border-subtle);
+}
+
+.txp-status-row:last-child {
+  border-bottom: none;
+}
+
+.txp-status-key {
+  font-weight: 600;
+  color: var(--txp-text-muted);
+}
+
+.txp-status-val {
+  color: var(--txp-crimson);
+  font-weight: 700;
+}
+
+.txp-small-text {
+  font-size: 0.75rem;
+  color: var(--txp-text-light);
+}
+
 /* ==========================================================================
    Site Footer
    ========================================================================== */

--- a/themes/oliver/assets/css/oliver.css
+++ b/themes/oliver/assets/css/oliver.css
@@ -1,56 +1,644 @@
+/* ==========================================================================
+   oliver.css — Textpattern-inspired documentation theme
+   Classic Textpattern 4.0 / Dean Allen Aesthetic, adapted to the Oliver
+   docs tree (masthead, tabbed site nav, two-column article + sidebar).
+   Pure CSS • Zero External Dependencies • Local System Fonts Only
+   ========================================================================== */
+
 :root {
-  --oliver-ink: #1c1e21;
-  --oliver-muted: #5c6470;
-  --oliver-line: #e2e5ea;
-  --oliver-accent: #3b5bdb;
-  --oliver-bg: #ffffff;
-  --oliver-sidebar: #f6f7f9;
+  /* Core Color Palette: Warm Linen, Cream, Slate & Crimson */
+  --txp-page-bg: #f2efe9;
+  --txp-paper-bg: #ffffff;
+  --txp-sidebar-bg: #fbfaf7;
+  --txp-header-bg: #272c30;
+  --txp-header-text: #ffffff;
+  --txp-header-tagline: #b0b7bd;
+
+  /* Text & Accents */
+  --txp-text-main: #2b2b2b;
+  --txp-text-muted: #66625b;
+  --txp-text-light: #88837a;
+  --txp-crimson: #8c2323;
+  --txp-crimson-hover: #b02e2e;
+  --txp-crimson-light: #fbf2f2;
+  --txp-slate: #3f474e;
+  --txp-slate-light: #eef2f5;
+
+  /* Borders & Dividers */
+  --txp-border-color: #ded9cd;
+  --txp-border-dark: #c4beaf;
+  --txp-border-subtle: #ede9df;
+
+  /* Code & Preformatted */
+  --txp-code-bg: #f7f6f0;
+  --txp-code-border: #e2ddd2;
+  --txp-code-text: #782323;
+  --txp-pre-bg: #282c34;
+  --txp-pre-text: #abb2bf;
+
+  /* Typography Stacks (100% Local System Fonts) */
+  --txp-font-serif: "Georgia", "Palatino Linotype", "Book Antiqua", Palatino, "Times New Roman", Times, serif;
+  --txp-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Trebuchet MS", "Lucida Grande", "Helvetica Neue", Arial, sans-serif;
+  --txp-font-mono: ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", "Courier New", Courier, monospace;
 }
 
-* { box-sizing: border-box; }
+/* Base Reset & Box Sizing */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 
-body {
+html {
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-text-size-adjust: 100%;
+}
+
+body.txp-body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-  color: var(--oliver-ink);
-  background: var(--oliver-bg);
-  line-height: 1.55;
+  padding: 24px 16px;
+  background-color: var(--txp-page-bg);
+  color: var(--txp-text-main);
+  font-family: var(--txp-font-serif);
+  background-image: radial-gradient(var(--txp-border-dark) 0.75px, transparent 0.75px);
+  background-size: 20px 20px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.site-sidebar {
-  position: sticky;
-  top: 0;
-  align-self: start;
-  padding: 1.25rem 1.5rem;
-  background: var(--oliver-sidebar);
-  border-right: 1px solid var(--oliver-line);
+/* Master Container */
+.txp-container {
+  max-width: 1060px;
+  margin: 0 auto;
+  background: var(--txp-paper-bg);
+  border: 1px solid var(--txp-border-dark);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07), 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
-@media (min-width: 64rem) {
-  body { display: grid; grid-template-columns: 18rem minmax(0, 1fr); }
-  .site-sidebar { height: 100vh; overflow-y: auto; }
-  main, nav.site-breadcrumb, nav.site-toc { padding: 2rem 3rem; max-width: 60rem; }
+/* ==========================================================================
+   Header & Masthead
+   ========================================================================== */
+
+.txp-header {
+  background-color: var(--txp-header-bg);
+  color: var(--txp-header-text);
+  border-bottom: 3px solid var(--txp-crimson);
 }
 
-.site-brand__name { display: block; font-weight: 700; font-size: 1.25rem; }
-.site-brand__tagline { display: block; margin-top: 0.25rem; color: var(--oliver-muted); font-size: 0.85rem; }
+.txp-branding {
+  padding: 36px 36px 28px 36px;
+}
 
-.site-menu summary { cursor: pointer; font-weight: 600; margin: 1rem 0 0.5rem; }
-.site-menu ul { list-style: none; padding-left: 0.75rem; margin: 0.25rem 0; }
-.site-menu li { margin: 0.15rem 0; }
-.site-menu a { color: var(--oliver-accent); text-decoration: none; }
-.site-menu a:hover { text-decoration: underline; }
+.txp-site-name {
+  margin: 0 0 6px 0;
+  font-family: var(--txp-font-serif);
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
 
-main { min-width: 0; padding: 2rem 1.5rem; }
-main h1 { font-size: 1.9rem; border-bottom: 1px solid var(--oliver-line); padding-bottom: 0.4rem; }
-main h2 { font-size: 1.4rem; margin-top: 2rem; }
-main h3 { font-size: 1.15rem; }
-main a { color: var(--oliver-accent); }
-main code { background: var(--oliver-sidebar); border-radius: 4px; padding: 0.1em 0.35em; font-size: 0.9em; }
-main pre { background: var(--oliver-sidebar); border: 1px solid var(--oliver-line); border-radius: 6px; padding: 1rem; overflow-x: auto; }
-main pre code { background: none; padding: 0; }
-main table { border-collapse: collapse; width: 100%; }
-main th, main td { border: 1px solid var(--oliver-line); padding: 0.4rem 0.6rem; text-align: left; }
-main blockquote { border-left: 3px solid var(--oliver-accent); margin-left: 0; padding-left: 1rem; color: var(--oliver-muted); }
+.txp-site-name a {
+  color: var(--txp-header-text);
+  text-decoration: none;
+  transition: color 0.15s ease-in-out;
+}
 
-.site-footer { grid-column: 1 / -1; padding: 1rem 1.5rem; border-top: 1px solid var(--oliver-line); color: var(--oliver-muted); font-size: 0.85rem; }
+.txp-site-name a:hover {
+  color: #ffcccc;
+}
+
+.txp-amp {
+  color: var(--txp-crimson);
+  font-style: italic;
+  font-weight: 400;
+  padding: 0 2px;
+}
+
+.txp-tagline {
+  margin: 0;
+  font-family: var(--txp-font-sans);
+  font-size: 0.95rem;
+  color: var(--txp-header-tagline);
+  letter-spacing: 0.02em;
+}
+
+/* Documentation menu (the emitted site-nav slot, rendered as a dense
+   sidebar link list in the Textpattern tradition). */
+.txp-sidebar .site-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.txp-sidebar .site-nav li {
+  margin-bottom: 6px;
+}
+
+.txp-sidebar .site-nav a {
+  display: block;
+  padding: 4px 6px;
+  color: var(--txp-text-main);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--txp-border-color);
+  font-weight: 500;
+  font-size: 0.85rem;
+  transition: all 0.15s ease;
+}
+
+.txp-sidebar .site-nav a:hover {
+  background-color: var(--txp-crimson-light);
+  color: var(--txp-crimson);
+  border-bottom-color: var(--txp-crimson);
+  padding-left: 10px;
+}
+
+.txp-sidebar .site-nav li.is-current a {
+  color: var(--txp-crimson);
+  font-weight: 700;
+}
+
+/* ==========================================================================
+   Two-Column Layout Grid
+   ========================================================================== */
+
+.txp-layout-body {
+  display: flex;
+  flex-direction: row;
+  min-height: 600px;
+}
+
+/* Main Content Column */
+.txp-content {
+  flex: 1 1 68%;
+  min-width: 0; /* Prevents overflow */
+  padding: 36px 40px;
+  background-color: var(--txp-paper-bg);
+}
+
+/* Sidebar Column */
+.txp-sidebar {
+  flex: 0 0 32%;
+  min-width: 280px;
+  max-width: 340px;
+  background-color: var(--txp-sidebar-bg);
+  border-left: 1px solid var(--txp-border-color);
+  padding: 32px 24px;
+}
+
+/* ==========================================================================
+   Article Header & Breadcrumb
+   ========================================================================== */
+
+.txp-article-header {
+  margin-bottom: 28px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--txp-border-color);
+}
+
+.txp-article-header .breadcrumb ol {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  font-family: var(--txp-font-sans);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--txp-text-light);
+}
+
+.txp-article-header .breadcrumb li {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.txp-article-header .breadcrumb li:not(:first-child)::before {
+  content: "›";
+  color: var(--txp-border-dark);
+  padding-right: 4px;
+}
+
+.txp-article-header .breadcrumb a {
+  color: var(--txp-crimson);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(140, 35, 35, 0.25);
+}
+
+.txp-article-header .breadcrumb li[aria-current="page"] {
+  color: var(--txp-text-main);
+  font-weight: 600;
+}
+
+/* ==========================================================================
+   Article & Typography
+   ========================================================================== */
+
+/* The page's own <h1> is the article title (every doc starts with "# Title"). */
+.txp-article-body h1 {
+  margin: 0 0 24px 0;
+  font-family: var(--txp-font-serif);
+  font-size: 2.15rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  line-height: 1.25;
+  border-bottom: 2px solid var(--txp-crimson);
+  padding-bottom: 10px;
+}
+
+.txp-article-body h2 {
+  font-family: var(--txp-font-serif);
+  color: #1a1a1a;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+  font-size: 1.5rem;
+  border-bottom: 1px dotted var(--txp-border-dark);
+  padding-bottom: 4px;
+}
+
+.txp-article-body h3 {
+  font-family: var(--txp-font-serif);
+  color: var(--txp-crimson);
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+  font-size: 1.25rem;
+}
+
+.txp-article-body h4 {
+  font-family: var(--txp-font-serif);
+  color: var(--txp-slate);
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.txp-article-body h5,
+.txp-article-body h6 {
+  font-family: var(--txp-font-serif);
+  color: #1a1a1a;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.txp-article-body {
+  font-size: 1.05rem;
+  color: var(--txp-text-main);
+}
+
+.txp-article-body p {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+}
+
+/* Hyperlinks */
+a {
+  color: var(--txp-crimson);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(140, 35, 35, 0.25);
+  transition: all 0.15s ease-in-out;
+}
+
+a:hover {
+  color: var(--txp-crimson-hover);
+  border-bottom-color: var(--txp-crimson);
+  background-color: var(--txp-crimson-light);
+}
+
+/* Blockquotes */
+blockquote {
+  margin: 1.5rem 0;
+  padding: 14px 20px;
+  background-color: #fcfbfa;
+  border-left: 4px solid var(--txp-crimson);
+  border-top: 1px solid var(--txp-border-subtle);
+  border-right: 1px solid var(--txp-border-subtle);
+  border-bottom: 1px solid var(--txp-border-subtle);
+  font-style: italic;
+  color: #4a463e;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+blockquote cite {
+  display: block;
+  margin-top: 8px;
+  font-family: var(--txp-font-sans);
+  font-size: 0.8rem;
+  font-style: normal;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--txp-text-light);
+}
+
+/* Lists */
+.txp-article-body ul,
+.txp-article-body ol {
+  margin-top: 0;
+  margin-bottom: 1.35rem;
+  padding-left: 28px;
+}
+
+.txp-article-body li {
+  margin-bottom: 0.4rem;
+}
+
+.txp-article-body li > ul,
+.txp-article-body li > ol {
+  margin-top: 0.3rem;
+  margin-bottom: 0.3rem;
+}
+
+/* Definition Lists */
+dl {
+  margin: 1.25rem 0;
+  background: var(--txp-sidebar-bg);
+  border: 1px solid var(--txp-border-color);
+  padding: 16px 20px;
+}
+
+dt {
+  font-family: var(--txp-font-sans);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--txp-crimson);
+  margin-top: 8px;
+}
+
+dt:first-child {
+  margin-top: 0;
+}
+
+dd {
+  margin-left: 0;
+  margin-bottom: 12px;
+  padding-left: 16px;
+  border-left: 2px solid var(--txp-border-color);
+  color: var(--txp-text-main);
+  font-size: 0.95rem;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-family: var(--txp-font-sans);
+  font-size: 0.9rem;
+  background: #ffffff;
+  border: 1px solid var(--txp-border-dark);
+}
+
+th {
+  background-color: var(--txp-slate);
+  color: #ffffff;
+  font-weight: 600;
+  text-align: left;
+  padding: 10px 14px;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--txp-slate);
+}
+
+td {
+  padding: 9px 14px;
+  border: 1px solid var(--txp-border-color);
+  vertical-align: top;
+}
+
+tr:nth-child(even) td {
+  background-color: #faf9f6;
+}
+
+tr:hover td {
+  background-color: var(--txp-crimson-light);
+}
+
+/* Code & Preformatted */
+code {
+  font-family: var(--txp-font-mono);
+  font-size: 0.88em;
+  background-color: var(--txp-code-bg);
+  color: var(--txp-code-text);
+  border: 1px solid var(--txp-code-border);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+
+pre {
+  margin: 1.5rem 0;
+  padding: 16px 20px;
+  background-color: #21252b;
+  color: #e5e9f0;
+  font-family: var(--txp-font-mono);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  border: 1px solid #181a1f;
+  border-left: 4px solid var(--txp-crimson);
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* Phrase Modifiers */
+del {
+  color: #9e4a4a;
+  text-decoration: line-through;
+}
+
+ins {
+  color: #2b6e3f;
+  text-decoration: underline;
+  background-color: #f0f8f2;
+}
+
+kbd {
+  font-family: var(--txp-font-mono);
+  font-size: 0.8em;
+  background-color: #f7f7f7;
+  color: #333333;
+  border: 1px solid #ccc;
+  border-bottom: 2px solid #bbb;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+abbr {
+  border-bottom: 1px dotted var(--txp-crimson);
+  cursor: help;
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  background-color: var(--txp-border-color);
+  margin: 2.25rem 0;
+}
+
+/* ==========================================================================
+   Sidebar Widgets
+   ========================================================================== */
+
+.txp-widget {
+  margin-bottom: 28px;
+  padding-bottom: 24px;
+  border-bottom: 1px dotted var(--txp-border-dark);
+  font-family: var(--txp-font-sans);
+  font-size: 0.9rem;
+}
+
+.txp-widget:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.txp-widget-title {
+  font-family: var(--txp-font-serif);
+  font-size: 1.15rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #1a1a1a;
+  margin: 0 0 12px 0;
+  padding-bottom: 4px;
+  border-bottom: 2px solid var(--txp-crimson);
+}
+
+.txp-widget p {
+  margin: 0 0 10px 0;
+  color: var(--txp-text-muted);
+  line-height: 1.5;
+}
+
+/* "On this page" table of contents (the emitted page-toc slot) */
+.txp-sidebar .page-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.txp-sidebar .page-toc li {
+  margin-bottom: 4px;
+}
+
+.txp-sidebar .page-toc a {
+  display: block;
+  padding: 3px 6px;
+  color: var(--txp-text-main);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--txp-border-color);
+  font-weight: 500;
+  font-size: 0.88rem;
+  transition: all 0.15s ease;
+}
+
+.txp-sidebar .page-toc a:hover {
+  background-color: var(--txp-crimson-light);
+  color: var(--txp-crimson);
+  border-bottom-color: var(--txp-crimson);
+  padding-left: 10px;
+}
+
+.txp-sidebar .page-toc .page-toc__l2 a {
+  padding-left: 16px;
+  font-weight: 400;
+}
+
+.txp-sidebar .page-toc .page-toc__l2 a:hover {
+  padding-left: 20px;
+}
+
+/* ==========================================================================
+   Site Footer
+   ========================================================================== */
+
+.txp-footer {
+  background-color: #1f2327;
+  color: #9ca3af;
+  border-top: 3px solid var(--txp-crimson);
+  padding: 24px 36px;
+  font-family: var(--txp-font-sans);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.txp-footer a {
+  color: #d1d5db;
+  border-bottom-color: rgba(209, 213, 219, 0.4);
+}
+
+.txp-footer a:hover {
+  color: #ffffff;
+  background: transparent;
+  border-bottom-color: #ffffff;
+}
+
+.txp-footer-line {
+  margin: 0 0 6px 0;
+}
+
+.txp-footer-meta {
+  margin: 0;
+  font-size: 0.775rem;
+  color: #6b7280;
+}
+
+.txp-footer-meta code {
+  background: #111417;
+  color: #e5e7eb;
+  border-color: #374151;
+}
+
+/* ==========================================================================
+   Responsive Adaptations
+   ========================================================================== */
+
+@media (max-width: 860px) {
+  body.txp-body {
+    padding: 10px;
+  }
+
+  .txp-branding {
+    padding: 24px 20px 18px 20px;
+  }
+
+  .txp-site-name {
+    font-size: 1.75rem;
+  }
+
+  .txp-layout-body {
+    flex-direction: column;
+  }
+
+  .txp-content {
+    padding: 24px 20px;
+  }
+
+  .txp-sidebar {
+    border-left: none;
+    border-top: 2px solid var(--txp-border-color);
+    max-width: 100%;
+    padding: 28px 20px;
+  }
+}

--- a/themes/oliver/assets/css/oliver.css
+++ b/themes/oliver/assets/css/oliver.css
@@ -1,0 +1,56 @@
+:root {
+  --oliver-ink: #1c1e21;
+  --oliver-muted: #5c6470;
+  --oliver-line: #e2e5ea;
+  --oliver-accent: #3b5bdb;
+  --oliver-bg: #ffffff;
+  --oliver-sidebar: #f6f7f9;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--oliver-ink);
+  background: var(--oliver-bg);
+  line-height: 1.55;
+}
+
+.site-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  padding: 1.25rem 1.5rem;
+  background: var(--oliver-sidebar);
+  border-right: 1px solid var(--oliver-line);
+}
+
+@media (min-width: 64rem) {
+  body { display: grid; grid-template-columns: 18rem minmax(0, 1fr); }
+  .site-sidebar { height: 100vh; overflow-y: auto; }
+  main, nav.site-breadcrumb, nav.site-toc { padding: 2rem 3rem; max-width: 60rem; }
+}
+
+.site-brand__name { display: block; font-weight: 700; font-size: 1.25rem; }
+.site-brand__tagline { display: block; margin-top: 0.25rem; color: var(--oliver-muted); font-size: 0.85rem; }
+
+.site-menu summary { cursor: pointer; font-weight: 600; margin: 1rem 0 0.5rem; }
+.site-menu ul { list-style: none; padding-left: 0.75rem; margin: 0.25rem 0; }
+.site-menu li { margin: 0.15rem 0; }
+.site-menu a { color: var(--oliver-accent); text-decoration: none; }
+.site-menu a:hover { text-decoration: underline; }
+
+main { min-width: 0; padding: 2rem 1.5rem; }
+main h1 { font-size: 1.9rem; border-bottom: 1px solid var(--oliver-line); padding-bottom: 0.4rem; }
+main h2 { font-size: 1.4rem; margin-top: 2rem; }
+main h3 { font-size: 1.15rem; }
+main a { color: var(--oliver-accent); }
+main code { background: var(--oliver-sidebar); border-radius: 4px; padding: 0.1em 0.35em; font-size: 0.9em; }
+main pre { background: var(--oliver-sidebar); border: 1px solid var(--oliver-line); border-radius: 6px; padding: 1rem; overflow-x: auto; }
+main pre code { background: none; padding: 0; }
+main table { border-collapse: collapse; width: 100%; }
+main th, main td { border: 1px solid var(--oliver-line); padding: 0.4rem 0.6rem; text-align: left; }
+main blockquote { border-left: 3px solid var(--oliver-accent); margin-left: 0; padding-left: 1rem; color: var(--oliver-muted); }
+
+.site-footer { grid-column: 1 / -1; padding: 1rem 1.5rem; border-top: 1px solid var(--oliver-line); color: var(--oliver-muted); font-size: 0.85rem; }

--- a/themes/oliver/layouts/main.html
+++ b/themes/oliver/layouts/main.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{title}} · Oliver</title>
+  <link rel="stylesheet" href="{{asset-url assets/css/oliver.css}}">
+</head>
+<body>
+<aside class="site-sidebar">
+<header class="site-brand">
+<span class="site-brand__name">Oliver</span>
+<span class="site-brand__tagline">A small, freestanding markup parsing and rendering library in Zig.</span>
+</header>
+<details class="site-menu" open>
+<summary>Documentation menu</summary>
+{{nav}}
+</details>
+</aside>
+{{breadcrumb}}
+{{toc}}
+<main>
+{{content}}
+</main>
+<footer class="site-footer">Oliver documentation · deterministic markup in, typed documents out</footer>
+</body>
+</html>

--- a/themes/oliver/layouts/main.html
+++ b/themes/oliver/layouts/main.html
@@ -6,22 +6,46 @@
   <title>{{title}} · Oliver</title>
   <link rel="stylesheet" href="{{asset-url assets/css/oliver.css}}">
 </head>
-<body>
-<aside class="site-sidebar">
-<header class="site-brand">
-<span class="site-brand__name">Oliver</span>
-<span class="site-brand__tagline">A small, freestanding markup parsing and rendering library in Zig.</span>
-</header>
-<details class="site-menu" open>
-<summary>Documentation menu</summary>
-{{nav}}
-</details>
-</aside>
-{{breadcrumb}}
-{{toc}}
-<main>
-{{content}}
-</main>
-<footer class="site-footer">Oliver documentation · deterministic markup in, typed documents out</footer>
+<body class="txp-body">
+<div class="txp-container">
+  <header class="txp-header">
+    <div class="txp-branding">
+      <p class="txp-site-name">Oliver<span class="txp-amp">&amp;</span>docs</p>
+      <p class="txp-tagline">A small, freestanding markup parsing and rendering library in Zig.</p>
+    </div>
+  </header>
+  <div class="txp-layout-body">
+    <article class="txp-content">
+      <header class="txp-article-header">
+        {{breadcrumb}}
+      </header>
+      <div class="txp-article-body">
+        {{content}}
+      </div>
+    </article>
+    <aside class="txp-sidebar">
+      <div class="txp-widget">
+        <h2 class="txp-widget-title">On this page</h2>
+        {{toc}}
+      </div>
+      <div class="txp-widget">
+        <h2 class="txp-widget-title">Documentation</h2>
+        {{nav}}
+      </div>
+      <div class="txp-widget">
+        <h2 class="txp-widget-title">About Oliver</h2>
+        <p>Oliver is a small, freestanding markup parsing and rendering library in Zig: Markdown, Textile, and Cooklang in, deterministic HTML out.</p>
+      </div>
+      <div class="txp-widget">
+        <h2 class="txp-widget-title">Publication</h2>
+        <p>This documentation is built with a pinned Boris binary and published to GitHub Pages. The publication guide, contracts, and pipeline are in the Documentation menu.</p>
+      </div>
+    </aside>
+  </div>
+  <footer class="txp-footer">
+    <p class="txp-footer-line">Oliver documentation · deterministic markup in, typed documents out</p>
+    <p class="txp-footer-meta">GitHub Pages · oliver theme · built with Boris</p>
+  </footer>
+</div>
 </body>
 </html>

--- a/themes/oliver/layouts/main.html
+++ b/themes/oliver/layouts/main.html
@@ -25,19 +25,43 @@
     </article>
     <aside class="txp-sidebar">
       <div class="txp-widget">
-        <h2 class="txp-widget-title">On this page</h2>
+        <h2 class="txp-widget-title" id="search">Search</h2>
+        <section class="site-search" data-boris-search-ui aria-labelledby="site-search-label">
+          <form action="_boris/search/" method="get" role="search" data-boris-search-form>
+            <label class="site-search__label" id="site-search-label" for="site-search-input">Search the documentation</label>
+            <div class="site-search__controls">
+              <input id="site-search-input" name="q" type="search" autocomplete="off" placeholder="Search…" spellcheck="false">
+            </div>
+          </form>
+          <p class="site-search__status" data-boris-search-status role="status" aria-live="polite">Loading search…</p>
+          <ol class="site-search__results" data-boris-search-results aria-label="Search results"></ol>
+          <noscript><p class="site-search__fallback">Search needs JavaScript in this static site. Use the Documentation menu.</p></noscript>
+        </section>
+      </div>
+      <div class="txp-widget">
+        <h2 class="txp-widget-title" id="on-this-page">On this page</h2>
         {{toc}}
       </div>
       <div class="txp-widget">
-        <h2 class="txp-widget-title">Documentation</h2>
+        <h2 class="txp-widget-title" id="documentation">Documentation</h2>
         {{nav}}
       </div>
       <div class="txp-widget">
-        <h2 class="txp-widget-title">About Oliver</h2>
+        <h2 class="txp-widget-title" id="conformance">Conformance</h2>
+        <div class="txp-status-box">
+          <div class="txp-status-row"><span class="txp-status-key">CommonMark 0.31.2</span><span class="txp-status-val">652/652</span></div>
+          <div class="txp-status-row"><span class="txp-status-key">Cooklang canonical</span><span class="txp-status-val">60/60</span></div>
+          <div class="txp-status-row"><span class="txp-status-key">Textile fixture wall</span><span class="txp-status-val">green</span></div>
+          <div class="txp-status-row"><span class="txp-status-key">Test suite</span><span class="txp-status-val">251/251</span></div>
+        </div>
+        <p class="txp-small-text">The walls gate every push. Snapshot from the docs home.</p>
+      </div>
+      <div class="txp-widget">
+        <h2 class="txp-widget-title" id="about-oliver">About Oliver</h2>
         <p>Oliver is a small, freestanding markup parsing and rendering library in Zig: Markdown, Textile, and Cooklang in, deterministic HTML out.</p>
       </div>
       <div class="txp-widget">
-        <h2 class="txp-widget-title">Publication</h2>
+        <h2 class="txp-widget-title" id="publication">Publication</h2>
         <p>This documentation is built with a pinned Boris binary and published to GitHub Pages. The publication guide, contracts, and pipeline are in the Documentation menu.</p>
       </div>
     </aside>
@@ -47,5 +71,116 @@
     <p class="txp-footer-meta">GitHub Pages · oliver theme · built with Boris</p>
   </footer>
 </div>
+<script>
+(() => {
+  "use strict";
+  // Site search over the compiler-emitted rendered-search index.
+  const ui = document.querySelector("[data-boris-search-ui]");
+  if (ui) {
+    const input = ui.querySelector("#site-search-input");
+    const form = ui.querySelector("form");
+    const status = ui.querySelector("[data-boris-search-status]");
+    const results = ui.querySelector("[data-boris-search-results]");
+    // Derive the site-root-relative prefix from the page-relative stylesheet
+    // href emitted by asset-url ("" from index.html, "../" from contracts/…).
+    const siteRootPrefix = (() => {
+      const sheet = document.querySelector('link[rel="stylesheet"][href*="assets/"]');
+      const href = sheet ? (sheet.getAttribute("href") || "") : "";
+      const marker = href.lastIndexOf("assets/");
+      return marker >= 0 ? href.slice(0, marker) : "";
+    })();
+    if (form) form.action = siteRootPrefix + "_boris/search/";
+    const indexUrl = new URL(siteRootPrefix + "_boris/search/search-index.json", document.baseURI);
+    const expectedFormat = "boris-rendered-search-index";
+    const expectedSchema = 1;
+    let documents = [];
+    const normalize = value => String(value || "").normalize("NFKD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/\s+/g, " ").trim();
+    const fields = section => [section.heading, section.text, section.code].map(normalize);
+    const excerpt = (section, terms) => {
+      const source = String(section.text || section.code || section.heading || "").replace(/\s+/g, " ").trim();
+      if (!source) return "";
+      const needle = terms.find(term => source.toLowerCase().indexOf(term) >= 0);
+      const start = needle ? Math.max(0, source.toLowerCase().indexOf(needle) - 48) : 0;
+      return (start ? "…" : "") + source.slice(start, start + 150) + (start + 150 < source.length ? "…" : "");
+    };
+    const scoreDocument = (doc, terms, phrase) => {
+      const title = normalize(doc.title);
+      let best = null;
+      (Array.isArray(doc.sections) ? doc.sections : []).forEach((section, sectionIndex) => {
+        const values = fields(section);
+        let score = 0;
+        terms.forEach(term => {
+          if (title.includes(term)) score += 12;
+          if (values[0].includes(term)) score += 8;
+          if (values[1].includes(term)) score += 2;
+          if (values[2].includes(term)) score += 1;
+        });
+        if (section.level === 1) score += 1;
+        if (phrase && (title.includes(phrase) || values.some(value => value.includes(phrase)))) score += 5;
+        if (score && (!best || score > best.score)) best = { doc, section, sectionIndex, score };
+      });
+      return best;
+    };
+    const setStatus = message => { status.textContent = message; };
+    const render = () => {
+      results.replaceChildren();
+      const query = normalize(input.value);
+      if (!query) { setStatus(documents.length ? "Type to search the site." : "Search index unavailable."); return; }
+      const terms = query.split(" ").filter(Boolean);
+      const matches = documents.map(doc => scoreDocument(doc, terms, query)).filter(Boolean).sort((a, b) => b.score - a.score || String(a.doc.path).localeCompare(String(b.doc.path)) || a.sectionIndex - b.sectionIndex);
+      if (!matches.length) { setStatus("No results. Try a different search."); return; }
+      setStatus(matches.length + " result" + (matches.length === 1 ? "" : "s") + ".");
+      matches.slice(0, 12).forEach(match => {
+        const item = document.createElement("li"); item.className = "site-search__result";
+        const link = document.createElement("a"); link.href = new URL(siteRootPrefix + String(match.doc.path).replace(/^\/+/, "") + (match.section.fragment ? "#" + match.section.fragment : ""), document.baseURI).href;
+        const title = document.createElement("span"); title.className = "site-search__title"; title.textContent = match.section.heading || match.doc.title;
+        const path = document.createElement("span"); path.className = "site-search__path"; path.textContent = String(match.doc.path) + (match.section.fragment ? "#" + String(match.section.fragment) : "");
+        const text = document.createElement("span"); text.className = "site-search__excerpt"; text.textContent = excerpt(match.section, terms);
+        link.append(title, path, text); item.append(link); results.append(item);
+      });
+    };
+    form.addEventListener("submit", event => { event.preventDefault(); render(); input.focus(); });
+    input.addEventListener("input", render);
+    document.addEventListener("keydown", event => {
+      if (event.key === "/" && document.activeElement !== input && !/INPUT|TEXTAREA|SELECT/.test(document.activeElement.tagName)) { event.preventDefault(); input.focus(); }
+      if (event.key === "Escape" && document.activeElement === input) { input.value = ""; render(); }
+    });
+    fetch(indexUrl, { credentials: "same-origin" }).then(response => { if (!response.ok) throw new Error("index request failed"); return response.json(); }).then(index => {
+      if (!index || index.format !== expectedFormat || index.schema_version !== expectedSchema || !Array.isArray(index.documents)) throw new Error("unsupported search index");
+      documents = index.documents.filter(doc => doc && typeof doc.path === "string" && typeof doc.title === "string" && Array.isArray(doc.sections)).map(doc => ({
+        path: doc.path,
+        title: doc.title,
+        sections: doc.sections.filter(section => section && typeof section.level === "number" && typeof section.heading === "string" && typeof section.fragment === "string" && typeof section.text === "string" && typeof section.code === "string")
+      }));
+      render();
+    }).catch(() => { documents = []; setStatus("Search index unavailable."); });
+  }
+  // Group the flat Documentation menu by first path segment. Nav hrefs are
+  // page-relative, so resolve each against the stylesheet's absolute location
+  // (the stylesheet always lives at the site root) rather than parsing raw hrefs.
+  const siteNav = document.querySelector(".txp-sidebar .site-nav");
+  if (siteNav) {
+    const sheet = document.querySelector('link[rel="stylesheet"][href*="assets/"]');
+    const siteRoot = sheet ? new URL("../../", sheet.href).pathname : null;
+    const groups = new Map();
+    Array.from(siteNav.querySelectorAll("li")).forEach(li => {
+      const a = li.querySelector("a");
+      if (!a || !siteRoot) return;
+      const path = new URL(a.href, document.baseURI).pathname;
+      const relative = path.startsWith(siteRoot) ? path.slice(siteRoot.length) : path.replace(/^\//, "");
+      const first = relative.split("/")[0] || "";
+      if (!first || !relative.includes("/")) return; // root pages stay ungrouped
+      if (!groups.has(first)) groups.set(first, []);
+      groups.get(first).push(li);
+    });
+    groups.forEach((items, group) => {
+      const heading = document.createElement("li");
+      heading.className = "site-nav__group";
+      heading.textContent = group.charAt(0).toUpperCase() + group.slice(1);
+      items[0].parentNode.insertBefore(heading, items[0]);
+    });
+  }
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
First project-site deploy for the docs (drawmeanelephant.github.io/oliver).

- Adapted Boris Pages workflow: docs/ input, themes/oliver, pinned Boris toolchain (.github/boris-pin.json), least-privilege permissions, public/evidence boundary, optional post-deploy audit
- Docs gate: boris validate against docs/ on every push/PR
- Publication user guide + contracts + schemas, starter profile
- Docs fixes the compiler surfaced: link routes, malformed code span, duplicate heading ids

Pages is already enabled with GitHub Actions as the source.