### PR TITLE
docs(TESTS): refresh stale test counts after the extension wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ zig build spec-conformance -- spec.txt
 | **Total** | **652/652** |
 
 ```bash
-zig build test    # run all tests (280 tests)
+zig build test    # run all tests (357 tests)
 zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -38,8 +38,11 @@ fifth — the XHTML profile suite — is described in its own section below):
    10,000-pair phrase storm, and a 2,000-deep phrase-nesting workload.
    Renderer tests construct documents directly so renderer behavior is
    verified without a dialect parser.
-2. **Fixture and adversarial tests** — 14 tests in `tests/fixtures_test.zig`.
-   The explicit index contains 275 Markdown and 105 Textile fixture pairs.
+2. **Fixture and adversarial tests** — 18 tests in `tests/fixtures_test.zig`.
+   The explicit index contains 299 Markdown (276 CommonMark/GFM +
+   18 extension + 5 frontmatter pairs) and 106 Textile (105 + 1
+   frontmatter pair) fixture pairs, plus 11 Cooklang pairs across the
+   fixture, frontmatter, serialize, scale, and menu tables.
    The Markdown wall includes byte-exact CommonMark 0.31.2 coverage of
    emphasis/strong, code spans, inline links, inline/reference-style images,
    block quotes, list items and lists (§§5.2–5.3: marker-width indentation,
@@ -145,7 +148,8 @@ fifth — the XHTML profile suite — is described in its own section below):
    docs/TEXTILE-PARITY.md §18). Every Textile fixture family in the
    index is counted in the final coverage scorecard,
    docs/TEXTILE-PARITY.md §24 — one fixture pair per row, summing to the
-   105 Textile pairs here. The Cooklang wall covers the semantic
+   105 parity pairs; the frontmatter pair brings the Textile wall to the
+   106 counted above. The Cooklang wall covers the semantic
    families end-to-end through Oliver's deterministic HTML policy
    (`cooklang-basic`, `cooklang-sections`, `cooklang-frontmatter`,
    `cooklang-literal`; docs/COOKLANG.md) and the canonical serializer
@@ -182,9 +186,9 @@ fifth — the XHTML profile suite — is described in its own section below):
    `--help`/`-h` handling. They run as part of the ordinary `zig build
    test` gate.
 
-The current complete result is **280/280 tests passing** with Zig 0.16.0
-(236 library module tests + 14 fixture/adversarial tests + 7
-conformance-harness tests + 10 CLI argument-parsing tests + 13 XHTML
+The current complete result is **357/357 tests passing** with Zig 0.16.0
+(304 library module tests + 18 fixture/adversarial tests + 7
+conformance-harness tests + 11 CLI argument-parsing tests + 17 XHTML
 profile tests). On top of the unit gate: the CommonMark
 0.31.2 corpus stays **652/652** with 0 mismatches (docs/README), the
 Textile wall stays fully green, and the Cooklang canonical corpus passes

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1179,7 +1179,7 @@ against `oliver render --from textile` during this wrap-up.
 | `notextile.` raw block | 2 | implemented (T25) | §23 |
 | inline composition (mixed families) | 1 | implemented (T4) | §3 |
 
-**105 fixture pairs, 280/280 tests, 652/652 CommonMark.** The
+**105 fixture pairs, 357/357 tests, 652/652 CommonMark.** The
 convergence pairs in `tests/fixtures_test.zig` additionally prove the
 shared renderer is byte-identical across dialects (Textile `*x*` ↔
 Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`, `!img.png!` ↔

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The documentation is written for two audiences:
 | CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
 | Cooklang canonical corpus | **60/60** |
 | Textile fixture wall | fully green |
-| Test suite | **280/280** |
+| Test suite | **357/357** |
 
 Both conformance gates run in CI on every push/PR
 (`zig build spec-conformance -- spec.txt --gate` and


### PR DESCRIPTION
## What

Refresh the stale test counts in the docs after the extension wave (#64–#67). The docs still advertised the pre-extension state (280/280, 275 Markdown pairs, 14 fixture tests) even though the suite had grown to 353/353 with the fixture wall expanded.

## Changes

- **docs/TESTS.md** — fixture-index paragraph (§1.2), Textile-wall cross-reference (§1.7), and the complete-result paragraph: 299 Markdown pairs (276 CommonMark/GFM + 18 extension + 5 frontmatter), 106 Textile (105 + 1 frontmatter), 10 Cooklang pairs, and the 353/353 breakdown (300 module + 18 fixture + 7 conformance + 11 CLI + 17 XHTML).
- **docs/TEXTILE-PARITY.md §24** — scorecard line 280/280 → 353/353.
- **docs/index.md** — coverage-table Test suite row.
- **README.md** — `zig build test` comment (280 → 353 tests).

The WORK-LEDGER reference to 280/280 is a historical milestone record and was intentionally left untouched.

## Verification

Counts recomputed fresh from `tests/fixtures_test.zig` (scripted against the index arrays) and confirmed against `zig build test --summary all` → 12/12 steps, 353/353 tests. No code changed.

Closes #73.
