### PR TITLE
fix(ci): run the full prepublication compile in the docs gate

### DIFF
--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -1,6 +1,6 @@
 # Docs publication gate.
 #
-# Runs the Boris prepublication validation against the docs/ tree on every
+# Runs the Boris prepublication compile against the docs/ tree on every
 # push and pull request, so broken links, content-local asset errors, or
 # URLs that escape the declared origin/base path fail before merge. The
 # gate uses the same pipeline as the Pages build: the same pinned Boris
@@ -8,9 +8,14 @@
 # .github/workflows/github-pages.yml), the same project-site location
 # (/oliver), the same theme, and the same profile/plan normalization.
 #
-# `boris validate` runs the same prepublication path as `boris compile`
-# without writing artifacts, so this job leaves the working tree clean and
-# adds no CI-side output beyond the plan check below.
+# This deliberately runs the full `boris` compile (into a throwaway dist/)
+# rather than `boris validate`: validate's early-return path
+# (`validatePrepublicationTarget`) does NOT run the post-render link audit,
+# so EPUBLICATIONLOCATION (URL escapes the declared origin/base path) and
+# EROUTEMISSING (broken local route) pass validate silently. The compile
+# runs that audit and fails before anything is published. The dist/ output
+# is ephemeral in CI, is never committed, and the job stops before any
+# artifact/evidence step.
 #
 # The project-site location is the canonical /oliver shape for this
 # repository. Update these flags together with
@@ -30,8 +35,8 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate docs publication
+  gate:
+    name: Docs publication gate
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -72,13 +77,13 @@ jobs:
           test "$(jq -r '.publication.site_kind' /tmp/publication-plan.json)" = "project-site"
           test "$(jq -r '.publication.base_path' /tmp/publication-plan.json)" = "/oliver"
 
-      # The same prepublication checks as the Pages build, without writing
-      # dist/. Fails on EPUBLICATIONLOCATION (URL escapes the declared
-      # origin/base path), EASSET, ECOMPONENT, and any other compiler
-      # finding that would fail the publish workflow.
-      - name: Validate docs against the project-site location
+      # The same prepublication path as the Pages build: full compile,
+      # including the post-render link audit that validate skips. Fails on
+      # EPUBLICATIONLOCATION, EROUTEMISSING, EASSET, ECOMPONENT, and any
+      # other compiler finding that would fail the publish workflow.
+      - name: Run the full prepublication compile (incl. link audit)
         run: |
-          boris/zig-out/bin/boris validate \
+          boris/zig-out/bin/boris \
             --input docs \
             --target public=dist \
             --target-layout public=themes/oliver/layouts/main.html \
@@ -86,4 +91,5 @@ jobs:
             --pages-base-url https://drawmeanelephant.github.io/oliver \
             --pages-origin https://drawmeanelephant.github.io \
             --pages-base-path /oliver \
-            --site-url https://drawmeanelephant.github.io/oliver
+            --site-url https://drawmeanelephant.github.io/oliver \
+            --quiet

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ zig-out/
 *.o
 .DS_Store
 .freebuff/
+# Throwaway prepublication compile output (docs-gate + Pages workflow)
+dist/
+# Pages workflow retained evidence staging (plan, artifact verification)
+evidence/


### PR DESCRIPTION
Makes the docs gate actually enforce what it claims: broken links and location escapes fail before merge.

## What changed

- **`.github/workflows/docs-gate.yml`** — the gate now runs the **same full `boris` compile as the Pages build** (into a throwaway `dist/`, `--quiet`) instead of `boris validate`.
- **`.gitignore`** — ignore the throwaway outputs both workflows write into the checkout: `dist/` and `evidence/`.

## Why

`boris validate` does not run the post-render link audit. Its `validation_only` early-return path (`validatePrepublicationTarget`) renders pages and the sitemap in memory but never reaches `link_audit.audit`, so two finding classes pass silently:

| Poison (in `docs/github-pages.md`) | `boris validate` (old gate) | `boris` compile (new gate) |
|---|---|---|
| `[escape](/outside-oliver)` — escapes `/oliver` | exit 0, silent | **exit 1** `EPUBLICATIONLOCATION` |
| `[broken](./no-such-page.md)` — dead link | exit 0, silent | **exit 1** `EROUTEMISSING` |

Verified with the pinned `30805ab8` binary: both poisons fail the new gate command, and the clean tree is green (exit 0). Root cause filed upstream as [drawmeanelephant/boris#430](https://github.com/drawmeanelephant/boris/issues/430).

Note: the published site was never at risk — the Pages workflow always ran the compile path (with the audit); only the pre-merge gate was weak.
