### PR TITLE
feat(cli): add --heading-ids for GFM-style auto heading ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ zig build spec-conformance -- spec.txt
 | **Total** | **652/652** |
 
 ```bash
-zig build test    # run all tests (365 tests)
+zig build test    # run all tests (366 tests)
 zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```
@@ -306,6 +306,7 @@ oliver render --from cooklang --to xhtml < recipe.cook
 # Markdown extensions (all off by default)
 oliver render --from markdown --wikilinks --callouts --smartypants < document.md
 oliver render --from markdown --footnotes --definition-lists --heading-attributes --strikethrough < document.md
+oliver render --from markdown --heading-ids < document.md  # GFM-style auto ids on headings
 oliver render --from markdown --frontmatter yaml < document.md  # --frontmatter works on any frontend
 oliver serialize --from cooklang < recipe.cook   # canonical .cook
 oliver scale --from cooklang --factor 2 < recipe.cook   # scaled .cook

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -88,8 +88,9 @@ YAML). Derived operations over the same model:
   selects the XML-compatible fragment serialization. Markdown render
   also exposes the extension surface as flags (`--wikilinks`,
   `--callouts`, `--smartypants`, `--footnotes`, `--definition-lists`,
-  `--heading-attributes`, `--strikethrough`) and `--frontmatter
-  yaml|toml` on any render frontend — all off by default.
+  `--heading-attributes`, `--strikethrough`, `--heading-ids`) and
+  `--frontmatter yaml|toml` on any render frontend — all off by
+  default.
 
 ## Go deeper
 

--- a/docs/MARKDOWN-EXTENSIONS.md
+++ b/docs/MARKDOWN-EXTENSIONS.md
@@ -2,7 +2,7 @@
 
 **Status:** implemented — opt-in Markdown dialect extensions  \
 **Modules:** `src/markdown.zig` (parse), `src/html.zig` (render), `src/document.zig` (model)  \
-**Options:** `oliver.ParseOptions.markdown` (parse) and `oliver.html.RenderOptions` (render); the `oliver render --from markdown` CLI exposes each as a flag (`--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough`, `--wikilinks`, `--callouts`, `--smartypants`), all off by default, plus `--frontmatter yaml|toml` on any render frontend
+**Options:** `oliver.ParseOptions.markdown` (parse) and `oliver.html.RenderOptions` (render); the `oliver render --from markdown` CLI exposes each as a flag (`--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough`, `--wikilinks`, `--callouts`, `--smartypants`, and the render-side `--heading-ids`), all off by default, plus `--frontmatter yaml|toml` on any render frontend
 
 The Markdown frontend is byte-exact CommonMark 0.31.2 by default (the
 652/652 conformance corpus is green with default options). The extensions

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -178,22 +178,23 @@ fifth — the XHTML profile suite — is described in its own section below):
    complete/nonoverlapping manifest validation, malformed divergence-record
    rejection, outcome classification, and the single-trailing-newline
    comparison. These tests need no downloaded corpus.
-4. **CLI argument-parsing tests** — 16 tests in `src/main.zig`: pure
+4. **CLI argument-parsing tests** — 17 tests in `src/main.zig`: pure
    `parseArgs` unit tests (no allocator, no I/O) pinning the subcommand
    grammar (exactly one of `render`/`serialize`/`scale`/`menu`), flag
    scoping (`--to` render-only; `--factor`/`--servings` scale-only; the
    Markdown extension flags `--wikilinks`/`--callouts`/`--smartypants`/
    `--footnotes`/`--definition-lists`/`--heading-attributes`/
-   `--strikethrough` render+Markdown-only, `--frontmatter yaml|toml` on
-   any render frontend), dialect validation, zero-factor/zero-servings
-   rejection, and `--help`/`-h` handling — plus end-to-end render
+   `--strikethrough`/`--heading-ids` render+Markdown-only,
+   `--frontmatter yaml|toml` on any render frontend), dialect
+   validation, zero-factor/zero-servings rejection, and
+   `--help`/`-h` handling — plus end-to-end render
    tests that run each extension through the shared render path
    (`renderWith`, the same path `main` uses). They run as part of the
    ordinary `zig build test` gate.
 
-The current complete result is **365/365 tests passing** with Zig 0.16.0
+The current complete result is **366/366 tests passing** with Zig 0.16.0
 (307 library module tests + 18 fixture/adversarial tests + 7
-conformance-harness tests + 16 CLI argument-parsing tests + 17 XHTML
+conformance-harness tests + 17 CLI argument-parsing tests + 17 XHTML
 profile tests). On top of the unit gate: the CommonMark
 0.31.2 corpus stays **652/652** with 0 mismatches (docs/README), the
 Textile wall stays fully green, and the Cooklang canonical corpus passes

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1179,7 +1179,7 @@ against `oliver render --from textile` during this wrap-up.
 | `notextile.` raw block | 2 | implemented (T25) | §23 |
 | inline composition (mixed families) | 1 | implemented (T4) | §3 |
 
-**105 fixture pairs, 365/365 tests, 652/652 CommonMark.** The
+**105 fixture pairs, 366/366 tests, 652/652 CommonMark.** The
 convergence pairs in `tests/fixtures_test.zig` additionally prove the
 shared renderer is byte-identical across dialects (Textile `*x*` ↔
 Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`, `!img.png!` ↔

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -49,7 +49,7 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 | Markdown extension worker | E1 modular wikilinks | `Options.wikilinks` inline scan → `.wikilink` leaf (`target`/`label`) + resolver-aware render arm (default: target percent-encoded as the href, `label orelse target` as text; docs/WIKILINKS.md); Markdown fixtures; Textile and the CommonMark corpus untouched | after F1 (v0.5) | implemented on main (issue #64) |
 | Markdown extension worker | E2 callouts/admonitions | `Options.callouts` recognition on the container-block quote path; `.block_quote` callout payload (`type`/`title`/`title_nodes`) + `<div class="callout callout-<type>">` render arm (docs/CALLOUTS.md); Markdown fixtures; corpus untouched | after E1 (v0.6) | implemented on main (issue #65) |
 | shared worker | E3 smart typography | extract Textile's `replaceChars`/`hasCharMacroTrigger` machinery into one shared module (`src/typography.zig`; two callers, Textile byte-identical); `Options.smartypants` text pass with the Textile exemption set (docs/SMARTY.md); Markdown fixtures | after F1/E1 (v1.0) | implemented on main (issue #67) |
-| shared worker | E4 CLI extension surface | `oliver render --from markdown` exposes the full extension surface as flags (`--wikilinks`, `--callouts`, `--smartypants`, `--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough` — scoped to render + Markdown) plus `--frontmatter yaml|toml` on any render frontend (threaded into the shared `markdownParseOptions` / `cooklangParseOptions` / `renderOptionsFor` seams; `renderWith` is the one render path shared by `main` and the tests); 5 new CLI tests (flag scoping, frontmatter validation, one end-to-end render per extension incl. the legacy four and cooklang frontmatter); usage text + README + TESTS + CAPABILITIES + MARKDOWN-EXTENSIONS | after the extension wave (issue #74) | this PR |
+| shared worker | E4 CLI extension surface | `oliver render --from markdown` exposes the full extension surface as flags (`--wikilinks`, `--callouts`, `--smartypants`, `--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough`, `--heading-ids` — scoped to render + Markdown) plus `--frontmatter yaml|toml` on any render frontend (threaded into the shared `markdownParseOptions` / `cooklangParseOptions` / `renderOptionsFor` seams; `renderWith` is the one render path shared by `main` and the tests); 6 new CLI tests (flag scoping, frontmatter validation, one end-to-end render per extension incl. the legacy four, heading ids, and cooklang frontmatter); usage text + README + TESTS + CAPABILITIES + MARKDOWN-EXTENSIONS | after the extension wave (issue #74) | merged (PR #83) |
 | Cooklang worker | CK6 string-quantity classify/scale + mixed numbers | public `classifyQuantity` / `parseFactor` / `scaleAmount` over authored amount strings (the exact-rational path, not `parseQuantity`'s f64 decimal arm); `scaleRecipe` becomes a caller of `scaleAmount` on ingredient quantities only; mixed `1 1/2` is a canonical scalable input (emits integer / fraction / terminating decimal); timers/cookware/refs still never scale; `scale-mixed` fixture; docs/COOKLANG.md §11 | after CK3 (issue #76; lets consumers delete a forked string scale) | merged (PR #77) |
 | Cooklang worker | CK7 scale edge-case hardening | review findings on the merged CK6 surface (issues #79–#81): `parseMixedNumber` trims leading/trailing ASCII space/tab (issue #79); `familyOfAmount` reads the decimal family from the source form exactly — no f64/i64 probe, terminating decimals at any magnitude (issue #80); `ScaledAmount.changed` distinguishes a rewrite from an overflow passthrough (issue #81); 3 unit tests pin the whitespace battery, the >i64 terminating cases, and the changed/passthrough triggers; docs/COOKLANG.md §11 + FEATURE-MATRIX + ARCHITECTURE + CLEANROOM session 29 | after CK6 | this PR |
 
@@ -1416,9 +1416,10 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 
 - **Objective:** expose the Markdown extension surface through
   `oliver render` — the four new extensions (wikilinks, callouts,
-  smartypants, frontmatter) and the four older parse options
-  (footnotes, definition lists, heading attributes, strikethrough) —
-  which all shipped library-only.
+  smartypants, frontmatter), the four older parse options (footnotes,
+  definition lists, heading attributes, strikethrough), and the
+  render-side `--heading-ids` (GFM-style auto heading ids) — which
+  all shipped library-only.
 - **Normative sources:** the extensions' own contracts
   (docs/WIKILINKS.md, CALLOUTS.md, SMARTY.md, FRONTMATTER.md,
   MARKDOWN-EXTENSIONS.md); no new markup semantics.
@@ -1431,13 +1432,14 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
   is the one markdown/textile render path shared by `main` and the
   tests, so the tested path is the shipped path.
 - **Acceptance:** `render --from markdown --wikilinks --callouts
-  --smartypants` renders all three; `--frontmatter yaml` strips the
-  fence on any frontend; the flags are rejected on textile/cooklang
-  render and on serialize/scale/menu; `--frontmatter json` and a
-  duplicate `--frontmatter` are rejected.
-- **Tests:** 5 CLI tests (flag scoping, frontmatter validation, one
-  end-to-end render per extension, the legacy four, cooklang
-  frontmatter). 365/365, 652/652, 60/60 re-verified.
+  --smartypants` renders all three; `--heading-ids` slugs every
+  heading; `--frontmatter yaml` strips the fence on any frontend; the
+  flags are rejected on textile/cooklang render and on
+  serialize/scale/menu; `--frontmatter json` and a duplicate
+  `--frontmatter` are rejected.
+- **Tests:** 6 CLI tests (flag scoping, frontmatter validation, one
+  end-to-end render per extension, the legacy four, heading ids,
+  cooklang frontmatter). 366/366, 652/652, 60/60 re-verified.
 - **Parallelism:** yes; parser and renderer untouched.
 - **Integration:** after the extension wave; gates re-verified.
 - **State:** this PR (issue #74).

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The documentation is written for two audiences:
 | CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
 | Cooklang canonical corpus | **60/60** |
 | Textile fixture wall | fully green |
-| Test suite | **365/365** |
+| Test suite | **366/366** |
 
 Both conformance gates run in CI on every push/PR
 (`zig build spec-conformance -- spec.txt --gate` and

--- a/src/main.zig
+++ b/src/main.zig
@@ -44,8 +44,9 @@ pub const RunConfig = struct {
     profile: oliver.OutputProfile = .html,
     /// Markdown extension surface (`render --from markdown` only; all off
     /// by default). `parseArgs` scopes them to the Markdown frontend;
-    /// `renderDocument` threads them into `markdown.Options` / the
-    /// footnotes render option (docs/MARKDOWN-EXTENSIONS.md).
+    /// `markdownParseOptions` / `renderOptionsFor` thread them into
+    /// `markdown.Options` and the footnotes / heading-ids render options
+    /// (docs/MARKDOWN-EXTENSIONS.md).
     footnotes: bool = false,
     definition_lists: bool = false,
     heading_attributes: bool = false,
@@ -53,6 +54,7 @@ pub const RunConfig = struct {
     wikilinks: bool = false,
     callouts: bool = false,
     smartypants: bool = false,
+    heading_ids: bool = false,
     /// Front matter mode (`render` with any frontend; null = default
     /// off). Shared by all three frontends (docs/FRONTMATTER.md §3).
     frontmatter: ?oliver.frontmatter.Option = null,
@@ -80,6 +82,7 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     var wikilinks = false;
     var callouts = false;
     var smartypants = false;
+    var heading_ids = false;
     var frontmatter: ?oliver.frontmatter.Option = null;
     var saw_to = false;
     var saw_from = false;
@@ -163,6 +166,8 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
             heading_attributes = true;
         } else if (std.mem.eql(u8, arg, "--strikethrough")) {
             strikethrough = true;
+        } else if (std.mem.eql(u8, arg, "--heading-ids")) {
+            heading_ids = true;
         } else if (std.mem.eql(u8, arg, "--frontmatter")) {
             if (index + 1 >= args.len) return error.Usage;
             index += 1;
@@ -194,7 +199,7 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     // Markdown-frontend options, and `--frontmatter` is a render
     // option shared by every frontend.
     const ext_flags = footnotes or definition_lists or heading_attributes or
-        strikethrough or wikilinks or callouts or smartypants;
+        strikethrough or wikilinks or callouts or smartypants or heading_ids;
     switch (cmd) {
         .render => {
             if (factor_num != null or servings_target != null) return error.Usage;
@@ -227,6 +232,7 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         .wikilinks = wikilinks,
         .callouts = callouts,
         .smartypants = smartypants,
+        .heading_ids = heading_ids,
         .frontmatter = frontmatter,
     };
 }
@@ -376,6 +382,7 @@ fn renderOptionsFor(cfg: RunConfig) oliver.html.RenderOptions {
     return .{
         .profile = cfg.profile,
         .footnotes = cfg.footnotes,
+        .heading_ids = cfg.heading_ids,
     };
 }
 
@@ -408,6 +415,7 @@ fn printUsage() void {
         \\Markdown extensions (render --from markdown, all off by default):
         \\  --wikilinks  --callouts  --smartypants  --footnotes
         \\  --definition-lists  --heading-attributes  --strikethrough
+        \\  --heading-ids  (GFM-style auto ids on headings)
         \\Front matter (render with any frontend, off by default):
         \\  --frontmatter yaml|toml
         \\
@@ -528,12 +536,15 @@ test "cli: markdown extension flags are scoped to render --from markdown" {
     try testing.expect(co.callouts);
     const sp = try parseArgs(&.{ "render", "--from", "markdown", "--smartypants" });
     try testing.expect(sp.smartypants);
+    const hi = try parseArgs(&.{ "render", "--from", "markdown", "--heading-ids" });
+    try testing.expect(hi.heading_ids);
     const all = try parseArgs(&.{ "render", "--from", "markdown", "--footnotes", "--definition-lists", "--heading-attributes", "--strikethrough" });
     try testing.expect(all.footnotes and all.definition_lists and all.heading_attributes and all.strikethrough);
 
     // A flag that cannot apply is an error (the --to-on-serialize rule).
     try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "textile", "--wikilinks" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "cooklang", "--smartypants" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "textile", "--heading-ids" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "serialize", "--from", "cooklang", "--callouts" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "2", "--footnotes" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "menu", "--from", "cooklang", "--wikilinks" }));
@@ -617,6 +628,15 @@ test "cli: the legacy markdown extensions render end to end" {
     defer allocator.free(fn_out);
     try testing.expect(std.mem.indexOf(u8, fn_out, "class=\"footnote-ref\"") != null);
     try testing.expect(std.mem.indexOf(u8, fn_out, "<section class=\"footnotes\"") != null);
+}
+
+test "cli: --heading-ids renders GFM-style heading ids end to end" {
+    const allocator = std.testing.allocator;
+    const hi = try parseArgs(&.{ "render", "--from", "markdown", "--heading-ids" });
+    const hi_out = try renderWith(allocator, hi, "# Head\n\n## A \"quoted\" -- heading!\n");
+    defer allocator.free(hi_out);
+    try testing.expect(std.mem.indexOf(u8, hi_out, "<h1 id=\"head\">Head</h1>") != null);
+    try testing.expect(std.mem.indexOf(u8, hi_out, "<h2 id=\"a-quoted----heading\">") != null);
 }
 
 test "cli: --frontmatter reaches the cooklang render path" {


### PR DESCRIPTION
## What

Expose the last unexposed Markdown extension: the render-only `heading_ids` option (`html.RenderOptions`, GFM-style auto heading ids) as a `--heading-ids` CLI flag. Follow-up to #74, which scoped it out as a trivial remainder.

## Changes

- **`--heading-ids`** — `render --from markdown` only, scoped with the other extension flags (rejected on textile/cooklang render and on serialize/scale/menu).
- Threaded through `renderOptionsFor` → `html.RenderOptions.heading_ids`.
- Usage text updated.

## Tests

- Scoping battery extended: `--heading-ids` accepted on render+markdown, rejected on textile render.
- New end-to-end test pinning the slug behavior: `# Head` → `<h1 id="head">Head</h1>`, and `## A "quoted" -- heading!` → `id="a-quoted----heading"` (non-word bytes dropped, whitespace collapsed, `--` preserved).

## Verification

- `zig build test` — 366/366 (12/12 steps; CLI 16 → 17)
- CommonMark `--gate` — 652/652, 0 regressions
- Cooklang — 60/60

## Docs

README CLI example + count, CAPABILITIES flag list, MARKDOWN-EXTENSIONS options line, TESTS.md §1.4 + counts, WORK-LEDGER E4 (marked merged). Count lines refreshed to 366/366.
