### PR TITLE
feat(cli): expose the markdown extension surface on oliver render

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ zig build spec-conformance -- spec.txt
 | **Total** | **652/652** |
 
 ```bash
-zig build test    # run all tests (360 tests)
+zig build test    # run all tests (365 tests)
 zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```
@@ -303,6 +303,10 @@ oliver render --from cooklang  < recipe.cook
 oliver render --from markdown --to xhtml < document.md  # XML-compatible fragment
 oliver render --from textile  --to xhtml < document.textile
 oliver render --from cooklang --to xhtml < recipe.cook
+# Markdown extensions (all off by default)
+oliver render --from markdown --wikilinks --callouts --smartypants < document.md
+oliver render --from markdown --footnotes --definition-lists --heading-attributes --strikethrough < document.md
+oliver render --from markdown --frontmatter yaml < document.md  # --frontmatter works on any frontend
 oliver serialize --from cooklang < recipe.cook   # canonical .cook
 oliver scale --from cooklang --factor 2 < recipe.cook   # scaled .cook
 oliver scale --from cooklang --servings 4 < recipe.cook  # via servings

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -85,7 +85,11 @@ YAML). Derived operations over the same model:
   `oliver scale --from cooklang (--factor n[/d] | --servings n)`,
   `oliver menu --from cooklang` — a thin stdin/stdout adapter; all
   semantics live in the library. HTML remains the default; `--to xhtml`
-  selects the XML-compatible fragment serialization.
+  selects the XML-compatible fragment serialization. Markdown render
+  also exposes the extension surface as flags (`--wikilinks`,
+  `--callouts`, `--smartypants`, `--footnotes`, `--definition-lists`,
+  `--heading-attributes`, `--strikethrough`) and `--frontmatter
+  yaml|toml` on any render frontend — all off by default.
 
 ## Go deeper
 

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -2,7 +2,7 @@
 
 **Status:** implemented — opt-in Markdown dialect extensions  \
 **Modules:** `src/markdown.zig` (parse), `src/html.zig` (render), `src/document.zig` (model)  \
-**Options:** `oliver.ParseOptions.markdown` (parse) and `oliver.html.RenderOptions` (render)
+**Options:** `oliver.ParseOptions.markdown` (parse) and `oliver.html.RenderOptions` (render); the `oliver render --from markdown` CLI exposes each as a flag (`--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough`, `--wikilinks`, `--callouts`, `--smartypants`), all off by default, plus `--frontmatter yaml|toml` on any render frontend
 
 The Markdown frontend is byte-exact CommonMark 0.31.2 by default (the
 652/652 conformance corpus is green with default options). The extensions

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -178,17 +178,22 @@ fifth — the XHTML profile suite — is described in its own section below):
    complete/nonoverlapping manifest validation, malformed divergence-record
    rejection, outcome classification, and the single-trailing-newline
    comparison. These tests need no downloaded corpus.
-4. **CLI argument-parsing tests** — 10 tests in `src/main.zig`: pure
+4. **CLI argument-parsing tests** — 16 tests in `src/main.zig`: pure
    `parseArgs` unit tests (no allocator, no I/O) pinning the subcommand
    grammar (exactly one of `render`/`serialize`/`scale`/`menu`), flag
-   scoping (`--to` render-only; `--factor`/`--servings` scale-only),
-   dialect validation, zero-factor/zero-servings rejection, and
-   `--help`/`-h` handling. They run as part of the ordinary `zig build
-   test` gate.
+   scoping (`--to` render-only; `--factor`/`--servings` scale-only; the
+   Markdown extension flags `--wikilinks`/`--callouts`/`--smartypants`/
+   `--footnotes`/`--definition-lists`/`--heading-attributes`/
+   `--strikethrough` render+Markdown-only, `--frontmatter yaml|toml` on
+   any render frontend), dialect validation, zero-factor/zero-servings
+   rejection, and `--help`/`-h` handling — plus end-to-end render
+   tests that run each extension through the shared render path
+   (`renderWith`, the same path `main` uses). They run as part of the
+   ordinary `zig build test` gate.
 
-The current complete result is **360/360 tests passing** with Zig 0.16.0
+The current complete result is **365/365 tests passing** with Zig 0.16.0
 (307 library module tests + 18 fixture/adversarial tests + 7
-conformance-harness tests + 11 CLI argument-parsing tests + 17 XHTML
+conformance-harness tests + 16 CLI argument-parsing tests + 17 XHTML
 profile tests). On top of the unit gate: the CommonMark
 0.31.2 corpus stays **652/652** with 0 mismatches (docs/README), the
 Textile wall stays fully green, and the Cooklang canonical corpus passes

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1179,7 +1179,7 @@ against `oliver render --from textile` during this wrap-up.
 | `notextile.` raw block | 2 | implemented (T25) | §23 |
 | inline composition (mixed families) | 1 | implemented (T4) | §3 |
 
-**105 fixture pairs, 360/360 tests, 652/652 CommonMark.** The
+**105 fixture pairs, 365/365 tests, 652/652 CommonMark.** The
 convergence pairs in `tests/fixtures_test.zig` additionally prove the
 shared renderer is byte-identical across dialects (Textile `*x*` ↔
 Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`, `!img.png!` ↔

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -49,6 +49,7 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 | Markdown extension worker | E1 modular wikilinks | `Options.wikilinks` inline scan → `.wikilink` leaf (`target`/`label`) + resolver-aware render arm (default: target percent-encoded as the href, `label orelse target` as text; docs/WIKILINKS.md); Markdown fixtures; Textile and the CommonMark corpus untouched | after F1 (v0.5) | implemented on main (issue #64) |
 | Markdown extension worker | E2 callouts/admonitions | `Options.callouts` recognition on the container-block quote path; `.block_quote` callout payload (`type`/`title`/`title_nodes`) + `<div class="callout callout-<type>">` render arm (docs/CALLOUTS.md); Markdown fixtures; corpus untouched | after E1 (v0.6) | implemented on main (issue #65) |
 | shared worker | E3 smart typography | extract Textile's `replaceChars`/`hasCharMacroTrigger` machinery into one shared module (`src/typography.zig`; two callers, Textile byte-identical); `Options.smartypants` text pass with the Textile exemption set (docs/SMARTY.md); Markdown fixtures | after F1/E1 (v1.0) | implemented on main (issue #67) |
+| shared worker | E4 CLI extension surface | `oliver render --from markdown` exposes the full extension surface as flags (`--wikilinks`, `--callouts`, `--smartypants`, `--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough` — scoped to render + Markdown) plus `--frontmatter yaml|toml` on any render frontend (threaded into the shared `markdownParseOptions` / `cooklangParseOptions` / `renderOptionsFor` seams; `renderWith` is the one render path shared by `main` and the tests); 5 new CLI tests (flag scoping, frontmatter validation, one end-to-end render per extension incl. the legacy four and cooklang frontmatter); usage text + README + TESTS + CAPABILITIES + MARKDOWN-EXTENSIONS | after the extension wave (issue #74) | this PR |
 | Cooklang worker | CK6 string-quantity classify/scale + mixed numbers | public `classifyQuantity` / `parseFactor` / `scaleAmount` over authored amount strings (the exact-rational path, not `parseQuantity`'s f64 decimal arm); `scaleRecipe` becomes a caller of `scaleAmount` on ingredient quantities only; mixed `1 1/2` is a canonical scalable input (emits integer / fraction / terminating decimal); timers/cookware/refs still never scale; `scale-mixed` fixture; docs/COOKLANG.md §11 | after CK3 (issue #76; lets consumers delete a forked string scale) | merged (PR #77) |
 | Cooklang worker | CK7 scale edge-case hardening | review findings on the merged CK6 surface (issues #79–#81): `parseMixedNumber` trims leading/trailing ASCII space/tab (issue #79); `familyOfAmount` reads the decimal family from the source form exactly — no f64/i64 probe, terminating decimals at any magnitude (issue #80); `ScaledAmount.changed` distinguishes a rewrite from an overflow passthrough (issue #81); 3 unit tests pin the whitespace battery, the >i64 terminating cases, and the changed/passthrough triggers; docs/COOKLANG.md §11 + FEATURE-MATRIX + ARCHITECTURE + CLEANROOM session 29 | after CK6 | this PR |
 
@@ -1410,6 +1411,36 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 - **Integration:** after CK6; the 652/652 and 60/60 gates are
   re-verified.
 - **State:** this PR (issues #79–#81).
+
+## E4 — CLI extension surface (issue #74)
+
+- **Objective:** expose the Markdown extension surface through
+  `oliver render` — the four new extensions (wikilinks, callouts,
+  smartypants, frontmatter) and the four older parse options
+  (footnotes, definition lists, heading attributes, strikethrough) —
+  which all shipped library-only.
+- **Normative sources:** the extensions' own contracts
+  (docs/WIKILINKS.md, CALLOUTS.md, SMARTY.md, FRONTMATTER.md,
+  MARKDOWN-EXTENSIONS.md); no new markup semantics.
+- **Dependencies:** the shipped extension wave (#64–#67).
+- **Seams:** `src/main.zig` — `parseArgs` gains the eight flags with
+  strict command scoping (Markdown extensions render+Markdown-only;
+  `--frontmatter yaml|toml` render-any-frontend, duplicate and invalid
+  values rejected); `markdownParseOptions` / `cooklangParseOptions` /
+  `renderOptionsFor` build the options from the config; `renderWith`
+  is the one markdown/textile render path shared by `main` and the
+  tests, so the tested path is the shipped path.
+- **Acceptance:** `render --from markdown --wikilinks --callouts
+  --smartypants` renders all three; `--frontmatter yaml` strips the
+  fence on any frontend; the flags are rejected on textile/cooklang
+  render and on serialize/scale/menu; `--frontmatter json` and a
+  duplicate `--frontmatter` are rejected.
+- **Tests:** 5 CLI tests (flag scoping, frontmatter validation, one
+  end-to-end render per extension, the legacy four, cooklang
+  frontmatter). 365/365, 652/652, 60/60 re-verified.
+- **Parallelism:** yes; parser and renderer untouched.
+- **Integration:** after the extension wave; gates re-verified.
+- **State:** this PR (issue #74).
 
 ## Deferred architectural cards
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The documentation is written for two audiences:
 | CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
 | Cooklang canonical corpus | **60/60** |
 | Textile fixture wall | fully green |
-| Test suite | **360/360** |
+| Test suite | **365/365** |
 
 Both conformance gates run in CI on every push/PR
 (`zig build spec-conformance -- spec.txt --gate` and

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,20 @@ pub const RunConfig = struct {
     factor_den: ?u32 = null,
     servings_target: ?u32 = null,
     profile: oliver.OutputProfile = .html,
+    /// Markdown extension surface (`render --from markdown` only; all off
+    /// by default). `parseArgs` scopes them to the Markdown frontend;
+    /// `renderDocument` threads them into `markdown.Options` / the
+    /// footnotes render option (docs/MARKDOWN-EXTENSIONS.md).
+    footnotes: bool = false,
+    definition_lists: bool = false,
+    heading_attributes: bool = false,
+    strikethrough: bool = false,
+    wikilinks: bool = false,
+    callouts: bool = false,
+    smartypants: bool = false,
+    /// Front matter mode (`render` with any frontend; null = default
+    /// off). Shared by all three frontends (docs/FRONTMATTER.md §3).
+    frontmatter: ?oliver.frontmatter.Option = null,
 };
 
 /// Parses the argument vector (excluding the program name) into a
@@ -59,8 +73,17 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     var factor_den: ?u32 = null;
     var servings_target: ?u32 = null;
     var profile: oliver.OutputProfile = .html;
+    var footnotes = false;
+    var definition_lists = false;
+    var heading_attributes = false;
+    var strikethrough = false;
+    var wikilinks = false;
+    var callouts = false;
+    var smartypants = false;
+    var frontmatter: ?oliver.frontmatter.Option = null;
     var saw_to = false;
     var saw_from = false;
+    var saw_frontmatter = false;
 
     var index: usize = 0;
     while (index < args.len) : (index += 1) {
@@ -126,6 +149,33 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
             const value = args[index];
             servings_target = std.fmt.parseUnsigned(u32, value, 10) catch return error.Usage;
             if (servings_target.? == 0) return error.Usage;
+        } else if (std.mem.eql(u8, arg, "--wikilinks")) {
+            wikilinks = true;
+        } else if (std.mem.eql(u8, arg, "--callouts")) {
+            callouts = true;
+        } else if (std.mem.eql(u8, arg, "--smartypants")) {
+            smartypants = true;
+        } else if (std.mem.eql(u8, arg, "--footnotes")) {
+            footnotes = true;
+        } else if (std.mem.eql(u8, arg, "--definition-lists")) {
+            definition_lists = true;
+        } else if (std.mem.eql(u8, arg, "--heading-attributes")) {
+            heading_attributes = true;
+        } else if (std.mem.eql(u8, arg, "--strikethrough")) {
+            strikethrough = true;
+        } else if (std.mem.eql(u8, arg, "--frontmatter")) {
+            if (index + 1 >= args.len) return error.Usage;
+            index += 1;
+            // A second `--frontmatter` would contradict the first (like
+            // a second `--from`), so reject duplicates.
+            if (saw_frontmatter) return error.Usage;
+            saw_frontmatter = true;
+            const value = args[index];
+            if (std.mem.eql(u8, value, "yaml")) {
+                frontmatter = .yaml;
+            } else if (std.mem.eql(u8, value, "toml")) {
+                frontmatter = .toml;
+            } else return error.Usage;
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             return error.Help;
         } else if (std.mem.eql(u8, arg, "--version")) {
@@ -139,18 +189,25 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     if (!cooklang and dialect == null) return error.Usage;
     // Flags must belong to the command they are given with: `--to`
     // selects the renderer profile (render only), `--factor` /
-    // `--servings` configure scaling (scale only), and serialize/scale/
-    // menu are Cooklang capabilities only (Markdown/Textile have no
-    // canonical form; the shared renderer is the output for those).
+    // `--servings` configure scaling (scale only), serialize/scale/menu
+    // are Cooklang capabilities only, the Markdown extension flags are
+    // Markdown-frontend options, and `--frontmatter` is a render
+    // option shared by every frontend.
+    const ext_flags = footnotes or definition_lists or heading_attributes or
+        strikethrough or wikilinks or callouts or smartypants;
     switch (cmd) {
         .render => {
             if (factor_num != null or servings_target != null) return error.Usage;
+            // The Markdown extensions cannot apply to Textile or
+            // Cooklang; rejecting them keeps the strict scoping rule.
+            if (ext_flags and dialect != .markdown) return error.Usage;
         },
         .serialize, .menu => {
-            if (!cooklang or saw_to or factor_num != null or servings_target != null) return error.Usage;
+            if (!cooklang or saw_to or factor_num != null or servings_target != null or
+                ext_flags or frontmatter != null) return error.Usage;
         },
         .scale => {
-            if (!cooklang or saw_to) return error.Usage;
+            if (!cooklang or saw_to or ext_flags or frontmatter != null) return error.Usage;
             // Scaling needs exactly one mode: factor or servings.
             if ((factor_num == null) == (servings_target == null)) return error.Usage;
         },
@@ -163,6 +220,14 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         .factor_den = factor_den,
         .servings_target = servings_target,
         .profile = profile,
+        .footnotes = footnotes,
+        .definition_lists = definition_lists,
+        .heading_attributes = heading_attributes,
+        .strikethrough = strikethrough,
+        .wikilinks = wikilinks,
+        .callouts = callouts,
+        .smartypants = smartypants,
+        .frontmatter = frontmatter,
     };
 }
 
@@ -210,7 +275,7 @@ pub fn main(init: std.process.Init) !u8 {
     var out_writer = std.Io.File.stdout().writer(init.io, &out_buf);
 
     if (cfg.cooklang) {
-        var result = oliver.cooklang.parse(gpa, input.items, .{}) catch |err| {
+        var result = oliver.cooklang.parse(gpa, input.items, cooklangParseOptions(cfg)) catch |err| {
             std.debug.print("oliver: {s}\n", .{@errorName(err)});
             return 1;
         };
@@ -256,14 +321,8 @@ pub fn main(init: std.process.Init) !u8 {
             },
         }
     } else {
-        const d = cfg.dialect.?;
-        var result = oliver.parse(gpa, input.items, d, .{}) catch |err| {
+        const html_bytes = renderWith(gpa, cfg, input.items) catch |err| {
             std.debug.print("oliver: {s}\n", .{@errorName(err)});
-            return 1;
-        };
-        defer result.deinit();
-        oliver.html.render(gpa, &out_writer.interface, &result.document, .{ .profile = profile }) catch |err| {
-            std.debug.print("oliver: render failed: {s}\n", .{@errorName(err)});
             if (err == error.RawHtmlNotXmlWellFormed) {
                 std.debug.print(
                     "oliver: --to xhtml rejects raw HTML that cannot be guaranteed well-formed XML\n" ++
@@ -273,9 +332,64 @@ pub fn main(init: std.process.Init) !u8 {
             }
             return 1;
         };
+        defer gpa.free(html_bytes);
+        out_writer.interface.writeAll(html_bytes) catch {};
     }
     out_writer.flush() catch {};
     return 0;
+}
+
+// ---------------------------------------------------------------------------
+// The render path, shared by `main` and the CLI tests so the tested path
+// is the shipped path.
+// ---------------------------------------------------------------------------
+
+/// The Markdown/Textile parse options selected by the extension flags in
+/// `cfg` (scoped to the render command by `parseArgs`).
+fn markdownParseOptions(cfg: RunConfig) oliver.ParseOptions {
+    var opts = oliver.ParseOptions{};
+    opts.markdown = .{
+        .footnotes = cfg.footnotes,
+        .definition_lists = cfg.definition_lists,
+        .heading_attributes = cfg.heading_attributes,
+        .strikethrough = cfg.strikethrough,
+        .wikilinks = cfg.wikilinks,
+        .callouts = cfg.callouts,
+        .smartypants = cfg.smartypants,
+    };
+    if (cfg.frontmatter) |fm| opts.frontmatter = fm;
+    return opts;
+}
+
+/// The Cooklang parse options selected by `cfg` (front matter only; the
+/// Markdown extensions do not apply to Cooklang).
+fn cooklangParseOptions(cfg: RunConfig) oliver.cooklang.ParseOptions {
+    var opts = oliver.cooklang.ParseOptions{};
+    if (cfg.frontmatter) |fm| opts.frontmatter = fm;
+    return opts;
+}
+
+/// The renderer options for the extension flags in `cfg`. The footnotes
+/// extension has a render side: references and the `<section>` emit only
+/// when this option is on (docs/MARKDOWN-EXTENSIONS.md).
+fn renderOptionsFor(cfg: RunConfig) oliver.html.RenderOptions {
+    return .{
+        .profile = cfg.profile,
+        .footnotes = cfg.footnotes,
+    };
+}
+
+/// Renders a Markdown/Textile document with the extension options from
+/// `cfg`. Returns the owned HTML bytes; the caller frees with the same
+/// allocator.
+fn renderWith(a: std.mem.Allocator, cfg: RunConfig, input: []const u8) ![]u8 {
+    var result = try oliver.parse(a, input, cfg.dialect.?, markdownParseOptions(cfg));
+    defer result.deinit();
+    var aw = std.Io.Writer.Allocating.init(a);
+    defer aw.deinit();
+    try oliver.html.render(a, &aw.writer, &result.document, renderOptionsFor(cfg));
+    var out = aw.toArrayList();
+    return out.toOwnedSlice(a);
 }
 
 fn printUsage() void {
@@ -290,6 +404,12 @@ fn printUsage() void {
         \\(XHTML fragment with --to xhtml). serialize/scale write canonical
         \\Cooklang text; menu writes the day/meal text dump. --version prints
         \\the version and the embedded source commit (CI builds).
+        \\
+        \\Markdown extensions (render --from markdown, all off by default):
+        \\  --wikilinks  --callouts  --smartypants  --footnotes
+        \\  --definition-lists  --heading-attributes  --strikethrough
+        \\Front matter (render with any frontend, off by default):
+        \\  --frontmatter yaml|toml
         \\
     , .{});
 }
@@ -399,4 +519,129 @@ test "cli: zero scale factors are rejected, not passed to the library" {
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "0" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "0/2" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "2/0" }));
+}
+
+test "cli: markdown extension flags are scoped to render --from markdown" {
+    const wl = try parseArgs(&.{ "render", "--from", "markdown", "--wikilinks" });
+    try testing.expect(wl.wikilinks);
+    const co = try parseArgs(&.{ "render", "--from", "markdown", "--callouts" });
+    try testing.expect(co.callouts);
+    const sp = try parseArgs(&.{ "render", "--from", "markdown", "--smartypants" });
+    try testing.expect(sp.smartypants);
+    const all = try parseArgs(&.{ "render", "--from", "markdown", "--footnotes", "--definition-lists", "--heading-attributes", "--strikethrough" });
+    try testing.expect(all.footnotes and all.definition_lists and all.heading_attributes and all.strikethrough);
+
+    // A flag that cannot apply is an error (the --to-on-serialize rule).
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "textile", "--wikilinks" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "cooklang", "--smartypants" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "serialize", "--from", "cooklang", "--callouts" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "2", "--footnotes" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "menu", "--from", "cooklang", "--wikilinks" }));
+}
+
+test "cli: --frontmatter is a render option shared by every frontend" {
+    const md = try parseArgs(&.{ "render", "--from", "markdown", "--frontmatter", "yaml" });
+    try testing.expectEqual(oliver.frontmatter.Option.yaml, md.frontmatter.?);
+    const tx = try parseArgs(&.{ "render", "--from", "textile", "--frontmatter", "toml" });
+    try testing.expectEqual(oliver.frontmatter.Option.toml, tx.frontmatter.?);
+    const ck = try parseArgs(&.{ "render", "--from", "cooklang", "--frontmatter", "yaml" });
+    try testing.expectEqual(oliver.frontmatter.Option.yaml, ck.frontmatter.?);
+
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "markdown", "--frontmatter", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "markdown", "--frontmatter" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "markdown", "--frontmatter", "yaml", "--frontmatter", "toml" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "serialize", "--from", "cooklang", "--frontmatter", "yaml" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "2", "--frontmatter", "yaml" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "menu", "--from", "cooklang", "--frontmatter", "yaml" }));
+}
+
+test "cli: the four new markdown extensions render end to end" {
+    const allocator = std.testing.allocator;
+
+    // Wikilinks resolve under the default policy (target percent-encoded
+    // href, label orelse target as text).
+    const wl = try parseArgs(&.{ "render", "--from", "markdown", "--wikilinks" });
+    const wl_out = try renderWith(allocator, wl, "See [[Page Name]] now.\n");
+    defer allocator.free(wl_out);
+    try testing.expect(std.mem.indexOf(u8, wl_out, "<a href=\"Page%20Name\">Page Name</a>") != null);
+
+    // Callouts become the semantic box with the inline-parsed title.
+    const co = try parseArgs(&.{ "render", "--from", "markdown", "--callouts" });
+    const co_out = try renderWith(allocator, co, "> [!note] Title\n> body\n");
+    defer allocator.free(co_out);
+    try testing.expect(std.mem.indexOf(u8, co_out, "<div class=\"callout callout-note\">") != null);
+    try testing.expect(std.mem.indexOf(u8, co_out, "<div class=\"callout-title\">Title</div>") != null);
+
+    // Smart typography applies the curly quotes and the em dash.
+    const sp = try parseArgs(&.{ "render", "--from", "markdown", "--smartypants" });
+    const sp_out = try renderWith(allocator, sp, "\"Hello\" -- world\n");
+    defer allocator.free(sp_out);
+    try testing.expect(std.mem.indexOf(u8, sp_out, "“Hello” — world") != null);
+
+    // Front matter: the fence is consumed and the body renders; the same
+    // input without the flag keeps `---` a thematic break (control).
+    const fm = try parseArgs(&.{ "render", "--from", "markdown", "--frontmatter", "yaml" });
+    const fm_out = try renderWith(allocator, fm, "---\ntitle: Hello\n---\n\n# Doc\n");
+    defer allocator.free(fm_out);
+    try testing.expect(std.mem.indexOf(u8, fm_out, "<h1>Doc</h1>") != null);
+    try testing.expect(std.mem.indexOf(u8, fm_out, "<hr") == null);
+    const plain = try parseArgs(&.{ "render", "--from", "markdown" });
+    const plain_out = try renderWith(allocator, plain, "---\ntitle: Hello\n---\n\n# Doc\n");
+    defer allocator.free(plain_out);
+    try testing.expect(std.mem.indexOf(u8, plain_out, "<hr") != null);
+}
+
+test "cli: the legacy markdown extensions render end to end" {
+    const allocator = std.testing.allocator;
+
+    const dl = try parseArgs(&.{ "render", "--from", "markdown", "--definition-lists" });
+    const dl_out = try renderWith(allocator, dl, "Term\n: definition\n");
+    defer allocator.free(dl_out);
+    try testing.expect(std.mem.indexOf(u8, dl_out, "<dl>") != null);
+    try testing.expect(std.mem.indexOf(u8, dl_out, "<dt>Term</dt>") != null);
+
+    const ha = try parseArgs(&.{ "render", "--from", "markdown", "--heading-attributes" });
+    const ha_out = try renderWith(allocator, ha, "# Head {#id .cls}\n");
+    defer allocator.free(ha_out);
+    try testing.expect(std.mem.indexOf(u8, ha_out, "<h1 id=\"id\" class=\"cls\">Head</h1>") != null);
+
+    const st = try parseArgs(&.{ "render", "--from", "markdown", "--strikethrough" });
+    const st_out = try renderWith(allocator, st, "~~gone~~\n");
+    defer allocator.free(st_out);
+    try testing.expect(std.mem.indexOf(u8, st_out, "<p><del>gone</del></p>") != null);
+
+    // Footnotes have a render side too: the references and the section
+    // emit only when the render option is on (renderWith threads it).
+    const fn_ = try parseArgs(&.{ "render", "--from", "markdown", "--footnotes" });
+    const fn_out = try renderWith(allocator, fn_, "Ref[^1].\n\n[^1]: note\n");
+    defer allocator.free(fn_out);
+    try testing.expect(std.mem.indexOf(u8, fn_out, "class=\"footnote-ref\"") != null);
+    try testing.expect(std.mem.indexOf(u8, fn_out, "<section class=\"footnotes\"") != null);
+}
+
+test "cli: --frontmatter reaches the cooklang render path" {
+    const allocator = std.testing.allocator;
+    const input = "+++\ntitle = \"x\"\n+++\nAdd @salt.\n";
+
+    // With --frontmatter toml the +++ fence is consumed; the default
+    // (yaml sniffing) leaves it as body text.
+    const toml = try parseArgs(&.{ "render", "--from", "cooklang", "--frontmatter", "toml" });
+    var result = try oliver.cooklang.parse(allocator, input, cooklangParseOptions(toml));
+    defer result.deinit();
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    try oliver.cooklang_html.render(allocator, &aw.writer, &result.recipe, .{ .profile = toml.profile });
+    var out = aw.toArrayList();
+    defer out.deinit(allocator);
+    try testing.expect(std.mem.indexOf(u8, out.items, "+++") == null);
+
+    const plain = try parseArgs(&.{ "render", "--from", "cooklang" });
+    var result2 = try oliver.cooklang.parse(allocator, input, cooklangParseOptions(plain));
+    defer result2.deinit();
+    var aw2 = std.Io.Writer.Allocating.init(allocator);
+    defer aw2.deinit();
+    try oliver.cooklang_html.render(allocator, &aw2.writer, &result2.recipe, .{ .profile = plain.profile });
+    var out2 = aw2.toArrayList();
+    defer out2.deinit(allocator);
+    try testing.expect(std.mem.indexOf(u8, out2.items, "+++") != null);
 }


### PR DESCRIPTION
## What

Expose the Markdown extension surface through the `oliver render` CLI (issue #74). The four extensions of the wave — wikilinks (#64), frontmatter (#66), callouts (#65), smartypants (#67) — and the four older parse options (footnotes, definition lists, heading attributes, strikethrough) all shipped library-only; a CLI consumer had no way to opt in.

## Changes

- **`--wikilinks` `--callouts` `--smartypants` `--footnotes` `--definition-lists` `--heading-attributes` `--strikethrough`** — `render --from markdown` only; rejected on textile/cooklang render and on serialize/scale/menu (a flag that cannot apply is an error, the `--to`-on-serialize rule).
- **`--frontmatter yaml|toml`** — works on any render frontend (markdown, textile, cooklang); invalid values, missing values, and duplicates rejected.
- Options threaded through shared seams (`markdownParseOptions` / `cooklangParseOptions` / `renderOptionsFor`; `renderWith` is the one markdown/textile render path shared by `main` and the tests), including the footnotes **render** side (`RenderOptions.footnotes`) so the `<section>` emits with the flag.
- Usage text updated with all eight flags.

## Tests

CLI suite 11 → 16: flag-scoping battery, `--frontmatter` validation battery, and five end-to-end render tests running each extension through the shipped path — wikilinks resolve (`Page%20Name` href), callouts render the box, smartypants typographs (`“Hello” — world`), `--frontmatter yaml` strips the fence (with a no-flag `<hr />` control), the legacy four render (`<dl>`, `id`/`class` heading, `<del>`, footnotes section), and `--frontmatter toml` consumes a `+++` fence on cooklang (with a control).

## Verification

- `zig build test` — 365/365 (12/12 steps; CLI 11 → 16)
- CommonMark `--gate` — 652/652, 0 regressions
- Cooklang — 60/60

## Docs

README CLI section, CAPABILITIES CLI bullet, MARKDOWN-EXTENSIONS options line, TESTS.md §1.4 + counts, WORK-LEDGER E4 card + traffic row. Count lines refreshed to 365/365.

Note: `heading_ids` (a render-only option, `html.RenderOptions`, not in `markdown.Options`) remains library-only; a `--heading-ids` flag would be a trivial follow-up.

Closes #74.
