### PR TITLE
test(fixtures): pin the cross-extension compositions and callout edges

### DIFF
--- a/docs/CALLOUTS.md
+++ b/docs/CALLOUTS.md
@@ -43,6 +43,12 @@ text `[!note]` — the corpus is untouched.
   continuation, nested containers — exactly the §5.1 container-stack
   extent. A truly blank line ends the callout (it ends the blockquote);
   no new blank-line semantics are introduced.
+- **Lazy-continuation boundary (pinned by `cross-callout-edges`):**
+  lazy continuation continues an *open* body paragraph only. A line
+  immediately after the title line — before any body paragraph is open
+  — is not part of the callout: it becomes a sibling block. Once a body
+  paragraph exists (`> Body one.`), a non-marker line lazily continues
+  it inside the callout, exactly as §5.1 does for ordinary blockquotes.
 
 ## 2. Recognition
 
@@ -115,7 +121,9 @@ When the payload is set:
   `[!note]` literal text in its first paragraph.
 - `[!note]` mid-line (`> text [!note]`), on a non-first line, or without
   a separator after `]` (`[!note]x`).
-- Malformed types: `[!]`, `[!two words]`, `[!note!]`, `[!note` (no `]`).
+- Malformed types: `[!]` (empty), `[!two words]` (space in the type),
+  `[!note!]` (punctuation in the type), `[!note` (no `]`) — all pinned
+  literal by `cross-callout-edges`.
 - `[!note]` not at the start of the line content (leading whitespace
   after the marker).
 
@@ -136,12 +144,19 @@ When the payload is set:
 - Case-insensitive types (`[!TIP]` → `callout-tip`); unknown types
   (`[!custom-unknown]`-style) → `callout-<type>` box (the type name is
   preserved in the class, Obsidian's behavior); titleless callouts;
-  multi-paragraph bodies; lazy continuation; nested callouts; lists,
-  links, and emphasis inside bodies; both marker-adjacency forms
-  (`> [!note]` and `>[!note]`).
-- The §6 literal battery — `[!note]x`, `[!]`, `[!no close`, and a
-  mid-line `[!note]` — pinned by `callout-literal`.
-- The §6 literal battery pinned by `callout-literal`.
+  multi-paragraph bodies; lazy continuation (with the §1 boundary);
+  nested callouts; lists, links, and emphasis inside bodies; both
+  marker-adjacency forms (`> [!note]` and `>[!note]`, pinned by
+  `cross-callout-title`).
+- Cross-extension: a `[[x]]` wikilink in the title or body is a normal
+  inline, and smartypants applies to title/body plain text around it
+  (pinned by `cross-callout-title`: `> [!note] See [[Page Name]] and
+  "quoted" -- text` renders the resolved link, curly quotes, and em
+  dash in the title).
+- The §6 literal battery — `[!note]x`, `[!]`, `[!no close`, a mid-line
+  `[!note]` (pinned by `callout-literal`), and `[!two words]`/`[!note!]`
+  (pinned by `cross-callout-edges`, with the lazy-continuation boundary
+  in both directions).
 - XHTML well-formedness gate passes for every fixture.
 - Off by default: 652/652 + full suite green.
 
@@ -152,5 +167,8 @@ Extension, off by default: the CommonMark 0.31.2 corpus is untouched
 Fixture wall: `callout-basic` (title + body + lazy continuation),
 `callout-types` (case-insensitivity, titleless, unknown types),
 `callout-body` (inline title, links, lists, nested callouts, multi-block
-bodies), `callout-literal` (§6 battery + mid-line rule). The XHTML
-well-formedness gate covers the div wrapper under both profiles.
+bodies), `callout-literal` (§6 battery + mid-line rule), and the
+cross-extension `cross-callout-title` (wikilinks + smartypants in
+titles, the no-space `>[!note]` form) and `cross-callout-edges`
+(`[!two words]`/`[!note!]`, the §1 lazy-continuation boundary). The
+XHTML well-formedness gate covers the div wrapper under both profiles.

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -326,5 +326,6 @@ in docs/SMARTY.md:
 - In GFM table cells an unescaped `|` is a cell separator (GFM §4.10), so
   a pipe-label wikilink inside a cell needs `\|` (docs/WIKILINKS.md §7).
 - Fixtures: `tests/fixtures/markdown/ext-*.md`, `wikilink-*.md`,
-  `callout-*.md`, and `smartypants-*.md` (parsed with all extensions
-  enabled) plus unit tests in `src/markdown.zig` and `src/html.zig`.
+  `callout-*.md`, `smartypants-*.md`, and the cross-extension
+  `cross-*.md` composition pairs (parsed with all extensions enabled)
+  plus unit tests in `src/markdown.zig` and `src/html.zig`.

--- a/docs/SMARTY.md
+++ b/docs/SMARTY.md
@@ -47,9 +47,14 @@ the macro table (pinned — `{c|}` stays literal under smartypants).
 ## 2. Where the pass applies
 
 - Applied to plain `.text` nodes in every Markdown inline scope:
-  paragraphs, ATX/Setext headings, list items, table cells (GFM), and
-  link **display text** (matching Textile, which replaces inside link
-  text).
+  paragraphs, ATX/Setext headings, list items, table cells (GFM), link
+  **display text** (matching Textile, which replaces inside link text),
+  footnote bodies, definition-list terms and definitions, and callout
+  titles/bodies (pinned by `cross-smartypants-scopes`: a footnote body
+  and a definition term both curl and dash). A heading containing a
+  wikilink slugs on the label, and the non-ASCII replacement bytes are
+  dropped by `slugify`, so heading ids are unaffected (also pinned by
+  `cross-smartypants-scopes`).
 - **Exempt (verbatim):** code spans, code blocks (fenced and indented),
   autolink labels, link destinations and titles, image src/alt/title,
   raw HTML and inline HTML, and HTML-looking `<...>` regions — the same
@@ -106,7 +111,11 @@ the macro table (pinned — `{c|}` stays literal under smartypants).
 - Fixture wall: `smartypants-basic` (the replacement set, runs, symbols),
   `smartypants-exempt` (the §2 exemption battery), `smartypants-scopes`
   (headings incl. the heading-id slug, link display text, list items,
-  GFM table cells, callout title/body, wikilink exemption).
+  GFM table cells, callout title/body, wikilink exemption), plus the
+  cross-extension `cross-smartypants-scopes` (footnote bodies,
+  definition-list terms, heading slug on a wikilink) and
+  `cross-callout-title` (wikilink + typography composing in a callout
+  title).
 - Textile fixtures byte-identical before/after the extraction refactor
   (the wall is the regression net).
 - Off by default: quotes/dashes stay literal — 652/652 + full suite

--- a/docs/WIKILINKS.md
+++ b/docs/WIKILINKS.md
@@ -148,7 +148,11 @@ policy (docs/ARCHITECTURE.md).
   trimming, labels), `wikilink-literal` (the §3 battery + the greedy
   closer `[[a]]]`), `wikilink-precedence` (`[[x]]` vs the `[x]` def,
   `[[foo]](/url)`, link-text demotion, code-span/autolink opacity),
-  `wikilink-escapes` (`\[[x]]`, `[[a\]b]]`).
+  `wikilink-escapes` (`\[[x]]`, `[[a\]b]]`). Cross-extension
+  compositions are pinned by `cross-callout-title` (a `[[x]]` inside a
+  callout title and body) and `cross-smartypants-scopes` (a heading
+  containing a wikilink slugs on the label: `# See [[Page Name]] now` →
+  `id="see-page-name-now"`).
 - Unit tests: node structure/spans, disabled behavior, malformed battery,
   greedy closer, link-text demotion, default + consumer resolver
   rendering, and a 10,000-wikilink determinism storm.

--- a/tests/fixtures/markdown/cross-callout-edges.html
+++ b/tests/fixtures/markdown/cross-callout-edges.html
@@ -1,0 +1,15 @@
+<blockquote>
+<p>[!two words] space in type</p>
+</blockquote>
+<blockquote>
+<p>[!note!] punctuation in type</p>
+</blockquote>
+<div class="callout callout-note">
+<div class="callout-title">Title</div>
+</div>
+<p>not lazy: no open body paragraph yet</p>
+<div class="callout callout-note">
+<div class="callout-title">Title</div>
+<p>Body one.
+lazy: continues the open body paragraph</p>
+</div>

--- a/tests/fixtures/markdown/cross-callout-edges.md
+++ b/tests/fixtures/markdown/cross-callout-edges.md
@@ -1,0 +1,10 @@
+> [!two words] space in type
+
+> [!note!] punctuation in type
+
+> [!note] Title
+not lazy: no open body paragraph yet
+
+> [!note] Title
+> Body one.
+lazy: continues the open body paragraph

--- a/tests/fixtures/markdown/cross-callout-title.html
+++ b/tests/fixtures/markdown/cross-callout-title.html
@@ -1,0 +1,8 @@
+<div class="callout callout-note">
+<div class="callout-title">See <a href="Page%20Name">Page Name</a> and “quoted” — text</div>
+<p>Body with a <a href="link">link</a> here.</p>
+</div>
+<div class="callout callout-tip">
+<div class="callout-title">No-space marker form</div>
+<p>Body with <strong>emphasis</strong>.</p>
+</div>

--- a/tests/fixtures/markdown/cross-callout-title.md
+++ b/tests/fixtures/markdown/cross-callout-title.md
@@ -1,0 +1,5 @@
+> [!note] See [[Page Name]] and "quoted" -- text
+> Body with a [[link]] here.
+
+>[!tip] No-space marker form
+> Body with **emphasis**.

--- a/tests/fixtures/markdown/cross-smartypants-scopes.html
+++ b/tests/fixtures/markdown/cross-smartypants-scopes.html
@@ -1,0 +1,13 @@
+<h1 id="see-page-name-now">See <a href="Page%20Name">Page Name</a> now</h1>
+<dl>
+<dt>A “term” — with quotes</dt>
+<dd>A “definition” — body.</dd>
+</dl>
+<p>Text<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>.</p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-1">
+<p>“Quoted” — footnote body. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+</ol>
+</section>

--- a/tests/fixtures/markdown/cross-smartypants-scopes.md
+++ b/tests/fixtures/markdown/cross-smartypants-scopes.md
@@ -1,0 +1,8 @@
+# See [[Page Name]] now
+
+A "term" -- with quotes
+: A "definition" -- body.
+
+Text[^a].
+
+[^a]: "Quoted" -- footnote body.

--- a/tests/fixtures_test.zig
+++ b/tests/fixtures_test.zig
@@ -1538,6 +1538,21 @@ const markdown_ext_fixtures = [_]MarkdownExtFixture{
         .input = @embedFile("fixtures/markdown/smartypants-scopes.md"),
         .expected = @embedFile("fixtures/markdown/smartypants-scopes.html"),
     },
+    .{
+        .name = "cross-callout-title",
+        .input = @embedFile("fixtures/markdown/cross-callout-title.md"),
+        .expected = @embedFile("fixtures/markdown/cross-callout-title.html"),
+    },
+    .{
+        .name = "cross-smartypants-scopes",
+        .input = @embedFile("fixtures/markdown/cross-smartypants-scopes.md"),
+        .expected = @embedFile("fixtures/markdown/cross-smartypants-scopes.html"),
+    },
+    .{
+        .name = "cross-callout-edges",
+        .input = @embedFile("fixtures/markdown/cross-callout-edges.md"),
+        .expected = @embedFile("fixtures/markdown/cross-callout-edges.html"),
+    },
 };
 
 const TextileFixture = struct {


### PR DESCRIPTION
Closes #72.

**What:** pin the cross-extension compositions and callout edge cases the four shipped extensions' contracts promise but left unpinned — regression-hardening only, no behavior change.

**Fixtures** (3 new extension-wall pairs, `tests/fixtures/markdown/cross-*`):
- `cross-callout-title` — a `[[x]]` wikilink is a normal inline in callout titles and bodies, smartypants applies around it (`> [!note] See [[Page Name]] and "quoted" -- text` → resolved link + curly quotes + em dash in one title), and the no-space `>[!note]` marker-adjacency form.
- `cross-smartypants-scopes` — smartypants in footnote bodies and definition-list terms, plus the heading slug on a wikilink label (`# See [[Page Name]] now` → `id="see-page-name-now"`).
- `cross-callout-edges` — `[!two words]` and `[!note!]` stay literal, and the lazy-continuation boundary in both directions (a line before any body paragraph opens is a sibling block; a lazy line after an open body paragraph continues inside the callout).

**Contract pins:** CALLOUTS.md §1 (lazy-continuation boundary), §6 (the two new literal shapes), §8 (compositions), §9 (wall list); SMARTY.md §2 (footnote/definition scopes + heading-slug note) and §6; WIKILINKS.md §8 (slug-on-label); MARKDOWN-EXTENSIONS.md (the `cross-*.md` wall). Also removes a duplicated battery line in CALLOUTS.md §8.

**Verification:** `zig build test` 353/353 (12/12 steps), CommonMark `--gate` 652/652 (0 regressions), Cooklang 60/60, `zig fmt` clean.

Note: `487b673` was committed directly on local `main` before the push rule surfaced; this branch carries that exact commit (`git merge-base` will confirm it is the only diff), so the merge lands the pins without duplication.
