### PR TITLE
ci: note the benign Node 20 deprecation warning for mlugg/setup-zig

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
+      # GitHub emits a Node 20 deprecation warning for this action: v2.2.1
+      # is the latest release and still declares a node20 runtime (GitHub
+      # force-runs it on Node 24). Benign until mlugg publishes a node24
+      # release; do not chase the warning by switching actions.
       - name: Install Zig 0.16.0
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
       # ziglang/setup-zig was deleted in the Zig org's GitHub->Codeberg
       # migration (Nov 2025); mlugg/setup-zig is its maintained successor
       # and a drop-in replacement supporting the same `version` input.
+      #
+      # GitHub emits a Node 20 deprecation warning for this action: v2.2.1
+      # is the latest release and still declares a node20 runtime (GitHub
+      # force-runs it on Node 24). Benign until mlugg publishes a node24
+      # release; do not chase the warning by switching actions.
       - name: Install Zig 0.16.0
         uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -60,6 +60,10 @@ jobs:
           path: boris
           fetch-depth: 1
 
+      # GitHub emits a Node 20 deprecation warning for this action: v2.2.1
+      # is the latest release and still declares a node20 runtime (GitHub
+      # force-runs it on Node 24). Benign until mlugg publishes a node24
+      # release; do not chase the warning by switching actions.
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -76,6 +76,10 @@ jobs:
           path: boris
           fetch-depth: 1
 
+      # GitHub emits a Node 20 deprecation warning for this action: v2.2.1
+      # is the latest release and still declares a node20 runtime (GitHub
+      # force-runs it on Node 24). Benign until mlugg publishes a node24
+      # release; do not chase the warning by switching actions.
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
@@ -361,6 +365,8 @@ jobs:
           path: boris
           fetch-depth: 1
 
+      # Same pinned action and same benign Node 20 deprecation warning as
+      # the build job's Install Zig step (see comment above).
       - name: Install Zig for deployment observer
         if: ${{ inputs.audit_deployment == true }}
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1


### PR DESCRIPTION
Comment-only change across all four workflows (`ci.yml`, `docs-gate.yml`, `github-pages.yml`, `binaries.yml`): a note that the Node 20 deprecation warning for `mlugg/setup-zig` is upstream and benign.

The pinned action (v2.2.1, `d1434d08…`) is the latest release and still declares a `node20` runtime; GitHub force-runs it on Node 24 and it works. No newer pin exists to bump to, so the note documents why the warning is expected until mlugg publishes a node24 release.

No behavior change — workflows re-validated to parse cleanly.
