### PR TITLE
xhtml: serialize footnote valueless attributes with empty values

### DIFF
--- a/src/html.zig
+++ b/src/html.zig
@@ -180,7 +180,7 @@ pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Docu
                 try pushChildren(gpa, &stack, f.node, f.tight_item);
             },
             .marker => |text| try writer.writeAll(text),
-            .backref => |n| try writeBackrefs(writer, &fn_ctx, n),
+            .backref => |n| try writeBackrefs(writer, &fn_ctx, n, options),
             .li_open => |n| {
                 var buf: [32]u8 = undefined;
                 const tag = try std.fmt.bufPrint(&buf, "<li id=\"fn-{d}\">\n", .{n});
@@ -191,7 +191,7 @@ pub fn render(gpa: std.mem.Allocator, writer: anytype, doc: *const document.Docu
                 // rendered, so the footnotes section is pushed now and
                 // renders in document order after the body.
                 if (f.node.tag == .document and fn_ctx.used.items.len > 0) {
-                    try pushFootnotesSection(gpa, &stack, doc, &fn_ctx);
+                    try pushFootnotesSection(gpa, &stack, doc, &fn_ctx, options);
                 }
                 try writeClose(writer, f.node, f.suppress_p, options, f.footnote_backref, &fn_ctx);
             },
@@ -599,7 +599,9 @@ fn writeOpen(
                     const id = try std.fmt.bufPrint(&id_buf, "{d}-{d}", .{ n, ord });
                     try writer.writeAll(id);
                 }
-                try writer.writeAll("\" data-footnote-ref>");
+                try writer.writeByte('"');
+                try writeValuelessAttr(writer, options, "data-footnote-ref");
+                try writer.writeByte('>');
                 try writer.writeAll(num);
                 try writer.writeAll("</a></sup>");
             } else {
@@ -707,7 +709,6 @@ fn writeOpen(
 }
 
 fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, options: RenderOptions, footnote_backref: u32, fn_ctx: *const Footnotes) !void {
-    _ = options;
     switch (node.tag) {
         .document, .footnote => {},
         .block_quote => try writer.writeAll("</blockquote>\n"),
@@ -743,7 +744,7 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
                 // Tight-list paragraphs are inline content of `<li>`; a
                 // following block gets its own leading newline in its frame.
             } else {
-                if (footnote_backref > 0) try writeBackrefs(writer, fn_ctx, footnote_backref);
+                if (footnote_backref > 0) try writeBackrefs(writer, fn_ctx, footnote_backref, options);
                 try writer.writeAll("</p>\n");
             }
         },
@@ -778,23 +779,26 @@ fn writeClose(writer: anytype, node: *const document.Node, suppress_p: bool, opt
 /// order: the first points at `#fnref-N`, the second at `#fnref-N-2`, and
 /// so on (issue #44) — so a reader who followed any reference can get
 /// back to it, and each anchor has its own target.
-fn writeBackrefs(writer: anytype, fn_ctx: *const Footnotes, n: u32) !void {
+fn writeBackrefs(writer: anytype, fn_ctx: *const Footnotes, n: u32, options: RenderOptions) !void {
     const label = fn_ctx.used.items[n - 1]; // numbers are 1-based, used is 0-based
     const count = fn_ctx.ref_counts.get(label) orelse 1;
+    // The valueless `data-footnote-backref` marker is bare in HTML and an
+    // explicit empty value under XHTML (issue #60).
+    const empty_value = if (options.profile == .xhtml) "=\"\"" else "";
     var ord: u32 = 1;
     while (ord <= count) : (ord += 1) {
         var buf: [256]u8 = undefined;
         const text = if (ord == 1)
             try std.fmt.bufPrint(
                 &buf,
-                " <a href=\"#fnref-{d}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{d}\" aria-label=\"Back to reference {d}\">↩</a>",
-                .{ n, n, n },
+                " <a href=\"#fnref-{d}\" class=\"footnote-backref\" data-footnote-backref{s} data-footnote-backref-idx=\"{d}\" aria-label=\"Back to reference {d}\">↩</a>",
+                .{ n, empty_value, n, n },
             )
         else
             try std.fmt.bufPrint(
                 &buf,
-                " <a href=\"#fnref-{d}-{d}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{d}-{d}\" aria-label=\"Back to reference {d}-{d}\">↩</a>",
-                .{ n, ord, n, ord, n, ord },
+                " <a href=\"#fnref-{d}-{d}\" class=\"footnote-backref\" data-footnote-backref{s} data-footnote-backref-idx=\"{d}-{d}\" aria-label=\"Back to reference {d}-{d}\">↩</a>",
+                .{ n, ord, empty_value, n, ord, n, ord },
             );
         try writer.writeAll(text);
     }
@@ -819,6 +823,7 @@ fn pushFootnotesSection(
     stack: *std.ArrayList(Frame),
     doc: *const document.Document,
     fn_ctx: *const Footnotes,
+    options: RenderOptions,
 ) !void {
     try stack.append(gpa, .{ .marker = "</section>\n" });
     try stack.append(gpa, .{ .marker = "</ol>\n" });
@@ -852,7 +857,11 @@ fn pushFootnotesSection(
         try stack.append(gpa, .{ .li_open = n });
     }
     try stack.append(gpa, .{ .marker = "<ol>\n" });
-    try stack.append(gpa, .{ .marker = "<section class=\"footnotes\" data-footnotes>\n" });
+    const section_marker = if (options.profile == .xhtml)
+        "<section class=\"footnotes\" data-footnotes=\"\">\n"
+    else
+        "<section class=\"footnotes\" data-footnotes>\n";
+    try stack.append(gpa, .{ .marker = section_marker });
 }
 
 /// Collects the plain-text projection of a heading's inline content: text
@@ -939,6 +948,16 @@ fn clampHeading(level: u8) u8 {
 /// `RenderOptions.void_trailing_slash` (default CommonMark reference style).
 fn voidSlash(options: RenderOptions) bool {
     return options.profile == .xhtml or options.void_trailing_slash;
+}
+
+/// Writes a valueless boolean-style attribute (e.g. `data-footnote-ref`).
+/// The HTML profile emits the bare form; the XHTML profile must stay
+/// XML-well-formed (a valueless attribute is not valid XML), so it writes
+/// an explicit empty value (`data-footnote-ref=""`). docs/XHTML.md.
+fn writeValuelessAttr(writer: anytype, options: RenderOptions, name: []const u8) !void {
+    try writer.writeByte(' ');
+    try writer.writeAll(name);
+    if (options.profile == .xhtml) try writer.writeAll("=\"\"");
 }
 
 /// The HTML tag name for the Textile phrase tags (the ones with a shared
@@ -1787,6 +1806,59 @@ test "html: repeated footnote references get unique ids and one backref each" {
         if (std.mem.startsWith(u8, out.items[i..], "id=\"fnref-")) count += 1;
     }
     try testing.expectEqual(@as(usize, 5), count);
+}
+
+test "html: XHTML profile writes footnote valueless attributes with empty values" {
+    // Regression (issue #60): footnote markers emitted valueless data-*
+    // attributes (`data-footnote-ref`, `data-footnotes`,
+    // `data-footnote-backref`), which are not XML-well-formed, so an
+    // XHTML-rendered document containing footnotes was invalid XML. Under
+    // `.xhtml` the valueless forms serialize with explicit empty values;
+    // the HTML profile output is byte-unchanged (sibling tests above).
+    var doc = try document.Document.init(testing.allocator, .{ .bytes = "" });
+    defer doc.deinit();
+
+    const p = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(doc.root, p);
+    try addText(&doc, p, "Hi");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "second" } }));
+    try addText(&doc, p, " and ");
+    try doc.appendChild(p, try doc.createNode(.footnote_ref, .{ .start = 0, .end = 0 }, .{ .footnote_ref = .{ .label = "syntax" } }));
+    try addText(&doc, p, ".");
+
+    const def1 = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+    const p1 = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(def1, p1);
+    try addText(&doc, p1, "First body");
+    try doc.footnotes.append(doc.allocator(), .{ .label = "syntax", .node = def1 });
+
+    const def2 = try doc.createNode(.footnote, .{ .start = 0, .end = 0 }, .none);
+    const p2 = try doc.createNode(.paragraph, .{ .start = 0, .end = 0 }, .{ .paragraph = .{} });
+    try doc.appendChild(def2, p2);
+    try addText(&doc, p2, "Second body");
+    try doc.footnotes.append(doc.allocator(), .{ .label = "second", .node = def2 });
+
+    var out = try renderDocOpts(&doc, .{ .footnotes = true, .profile = .xhtml });
+    defer out.deinit(testing.allocator);
+    try testing.expectEqualStrings(
+        "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref=\"\">1</a></sup> and <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref=\"\">2</a></sup>.</p>\n" ++
+            "<section class=\"footnotes\" data-footnotes=\"\">\n" ++
+            "<ol>\n" ++
+            "<li id=\"fn-1\">\n" ++
+            "<p>Second body <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref=\"\" data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" ++
+            "</li>\n" ++
+            "<li id=\"fn-2\">\n" ++
+            "<p>First body <a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref=\"\" data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" ++
+            "</li>\n" ++
+            "</ol>\n" ++
+            "</section>\n",
+        out.items,
+    );
+
+    // The bare valueless forms must not appear under XHTML.
+    try testing.expect(std.mem.indexOf(u8, out.items, "data-footnote-ref>") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "data-footnotes>") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "data-footnote-backref ") == null);
 }
 
 test "html: render without footnote context never frees an uninitialized map" {

--- a/tests/xhtml_test.zig
+++ b/tests/xhtml_test.zig
@@ -445,6 +445,29 @@ test "xhtml: representative output is well-formed XML" {
     defer wrapped_ck_nul.deinit(std.testing.allocator);
     try wrapFragment(xhtml_ck_nul.items, &wrapped_ck_nul);
     try wellformed.check(wrapped_ck_nul.items);
+
+    // Footnote machinery must stay XML-well-formed: the valueless data-*
+    // attributes serialize with explicit empty values under XHTML
+    // (issue #60) — a bare attribute would fail the gate below. The
+    // repeated reference also exercises the `-2` backref-id format.
+    const footnote_input =
+        \\Reference[^1] and repeat[^1] and another[^2].
+        \\
+        \\[^1]: First body.
+        \\[^2]: Second body.
+        \\
+    ;
+    var fn_result = try oliver.parse(std.testing.allocator, footnote_input, .markdown, .{ .markdown = .{ .footnotes = true } });
+    defer fn_result.deinit();
+    var fn_aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer fn_aw.deinit();
+    try oliver.html.render(std.testing.allocator, &fn_aw.writer, &fn_result.document, .{ .profile = .xhtml, .footnotes = true });
+    var fn_frag = fn_aw.toArrayList();
+    defer fn_frag.deinit(std.testing.allocator);
+    var wrapped_fn = std.ArrayList(u8).empty;
+    defer wrapped_fn.deinit(std.testing.allocator);
+    try wrapFragment(fn_frag.items, &wrapped_fn);
+    try wellformed.check(wrapped_fn.items);
 }
 
 test "xhtml: wellformedness checker itself distinguishes clean from poisoned" {


### PR DESCRIPTION
Fixes #60.

**Problem:** the XHTML output profile fails closed on verbatim raw HTML, but its footnote machinery emitted hardcoded **valueless** attributes — `data-footnote-ref`, `data-footnotes`, `data-footnote-backref` — which are not XML-well-formed. An XHTML-rendered document containing footnotes was therefore invalid XML, and the build did not fail closed on it.

**Fix:** under `profile = .xhtml`, valueless attributes serialize with an explicit empty value (`data-footnote-ref=""`) via a shared `writeValuelessAttr` helper, matching how the profile treats other serialization deltas. HTML output is byte-unchanged.

**Tests:**
- byte-exact XHTML footnote regression test in `src/html.zig` (mirrors the HTML sibling, asserts the `=""` forms and absence of bare forms)
- a footnote case added to the mechanical well-formedness gate (`tests/xhtml_test.zig`) — it fails on the old bare forms, so this is a true regression wall; includes a repeated reference to cover the `-2` backref format

**Verification:** full suite green, CommonMark gate 652/652 (0 regressions), Cooklang 60/60.
