### PR TITLE
fix(cooklang): align the scale-factor grammar and its u32 boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ zig build spec-conformance -- spec.txt
 | **Total** | **652/652** |
 
 ```bash
-zig build test    # run all tests (366 tests)
+zig build test    # run all tests (369 tests)
 zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```
@@ -310,6 +310,7 @@ oliver render --from markdown --heading-ids < document.md  # GFM-style auto ids 
 oliver render --from markdown --frontmatter yaml < document.md  # --frontmatter works on any frontend
 oliver serialize --from cooklang < recipe.cook   # canonical .cook
 oliver scale --from cooklang --factor 2 < recipe.cook   # scaled .cook
+oliver scale --from cooklang --factor 1.5 < recipe.cook # decimals and mixed work too
 oliver scale --from cooklang --servings 4 < recipe.cook  # via servings
 oliver menu --from cooklang < plan.menu                 # day/meal text dump
 oliver --version   # prints version + embedded source commit (CI builds)

--- a/docs/CLEANROOM.md
+++ b/docs/CLEANROOM.md
@@ -659,3 +659,19 @@ rewrite from an overflow passthrough (product beyond 128-bit,
 fractional part beyond u64, or mixed `whole × den` beyond u64)
 without a pointer comparison (issue #81). No parser implementation
 source was consulted.
+
+Session 30 (S1 scale-factor grammar alignment) provenance record: no
+new upstream specification — the fixes below align the CK6 string
+surface with the CLI and the recipe API (issues #85–#86). (1) The CLI
+`--factor` flag now routes through `oliver.cooklang_scale.parseFactor`
+(the documented string surface) instead of a parallel `num[/den]` u32
+split parser, so decimals, mixed numbers, and spaces around the slash
+work exactly as the library accepts them, and leading zeros,
+multi-slash shapes, and words are rejected exactly as the library
+rejects them. (2) `parseFactor` now caps both parts at u32 — the same
+cap as `ScaleBy.factor` (`cooklang.Fraction`) and the model's quantity
+fractions — so every parsed factor can reach `scaleRecipe`;
+`scaleAmount` remains u64 arithmetic and accepts wider factors when
+constructed directly. (3) `--factor`/`--servings` gain the duplicate
+rejection every other value flag has. No parser implementation source
+was consulted.

--- a/docs/COOKLANG.md
+++ b/docs/COOKLANG.md
@@ -398,8 +398,10 @@ Contract, verified by tests:
   text rather than a typed `Recipe`:
   `oliver.cooklang.classifyQuantity(amount)` → `empty` | `scalable` |
   `fixed`; `oliver.cooklang_scale.parseFactor(text)` → an exact
-  rational (`error.InvalidScaleFactor` for 0, a 0-denominator, or a
-  non-scalable form); `oliver.cooklang_scale.scaleAmount(allocator,
+  rational (`error.InvalidScaleFactor` for 0, a 0-denominator, a
+  non-scalable form, or a numerator/denominator above u32 — the cap
+  that matches `ScaleBy.factor`, so every parsed factor reaches
+  `scaleRecipe`); `oliver.cooklang_scale.scaleAmount(allocator,
   amount, factor)` → `{ class, original, scaled }`. The same three
   names are re-exported from `cooklang_scale`.
 - **`scaleRecipe`**, the whole-recipe operation:
@@ -446,7 +448,10 @@ not. A leading `=` is `fixed` even if the rest would parse (`=1`,
   — overflow (or a fractional part / mixed `whole × den` beyond u64)
   keeps `scaled` aliasing `original` with `changed == false`, never a
   wrong number.
-- `parseFactor` accepts the same scalable forms as amounts.
+- `parseFactor` accepts the same scalable forms as amounts, capped at
+  u32 on both parts to match `ScaleBy.factor` (`cooklang.Fraction`);
+  `scaleAmount` is u64 arithmetic and accepts wider factors when
+  constructed directly.
 
 What scales on a `Recipe`, what does not (per the conventions):
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -178,23 +178,25 @@ fifth — the XHTML profile suite — is described in its own section below):
    complete/nonoverlapping manifest validation, malformed divergence-record
    rejection, outcome classification, and the single-trailing-newline
    comparison. These tests need no downloaded corpus.
-4. **CLI argument-parsing tests** — 17 tests in `src/main.zig`: pure
+4. **CLI argument-parsing tests** — 19 tests in `src/main.zig`: pure
    `parseArgs` unit tests (no allocator, no I/O) pinning the subcommand
    grammar (exactly one of `render`/`serialize`/`scale`/`menu`), flag
    scoping (`--to` render-only; `--factor`/`--servings` scale-only; the
    Markdown extension flags `--wikilinks`/`--callouts`/`--smartypants`/
    `--footnotes`/`--definition-lists`/`--heading-attributes`/
    `--strikethrough`/`--heading-ids` render+Markdown-only,
-   `--frontmatter yaml|toml` on any render frontend), dialect
-   validation, zero-factor/zero-servings rejection, and
-   `--help`/`-h` handling — plus end-to-end render
-   tests that run each extension through the shared render path
-   (`renderWith`, the same path `main` uses). They run as part of the
-   ordinary `zig build test` gate.
+   `--frontmatter yaml|toml` on any render frontend), the `--factor`
+   grammar (routed through `parseFactor` — decimals, mixed numbers,
+   spaces around the slash accepted; leading zeros, over-u32 values
+   rejected), duplicate value-flag rejection, dialect validation,
+   zero-factor/zero-servings rejection, and `--help`/`-h` handling —
+   plus end-to-end render and scale tests that run through the shared
+   paths (`renderWith` / `scaleWith`, the same paths `main` uses).
+   They run as part of the ordinary `zig build test` gate.
 
-The current complete result is **366/366 tests passing** with Zig 0.16.0
-(307 library module tests + 18 fixture/adversarial tests + 7
-conformance-harness tests + 17 CLI argument-parsing tests + 17 XHTML
+The current complete result is **369/369 tests passing** with Zig 0.16.0
+(308 library module tests + 18 fixture/adversarial tests + 7
+conformance-harness tests + 19 CLI argument-parsing tests + 17 XHTML
 profile tests). On top of the unit gate: the CommonMark
 0.31.2 corpus stays **652/652** with 0 mismatches (docs/README), the
 Textile wall stays fully green, and the Cooklang canonical corpus passes

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1179,7 +1179,7 @@ against `oliver render --from textile` during this wrap-up.
 | `notextile.` raw block | 2 | implemented (T25) | §23 |
 | inline composition (mixed families) | 1 | implemented (T4) | §3 |
 
-**105 fixture pairs, 366/366 tests, 652/652 CommonMark.** The
+**105 fixture pairs, 369/369 tests, 652/652 CommonMark.** The
 convergence pairs in `tests/fixtures_test.zig` additionally prove the
 shared renderer is byte-identical across dialects (Textile `*x*` ↔
 Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`, `!img.png!` ↔

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -50,6 +50,7 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 | Markdown extension worker | E2 callouts/admonitions | `Options.callouts` recognition on the container-block quote path; `.block_quote` callout payload (`type`/`title`/`title_nodes`) + `<div class="callout callout-<type>">` render arm (docs/CALLOUTS.md); Markdown fixtures; corpus untouched | after E1 (v0.6) | implemented on main (issue #65) |
 | shared worker | E3 smart typography | extract Textile's `replaceChars`/`hasCharMacroTrigger` machinery into one shared module (`src/typography.zig`; two callers, Textile byte-identical); `Options.smartypants` text pass with the Textile exemption set (docs/SMARTY.md); Markdown fixtures | after F1/E1 (v1.0) | implemented on main (issue #67) |
 | shared worker | E4 CLI extension surface | `oliver render --from markdown` exposes the full extension surface as flags (`--wikilinks`, `--callouts`, `--smartypants`, `--footnotes`, `--definition-lists`, `--heading-attributes`, `--strikethrough`, `--heading-ids` — scoped to render + Markdown) plus `--frontmatter yaml|toml` on any render frontend (threaded into the shared `markdownParseOptions` / `cooklangParseOptions` / `renderOptionsFor` seams; `renderWith` is the one render path shared by `main` and the tests); 6 new CLI tests (flag scoping, frontmatter validation, one end-to-end render per extension incl. the legacy four, heading ids, and cooklang frontmatter); usage text + README + TESTS + CAPABILITIES + MARKDOWN-EXTENSIONS | after the extension wave (issue #74) | merged (PR #83) |
+| shared worker | S1 scale-factor grammar alignment | review findings #85–#86: `oliver scale --factor` routes through the library's `parseFactor` (decimals, mixed `1 1/2`, spaces around the slash accepted; leading zeros, `1/2/3`, `some`, over-u32 values rejected) instead of a parallel u32 split parser; `parseFactor` caps at u32 to match `ScaleBy.factor` while `scaleAmount` keeps its u64 path; `--factor`/`--servings` gain duplicate rejection; `scaleWith` is the shared scale path; 3 new tests (parseFactor u32 boundary; factor grammar battery; scale end-to-end); docs/COOKLANG.md §11 + README + TESTS | after #74 and CK7 | this PR |
 | Cooklang worker | CK6 string-quantity classify/scale + mixed numbers | public `classifyQuantity` / `parseFactor` / `scaleAmount` over authored amount strings (the exact-rational path, not `parseQuantity`'s f64 decimal arm); `scaleRecipe` becomes a caller of `scaleAmount` on ingredient quantities only; mixed `1 1/2` is a canonical scalable input (emits integer / fraction / terminating decimal); timers/cookware/refs still never scale; `scale-mixed` fixture; docs/COOKLANG.md §11 | after CK3 (issue #76; lets consumers delete a forked string scale) | merged (PR #77) |
 | Cooklang worker | CK7 scale edge-case hardening | review findings on the merged CK6 surface (issues #79–#81): `parseMixedNumber` trims leading/trailing ASCII space/tab (issue #79); `familyOfAmount` reads the decimal family from the source form exactly — no f64/i64 probe, terminating decimals at any magnitude (issue #80); `ScaledAmount.changed` distinguishes a rewrite from an overflow passthrough (issue #81); 3 unit tests pin the whitespace battery, the >i64 terminating cases, and the changed/passthrough triggers; docs/COOKLANG.md §11 + FEATURE-MATRIX + ARCHITECTURE + CLEANROOM session 29 | after CK6 | this PR |
 
@@ -1443,6 +1444,35 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 - **Parallelism:** yes; parser and renderer untouched.
 - **Integration:** after the extension wave; gates re-verified.
 - **State:** this PR (issue #74).
+
+## S1 — Scale-factor grammar alignment (issues #85–#86)
+
+- **Objective:** close the two review findings on the merged CLI +
+  Cooklang surface: the CLI's `--factor` used a parallel u32 split
+  parser instead of the library's public `parseFactor`, and the string
+  surface was u64 while the recipe-level factor mode was u32.
+- **Normative sources:** docs/COOKLANG.md §11 (the CK6 string surface);
+  no new markup semantics.
+- **Dependencies:** CK6/CK7 string surface; the #74 CLI work.
+- **Seams:** `src/cooklang_scale.zig` (`parseFactor` now rejects a
+  numerator or denominator above u32 — the cap that matches
+  `ScaleBy.factor` — so every parsed factor reaches `scaleRecipe`);
+  `src/main.zig` (`--factor` routes through `parseFactor`, mapping
+  `InvalidScaleFactor` to a usage error; `--factor`/`--servings` gain
+  the duplicate rejection every other value flag has; `scaleWith` is
+  the shared scale path used by `main` and the tests).
+- **Acceptance:** `--factor 1.5`, `--factor "1 1/2"`, `--factor
+  "1 / 2"` scale correctly; `--factor 01/2`, `1/2/3`, `some`, and
+  values above u32 are usage errors; `--factor 2 --factor 3` and
+  `--servings 2 --servings 4` are usage errors; `parseFactor` caps at
+  u32 while `scaleAmount` keeps its u64 path.
+- **Tests:** 1 library test (parseFactor u32 boundary + scaleAmount's
+  wider direct path) and 2 CLI tests (factor grammar battery +
+  duplicates; scale end-to-end through `scaleWith`). 369/369, 652/652,
+  60/60 re-verified.
+- **Parallelism:** yes; parsers and renderers untouched.
+- **Integration:** after #74 and CK7; gates re-verified.
+- **State:** this PR (issues #85–#86).
 
 ## Deferred architectural cards
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The documentation is written for two audiences:
 | CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
 | Cooklang canonical corpus | **60/60** |
 | Textile fixture wall | fully green |
-| Test suite | **366/366** |
+| Test suite | **369/369** |
 
 Both conformance gates run in CI on every push/PR
 (`zig build spec-conformance -- spec.txt --gate` and

--- a/src/cooklang_scale.zig
+++ b/src/cooklang_scale.zig
@@ -55,14 +55,20 @@ pub const ScaleError = error{ OutOfMemory, InvalidScaleFactor };
 /// serving count (the current count is read from the recipe's
 /// frontmatter per the conventions; `num`, `den`, and the target must
 /// be non-zero — a zero numerator or denominator is
-/// `error.InvalidScaleFactor`).
+/// `error.InvalidScaleFactor`). The factor's `num`/`den` are
+/// `cooklang.Fraction` (u32) — the same cap as the model's quantity
+/// fractions — so `parseFactor` rejects larger values rather than
+/// returning a factor that cannot reach `scaleRecipe`.
 pub const ScaleBy = union(enum) {
     factor: cooklang.Fraction,
     servings: u32,
 };
 
 /// An exact rational scale factor (`num/den`). Zero numerator or
-/// denominator is invalid (`error.InvalidScaleFactor`).
+/// denominator is invalid (`error.InvalidScaleFactor`). This is the
+/// string surface's type (u64 arithmetic); `parseFactor` additionally
+/// caps results at u32 so they fit `ScaleBy.factor` — see
+/// `scaleAmount` for the wider direct-construction path.
 pub const ScaleFactor = struct {
     num: u64,
     den: u64,
@@ -90,13 +96,21 @@ pub const QuantityClass = cooklang.QuantityClass;
 
 /// Parses a scale factor as an exact rational. Accepts the same
 /// canonical scalable forms as amounts (integer, `a/b`, decimal,
-/// mixed). Zero, a zero denominator, and anything that is not a
-/// scalable form are `error.InvalidScaleFactor`.
+/// mixed). Zero, a zero denominator, anything that is not a scalable
+/// form, and any value whose numerator or denominator exceeds u32 are
+/// `error.InvalidScaleFactor` — the u32 cap matches `ScaleBy.factor`
+/// (`cooklang.Fraction`), so every parsed factor can reach
+/// `scaleRecipe` (docs/COOKLANG.md §11).
 pub fn parseFactor(text: []const u8) ScaleError!ScaleFactor {
     const t = std.mem.trim(u8, text, " \t");
     const r = rationalOf(t) orelse return error.InvalidScaleFactor;
     if (r.num == 0) return error.InvalidScaleFactor;
-    if (r.num > std.math.maxInt(u64) or r.den > std.math.maxInt(u64)) return error.InvalidScaleFactor;
+    // The recipe-level factor mode (and the model's quantity fractions)
+    // are u32-capped; reject larger values here so the string surface
+    // is consistent with `ScaleBy.factor` (issue #86). `scaleAmount` is
+    // u64 arithmetic and still accepts wider factors when constructed
+    // directly.
+    if (r.num > std.math.maxInt(u32) or r.den > std.math.maxInt(u32)) return error.InvalidScaleFactor;
     return .{ .num = @intCast(r.num), .den = @intCast(r.den) };
 }
 
@@ -517,6 +531,25 @@ test "cooklang scale: sections recurse, notes and text untouched" {
     const out = try scaleT(std.testing.allocator, input, .{ .factor = .{ .num = 2, .den = 1 } });
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("= Dough\n\nMix @flour{400%g}.\n\n> Keep the @salt nearby.\n\n= Filling\n\nCombine @cheese{200%g}(grated).\n", out);
+}
+
+test "cooklang scale: parseFactor is u32-capped to match ScaleBy.factor" {
+    // The recipe-level factor mode is u32-capped (cooklang.Fraction), so
+    // the string surface rejects larger values rather than returning a
+    // factor that cannot reach scaleRecipe (issue #86).
+    try std.testing.expectError(error.InvalidScaleFactor, parseFactor("4294967296")); // u32 max + 1
+    try std.testing.expectError(error.InvalidScaleFactor, parseFactor("1/4294967296")); // denominator over u32
+    const max = try parseFactor("4294967295"); // u32 max is accepted
+    try std.testing.expectEqual(@as(u64, 4294967295), max.num);
+    try std.testing.expectEqual(@as(u64, 1), max.den);
+    const max_den = try parseFactor("1/4294967295");
+    try std.testing.expectEqual(@as(u64, 1), max_den.num);
+    try std.testing.expectEqual(@as(u64, 4294967295), max_den.den);
+    // scaleAmount is u64 arithmetic and still accepts wider factors when
+    // constructed directly (not through parseFactor).
+    var wide = try scaleAmount(std.testing.allocator, "1", .{ .num = 5000000000, .den = 1 });
+    defer wide.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("5000000000", wide.scaled);
 }
 
 test "cooklang scale: invalid factors are rejected, not guessed" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,6 +87,8 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     var saw_to = false;
     var saw_from = false;
     var saw_frontmatter = false;
+    var saw_factor = false;
+    var saw_servings = false;
 
     var index: usize = 0;
     while (index < args.len) : (index += 1) {
@@ -132,23 +134,28 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         } else if (std.mem.eql(u8, arg, "--factor")) {
             if (index + 1 >= args.len) return error.Usage;
             index += 1;
+            // A second `--factor` would contradict the first; reject
+            // duplicates like `--from`/`--to`/`--frontmatter`.
+            if (saw_factor) return error.Usage;
+            saw_factor = true;
             const value = args[index];
-            var parts = std.mem.splitScalar(u8, value, '/');
-            const num = parts.next() orelse return error.Usage;
-            factor_num = std.fmt.parseUnsigned(u32, num, 10) catch return error.Usage;
-            // A zero numerator scales everything to nothing and a zero
-            // denominator is division by zero; both are degenerate, so
-            // both are rejected here (symmetric with `--servings 0`; the
-            // library rejects them too, docs/COOKLANG.md §11).
-            if (factor_num.? == 0) return error.Usage;
-            if (parts.next()) |den| {
-                factor_den = std.fmt.parseUnsigned(u32, den, 10) catch return error.Usage;
-                if (factor_den.? == 0) return error.Usage;
-            }
-            if (parts.next() != null) return error.Usage;
+            // The library's parseFactor owns the grammar: the same
+            // scalable forms as amounts (integer, a/b, decimal, mixed
+            // `1 1/2`; spaces around the slash accepted) and the u32 cap
+            // that matches ScaleBy.factor. Zero numerators and zero
+            // denominators are rejected by parseFactor itself
+            // (docs/COOKLANG.md §11); InvalidScaleFactor maps to a usage
+            // error.
+            const f = oliver.cooklang_scale.parseFactor(value) catch return error.Usage;
+            factor_num = @intCast(f.num);
+            factor_den = @intCast(f.den);
         } else if (std.mem.eql(u8, arg, "--servings")) {
             if (index + 1 >= args.len) return error.Usage;
             index += 1;
+            // Duplicate servings contradict each other; reject them like
+            // every other value flag.
+            if (saw_servings) return error.Usage;
+            saw_servings = true;
             const value = args[index];
             servings_target = std.fmt.parseUnsigned(u32, value, 10) catch return error.Usage;
             if (servings_target.? == 0) return error.Usage;
@@ -294,19 +301,12 @@ pub fn main(init: std.process.Init) !u8 {
                 };
             },
             .scale => {
-                const by: oliver.cooklang_scale.ScaleBy = if (cfg.factor_num) |n|
-                    .{ .factor = .{ .num = n, .den = cfg.factor_den orelse 1 } }
-                else
-                    .{ .servings = cfg.servings_target.? };
-                var scaled = oliver.cooklang_scale.scaleRecipe(gpa, &result.recipe, by) catch |err| {
+                const scaled = scaleWith(gpa, input.items, cfg) catch |err| {
                     std.debug.print("oliver: scale failed: {s}\n", .{@errorName(err)});
                     return 1;
                 };
-                defer scaled.deinit();
-                oliver.cooklang_serialize.serialize(gpa, &out_writer.interface, &scaled, .{}) catch |err| {
-                    std.debug.print("oliver: serialize failed: {s}\n", .{@errorName(err)});
-                    return 1;
-                };
+                defer gpa.free(scaled);
+                out_writer.interface.writeAll(scaled) catch {};
             },
             .menu => {
                 var m = oliver.cooklang_menu.menuView(gpa, &result.recipe) catch |err| {
@@ -399,11 +399,31 @@ fn renderWith(a: std.mem.Allocator, cfg: RunConfig, input: []const u8) ![]u8 {
     return out.toOwnedSlice(a);
 }
 
+/// Scales a Cooklang recipe with the `--factor` / `--servings` mode from
+/// `cfg` (scoped to the scale command by `parseArgs`) and serializes the
+/// result. Returns the owned canonical `.cook` bytes; the caller frees
+/// with the same allocator.
+fn scaleWith(a: std.mem.Allocator, input: []const u8, cfg: RunConfig) ![]u8 {
+    var result = try oliver.cooklang.parse(a, input, cooklangParseOptions(cfg));
+    defer result.deinit();
+    const by: oliver.cooklang_scale.ScaleBy = if (cfg.factor_num) |n|
+        .{ .factor = .{ .num = n, .den = cfg.factor_den orelse 1 } }
+    else
+        .{ .servings = cfg.servings_target.? };
+    var scaled = try oliver.cooklang_scale.scaleRecipe(a, &result.recipe, by);
+    defer scaled.deinit();
+    var aw = std.Io.Writer.Allocating.init(a);
+    defer aw.deinit();
+    try oliver.cooklang_serialize.serialize(a, &aw.writer, &scaled, .{});
+    var out = aw.toArrayList();
+    return out.toOwnedSlice(a);
+}
+
 fn printUsage() void {
     std.debug.print(
         \\usage: oliver render --from <markdown|textile|cooklang> [--to <html|xhtml>]
         \\       oliver serialize --from cooklang
-        \\       oliver scale --from cooklang (--factor <num[/den]> | --servings <n>)
+        \\       oliver scale --from cooklang (--factor <scalable> | --servings <n>)
         \\       oliver menu --from cooklang
         \\       oliver --version
         \\
@@ -411,6 +431,8 @@ fn printUsage() void {
         \\(XHTML fragment with --to xhtml). serialize/scale write canonical
         \\Cooklang text; menu writes the day/meal text dump. --version prints
         \\the version and the embedded source commit (CI builds).
+        \\scale --factor accepts the same scalable quantity forms as amounts
+        \\(2, 1/2, 1.5, 1 1/2; quote values containing spaces).
         \\
         \\Markdown extensions (render --from markdown, all off by default):
         \\  --wikilinks  --callouts  --smartypants  --footnotes
@@ -527,6 +549,45 @@ test "cli: zero scale factors are rejected, not passed to the library" {
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "0" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "0/2" }));
     try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "2/0" }));
+}
+
+test "cli: --factor parses the full scalable grammar through parseFactor" {
+    // The library's parseFactor owns the grammar, so the CLI accepts the
+    // same scalable forms as amounts (issue #85) and rejects the same
+    // non-canonical shapes, including leading zeros.
+    const decimal = try parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1.5" });
+    try testing.expectEqual(@as(u32, 3), decimal.factor_num.?);
+    try testing.expectEqual(@as(u32, 2), decimal.factor_den.?);
+    const mixed = try parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1 1/2" });
+    try testing.expectEqual(@as(u32, 3), mixed.factor_num.?);
+    try testing.expectEqual(@as(u32, 2), mixed.factor_den.?);
+    const spaced = try parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1 / 2" });
+    try testing.expectEqual(@as(u32, 1), spaced.factor_num.?);
+    try testing.expectEqual(@as(u32, 2), spaced.factor_den.?);
+
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "01/2" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1/2/3" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "some" }));
+    // Above the u32 cap that matches ScaleBy.factor (issue #86).
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "4294967296" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1/4294967296" }));
+
+    // Duplicate value flags contradict each other (the --from rule).
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "2", "--factor", "3" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "scale", "--from", "cooklang", "--servings", "2", "--servings", "4" }));
+}
+
+test "cli: --factor grammar reaches the scale path end to end" {
+    const allocator = std.testing.allocator;
+    const decimal = try parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1.5" });
+    const out = try scaleWith(allocator, "Add @x{2}.\n", decimal);
+    defer allocator.free(out);
+    try testing.expectEqualStrings("Add @x{3}.\n", out);
+
+    const mixed = try parseArgs(&.{ "scale", "--from", "cooklang", "--factor", "1 1/2" });
+    const out2 = try scaleWith(allocator, "Add @flour{2%cup}.\n", mixed);
+    defer allocator.free(out2);
+    try testing.expectEqualStrings("Add @flour{3%cup}.\n", out2);
 }
 
 test "cli: markdown extension flags are scoped to render --from markdown" {


### PR DESCRIPTION
## What

Close the two review findings on the merged CLI + Cooklang surface: the CLI's `--factor` used a parallel u32 split parser instead of the library's public `parseFactor`, and the string surface was u64 while the recipe-level factor mode was u32.

## Changes

- **#86 — the u32/u64 seam** (`src/cooklang_scale.zig`): `parseFactor` now rejects a numerator or denominator above u32 (`error.InvalidScaleFactor`) — the cap that matches `ScaleBy.factor` (`cooklang.Fraction`) — so every parsed factor can reach `scaleRecipe`. `scaleAmount` keeps its u64 arithmetic path (wider directly-constructed factors still work; pinned). Docs updated on `parseFactor`, `ScaleBy`, and §11.
- **#85 — the CLI grammar** (`src/main.zig`): `oliver scale --factor` routes through `oliver.cooklang_scale.parseFactor` (mapping `InvalidScaleFactor` to a usage error), so decimals, mixed numbers, and spaces around the slash work exactly as the library accepts them, and leading zeros / multi-slash shapes / words are rejected exactly as the library rejects them. `--factor`/`--servings` also gain the duplicate rejection every other value flag has, and `scaleWith` is now the shared scale path used by `main` and the tests (mirroring `renderWith`). Usage text updated.

## Verification (through the binary)

- `--factor 1.5` → scales by 3/2 · `--factor "1 1/2"` → 3/2 · `--factor "1 / 2"` → 1/2
- `--factor 01/2`, `1/2/3`, `some`, `4294967296` → usage error
- `--factor 2 --factor 3` / `--servings 2 --servings 4` → usage error (duplicates)

## Tests

3 new: the `parseFactor` u32 boundary (u32 max accepted on both parts; just above rejected; `scaleAmount`'s wider direct path still works), the factor-grammar battery with duplicates, and a scale end-to-end through `scaleWith` (`--factor 1.5` → `{3}`, `--factor "1 1/2"` → `{3%cup}`).

## Verification

- `zig build test` — 369/369 (12/12 steps; library 307 → 308, CLI 17 → 19)
- CommonMark `--gate` — 652/652, 0 regressions
- Cooklang — 60/60

## Docs

COOKLANG.md §11 (`parseFactor` bullets), README (`--factor 1.5` example + count), TESTS.md §1.4 + counts, WORK-LEDGER S1 card + traffic row, CLEANROOM session 30, and the count lines (369/369).

Closes #85. Closes #86.
