### PR TITLE
feat: publish prebuilt binaries via a rolling builds release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,87 @@
+# Prebuilt binaries release.
+#
+# Minimal contract for consumers: one always-findable release on this
+# repository whose download URL is stable and derived from the tag alone:
+#
+#   https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>
+#
+# The `builds` release is re-populated on every push to main (and on
+# manual dispatch), so the tag always points at the current tip of main.
+# That is a deliberate simplification: Oliver is maintained solo and the
+# consumers are the same people, so per-commit artifact names and
+# immutable-byte guarantees are ceremony this project does not need.
+# Revisit per-sha asset names only if an external consumer pins arbitrary
+# old commits; the cross-compile matrix below makes that a naming-only
+# change.
+#
+# The matrix is the four platforms consumers actually run. Windows
+# cross-compiles trivially from Zig but would ship untested from a solo
+# maintainer, so it is deliberately excluded until someone needs it.
+# Everything is built on one ubuntu runner: no per-OS runners required.
+
+name: Binaries
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write # create/update the `builds` release and its assets
+
+jobs:
+  build:
+    name: Build and publish prebuilt binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install Zig 0.16.0
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Cross-compile the release matrix
+        run: |
+          mkdir -p dist
+          for target in x86_64-linux x86_64-macos aarch64-linux aarch64-macos; do
+            arch="${target%-*}"
+            os="${target#*-}"
+            echo "==> $target"
+            # -Dcommit embeds this exact source commit into the binary;
+            # `oliver --version` prints it so a pinned consumer can assert
+            # downloaded-binary commit == pin.
+            zig build -Dtarget="$target" -Doptimize=ReleaseSafe \
+              -Dcommit="$GITHUB_SHA" \
+              --prefix "/tmp/oliver/$target" >/dev/null
+            cp "/tmp/oliver/$target/bin/oliver" "dist/oliver-$os-$arch"
+          done
+
+      # Cheap integrity check before anything is published: the native
+      # Linux binary must render a known input byte-for-byte and must
+      # report the exact commit that produced it.
+      - name: Smoke-test the native binary
+        run: |
+          test "$(printf '# Hello *world*\n' | dist/oliver-linux-x86_64 render --from markdown)" = \
+            '<h1>Hello <em>world</em></h1>'
+          test "$(dist/oliver-linux-x86_64 --version)" = \
+            "oliver 0.0.0 (commit $GITHUB_SHA)"
+
+      - name: Write the checksum manifest
+        run: |
+          (cd dist && sha256sum oliver-*) > sha256sums.txt
+
+      # Create the release once; on later runs it already exists and only
+      # the assets are replaced (--clobber makes re-runs idempotent).
+      - name: Publish to the builds release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view builds >/dev/null 2>&1; then
+            gh release create builds \
+              --title "Oliver prebuilt binaries" \
+              --notes "Rolling prebuilt binaries for the current tip of main. Download URL: https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>"
+          fi
+          gh release upload builds dist/* sha256sums.txt --clobber

--- a/README.md
+++ b/README.md
@@ -198,6 +198,29 @@ zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```
 
+### Prebuilt binaries
+
+A rolling `builds` release on this repository carries the current CLI
+binary for each supported platform, rebuilt on every push to `main`:
+
+- `oliver-linux-x86_64`, `oliver-linux-aarch64`
+- `oliver-macos-x86_64`, `oliver-macos-aarch64`
+
+Download URL (stable, derived from the tag):
+
+```text
+https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>
+```
+
+`sha256sums.txt` in the same release verifies the assets. The binaries
+are ReleaseSafe and statically linked (macOS links only system libSystem).
+
+Every CI-built binary embeds the exact source commit it was built from:
+`oliver --version` prints `oliver <version> (commit <full-sha>)`. A
+consumer that pins a commit can assert the downloaded binary's reported
+commit equals its pin and reject on mismatch — the download URL itself
+may move, the byte identity cannot silently drift.
+
 ## Library use
 
 ```zig
@@ -266,6 +289,7 @@ oliver serialize --from cooklang < recipe.cook   # canonical .cook
 oliver scale --from cooklang --factor 2 < recipe.cook   # scaled .cook
 oliver scale --from cooklang --servings 4 < recipe.cook  # via servings
 oliver menu --from cooklang < plan.menu                 # day/meal text dump
+oliver --version   # prints version + embedded source commit (CI builds)
 ```
 
 A thin stdin/stdout adapter — all semantics live in the library.

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,12 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // The source commit SHA, embedded into `oliver --version` so a
+    // downloaded binary can prove which commit it was built from. CI
+    // passes -Dcommit=$GITHUB_SHA; local builds leave it unset and the
+    // CLI reports no commit.
+    const commit = b.option([]const u8, "commit", "Source commit SHA reported by `oliver --version`") orelse "";
+
     // The core library. Consumers import it by name (see build.zig.zon);
     // `addModule` registers it as the package's "oliver" module.
     const oliver_mod = b.addModule("oliver", .{
@@ -22,12 +28,18 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
 
     // Provisional CLI: a thin adapter over the library (stdin -> stdout).
+    // The version + commit are injected at build time so `oliver --version`
+    // is authoritative (consumers assert it against their pin).
+    const cli_options = b.addOptions();
+    cli_options.addOption([]const u8, "commit", commit);
+    cli_options.addOption([]const u8, "version", packageVersion(b));
     const cli_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
             .{ .name = "oliver", .module = oliver_mod },
+            .{ .name = "build_options", .module = cli_options.createModule() },
         },
     });
     const cli = b.addExecutable(.{
@@ -145,4 +157,17 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_spec_tool_tests.step);
     test_step.dependOn(&run_cli_tests.step);
     test_step.dependOn(&run_xhtml_tests.step);
+}
+
+/// The package version from build.zig.zon (single source of truth). Zig
+/// 0.16 exposes no Build API for it, so read the zon file at configure
+/// time and extract `.version = "..."`; fall back to "0.0.0" if the file
+/// is unreadable or the marker is missing.
+fn packageVersion(b: *std.Build) []const u8 {
+    const marker = ".version = \"";
+    const zon = std.Io.Dir.readFileAlloc(.cwd(), b.graph.io, "build.zig.zon", b.allocator, .limited(1 << 20)) catch return "0.0.0";
+    const start = std.mem.indexOf(u8, zon, marker) orelse return "0.0.0";
+    const rest = zon[start + marker.len ..];
+    const end = std.mem.indexOfScalar(u8, rest, '"') orelse return "0.0.0";
+    return b.dupe(rest[0..end]);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -186,7 +186,7 @@ pub fn main(init: std.process.Init) !u8 {
         },
         // `--version` is a requested outcome like `--help`: print the
         // version and the embedded source commit, then exit 0.
-        error.Version => return version(),
+        error.Version => return version(init),
         error.Usage => return usage(),
     };
     const profile = cfg.profile;
@@ -301,12 +301,15 @@ fn usage() u8 {
 
 /// `--version` is a requested outcome: print the package version and, for
 /// CI builds that embedded one, the exact source commit, then exit 0.
-fn version() u8 {
-    if (build_options.commit.len == 0) {
-        std.debug.print("oliver {s}\n", .{build_options.version});
-    } else {
-        std.debug.print("oliver {s} (commit {s})\n", .{ build_options.version, build_options.commit });
-    }
+/// Written to stdout (not stderr) so a consumer can parse it: an
+/// installer asserts the reported commit equals its pin.
+fn version(init: std.process.Init) u8 {
+    const text = if (build_options.commit.len == 0)
+        std.fmt.allocPrint(init.gpa, "oliver {s}\n", .{build_options.version}) catch return 1
+    else
+        std.fmt.allocPrint(init.gpa, "oliver {s} (commit {s})\n", .{ build_options.version, build_options.commit }) catch return 1;
+    defer init.gpa.free(text);
+    std.Io.File.stdout().writeStreamingAll(init.io, text) catch return 1;
     return 0;
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,6 +15,10 @@
 
 const std = @import("std");
 const oliver = @import("oliver");
+// Injected by build.zig: the package version and the source commit SHA
+// (CI passes -Dcommit=$GITHUB_SHA). `oliver --version` prints them so a
+// downloaded binary can prove which commit it was built from.
+const build_options = @import("build_options");
 
 /// The CLI operation, selected by the subcommand token. Exactly one is
 /// required; `parseArgs` rejects a missing, duplicated, or conflicting
@@ -47,7 +51,7 @@ pub const RunConfig = struct {
 /// scale-only), and `error.Help` for `--help`/`-h` (help is a requested
 /// outcome, not an error). Pure: no allocator, no I/O, so it is
 /// unit-tested directly.
-pub fn parseArgs(args: []const []const u8) error{ Usage, Help }!RunConfig {
+pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConfig {
     var command: ?Command = null;
     var dialect: ?oliver.Dialect = null;
     var cooklang = false;
@@ -124,6 +128,8 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help }!RunConfig {
             if (servings_target.? == 0) return error.Usage;
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             return error.Help;
+        } else if (std.mem.eql(u8, arg, "--version")) {
+            return error.Version;
         } else return error.Usage;
     }
 
@@ -178,6 +184,9 @@ pub fn main(init: std.process.Init) !u8 {
             printUsage();
             return 0;
         },
+        // `--version` is a requested outcome like `--help`: print the
+        // version and the embedded source commit, then exit 0.
+        error.Version => return version(),
         error.Usage => return usage(),
     };
     const profile = cfg.profile;
@@ -275,10 +284,12 @@ fn printUsage() void {
         \\       oliver serialize --from cooklang
         \\       oliver scale --from cooklang (--factor <num[/den]> | --servings <n>)
         \\       oliver menu --from cooklang
+        \\       oliver --version
         \\
         \\Reads a document from stdin and writes rendered HTML to stdout
         \\(XHTML fragment with --to xhtml). serialize/scale write canonical
-        \\Cooklang text; menu writes the day/meal text dump.
+        \\Cooklang text; menu writes the day/meal text dump. --version prints
+        \\the version and the embedded source commit (CI builds).
         \\
     , .{});
 }
@@ -286,6 +297,17 @@ fn printUsage() void {
 fn usage() u8 {
     printUsage();
     return 1;
+}
+
+/// `--version` is a requested outcome: print the package version and, for
+/// CI builds that embedded one, the exact source commit, then exit 0.
+fn version() u8 {
+    if (build_options.commit.len == 0) {
+        std.debug.print("oliver {s}\n", .{build_options.version});
+    } else {
+        std.debug.print("oliver {s} (commit {s})\n", .{ build_options.version, build_options.commit });
+    }
+    return 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -340,6 +362,11 @@ test "cli: --from must name a supported dialect and appear at most once" {
 test "cli: --help and -h are requested outcomes, not errors" {
     try testing.expectError(error.Help, parseArgs(&.{"--help"}));
     try testing.expectError(error.Help, parseArgs(&.{ "render", "--from", "markdown", "-h" }));
+}
+
+test "cli: --version is a requested outcome, not an error" {
+    try testing.expectError(error.Version, parseArgs(&.{"--version"}));
+    try testing.expectError(error.Version, parseArgs(&.{ "render", "--from", "markdown", "--version" }));
 }
 
 test "cli: invalid --to values and missing values fail clearly" {


### PR DESCRIPTION
**What:** Adds `.github/workflows/binaries.yml`, which cross-compiles the CLI for linux/macos × x86_64/aarch64 on one runner and publishes it to a single `builds` release — a stable, always-findable download URL:

```
https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>
```

plus `sha256sums.txt` per build for verification.

**Also:** `oliver --version` now prints the version and the exact source commit (embedded at build time via `-Dcommit`), on stdout, so a pinned consumer can assert the downloaded binary's commit equals its pin even though the URL is mutable.

**Verification:** `zig fmt` clean, full test suite passes, 652/652 CommonMark conformance gate and 60/60 Cooklang gate pass on the committed tree (all run again in CI on this PR).

**Status:** the `builds` release is already live and verified end-to-end from the public URL (download → sha256 → `--version` pin assertion). After this merges, the workflow takes over: every push to `main` rebuilds and clobber-uploads the assets.
