### PR TITLE
test(fuzz): deterministic multi-dialect fuzz wall over the parse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ zig build spec-conformance -- spec.txt
 | **Total** | **652/652** |
 
 ```bash
-zig build test    # run all tests (375 tests)
+zig build test    # run all tests (376 tests)
 zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```

--- a/build.zig
+++ b/build.zig
@@ -151,12 +151,30 @@ pub fn build(b: *std.Build) void {
     });
     const run_xhtml_tests = b.addRunArtifact(xhtml_tests);
 
+    // Deterministic mutation-fuzz tests (tests/fuzz.zig) over the public
+    // parse API: a fixed-seed PRNG mutates a seed corpus across all three
+    // dialects with the extension surface on, asserting the adversarial
+    // contracts (no crash, no leak, deterministic output; docs/TESTS.md).
+    // Runs in the ordinary test gate with a fixed iteration budget.
+    const fuzz_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/fuzz.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "oliver", .module = oliver_mod },
+            },
+        }),
+    });
+    const run_fuzz_tests = b.addRunArtifact(fuzz_tests);
+
     const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_lib_tests.step);
     test_step.dependOn(&run_fixture_tests.step);
     test_step.dependOn(&run_spec_tool_tests.step);
     test_step.dependOn(&run_cli_tests.step);
     test_step.dependOn(&run_xhtml_tests.step);
+    test_step.dependOn(&run_fuzz_tests.step);
 }
 
 /// The package version from build.zig.zon (single source of truth). Zig

--- a/docs/CLEANROOM.md
+++ b/docs/CLEANROOM.md
@@ -698,3 +698,11 @@ byte-exact; `escaped` reuses the renderer's existing HTML-escaping;
 (`RawHtmlNotXmlWellFormed`) with a sibling error. The uniform scope
 (Markdown `.raw_html`/`.html_block` and Textile `pre.`) is pinned in
 docs/RAW-HTML.md §3. No parser implementation source was consulted.
+
+Session 33 (F2 mutation-fuzz wall) provenance record: no upstream
+specification — the harness is Oliver-authored test tooling over the
+project's own adversarial contracts (completion without crash, leak,
+unbounded recursion, or output nondeterminism; docs/TESTS.md). The seed
+corpus is the project's own representative inputs, and the mutation
+engine is a plain seeded PRNG over byte edits. No parser implementation
+source was consulted.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -194,10 +194,10 @@ fifth — the XHTML profile suite — is described in its own section below):
    paths (`renderWith` / `scaleWith`, the same paths `main` uses).
    They run as part of the ordinary `zig build test` gate.
 
-The current complete result is **375/375 tests passing** with Zig 0.16.0
+The current complete result is **376/376 tests passing** with Zig 0.16.0
 (309 library module tests + 18 fixture/adversarial tests + 7
 conformance-harness tests + 22 CLI argument-parsing tests + 19 XHTML
-profile tests). On top of the unit gate: the CommonMark
+profile tests + 1 fuzz wall). On top of the unit gate: the CommonMark
 0.31.2 corpus stays **652/652** with 0 mismatches (docs/README), the
 Textile wall stays fully green, and the Cooklang canonical corpus passes
 **60/60** via `zig build cooklang-conformance` (bare: the vendored
@@ -307,8 +307,14 @@ under `std.testing.allocator`:
   block, each rendered twice.
 
 The contract is completion without crash, leak, unbounded recursion, or output
-nondeterminism. A dedicated fuzz target remains planned; the public
-`parse(allocator, bytes, dialect, options)` API is already the fuzz entry point.
+nondeterminism. A dedicated mutation-fuzz wall (`tests/fuzz.zig`, issue #94)
+runs in the ordinary gate: a fixed-seed PRNG mutates a comptime seed corpus
+(representative inputs per dialect) into 1,000 derived inputs, each parsed
+across **all three dialects** with the extension surface on and the front
+matter modes, rendered/serialized twice for determinism, and (for Cooklang)
+scaled — the public `parse(allocator, bytes, dialect, options)` API is the
+fuzz entry point. A failure prints the iteration, the dialect, and the
+failing bytes (raw and hex) for minimization.
 
 ## CommonMark 0.31.2 scorecard
 

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1179,7 +1179,7 @@ against `oliver render --from textile` during this wrap-up.
 | `notextile.` raw block | 2 | implemented (T25) | §23 |
 | inline composition (mixed families) | 1 | implemented (T4) | §3 |
 
-**105 fixture pairs, 375/375 tests, 652/652 CommonMark.** The
+**105 fixture pairs, 376/376 tests, 652/652 CommonMark.** The
 convergence pairs in `tests/fixtures_test.zig` additionally prove the
 shared renderer is byte-identical across dialects (Textile `*x*` ↔
 Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`, `!img.png!` ↔

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -55,6 +55,7 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 | Cooklang worker | CK7 scale edge-case hardening | review findings on the merged CK6 surface (issues #79–#81): `parseMixedNumber` trims leading/trailing ASCII space/tab (issue #79); `familyOfAmount` reads the decimal family from the source form exactly — no f64/i64 probe, terminating decimals at any magnitude (issue #80); `ScaledAmount.changed` distinguishes a rewrite from an overflow passthrough (issue #81); 3 unit tests pin the whitespace battery, the >i64 terminating cases, and the changed/passthrough triggers; docs/COOKLANG.md §11 + FEATURE-MATRIX + ARCHITECTURE + CLEANROOM session 29 | after CK6 | merged (PR #82) |
 | Markdown extension worker | E5 GFM task lists | `Options.task_lists` checkbox recognition at a list item's content start (a `.task_checkbox` leaf; `[ ]`/`[x]`/`[X]` + trailing whitespace; strict shape — the item's first block at the content's first bytes, else literal); disabled `<input type="checkbox">` rendering with valueless `disabled`/`checked` and the render profile's void form (xml-form under `.xhtml`; the profiles agree byte-for-byte); the label scans normally after the checkbox; `--task-lists` CLI flag; docs/TASK-LISTS.md + fixture pair + xhtml hermetic pin + CLI end-to-end test | after the extension wave (issue #92, v1.1) | this PR |
 | shared worker | E6 raw-HTML policy | `html.RenderOptions.raw_html` — the ARCHITECTURE "allowed / escaped / rejected" knob, now implemented: `allowed` (verbatim, the default; XHTML still fails closed), `escaped` (HTML-escapes the bytes — well-formed under both profiles, closing the `pre.` XHTML gap), `rejected` (`error.RawHtmlRejected`, fail closed even in HTML mode); applies uniformly to `.raw_html` inline, `.html_block` (Markdown §4.6 + Textile `==`/`notextile.`), and Textile `pre.` verbatim; `--raw-html allowed|escaped|rejected` CLI flag (render-only, duplicate-rejected); docs/RAW-HTML.md §3 + unit tests + xhtml hermetic pin + CLI battery | after the extension wave (issue #93, v1.1) | this PR |
+| shared worker | F2 deterministic mutation-fuzz wall | `tests/fuzz.zig` — the "dedicated fuzz target" docs/TESTS.md recorded as planned: a fixed-seed PRNG mutates a comptime seed corpus (representative inputs per dialect) into 1,000 derived inputs, each parsed across all three dialects with the extension surface on and the front matter modes, rendered/serialized twice for determinism, and (for Cooklang) scaled — asserting no crash, no leak (test allocator), and byte-deterministic output; failures print the iteration, dialect, and bytes for minimization; wired into `zig build test` as its own step (~5s in Debug) | after the extension wave (issue #94, v1.1) | this PR |
 
 ## M1 — Thematic-break / Setext precedence rung
 
@@ -1539,6 +1540,36 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
   arm is exercised but its default behavior is unchanged).
 - **Integration:** after the extension wave; gates re-verified.
 - **State:** this PR (issue #93).
+
+## F2 — Deterministic mutation-fuzz wall (issue #94)
+
+- **Objective:** deliver the "dedicated fuzz target" that docs/TESTS.md
+  has recorded as planned since the adversarial suite landed: a
+  mutation-based fuzz wall over the public
+  `parse(allocator, bytes, dialect, options)` API, wired into the
+  ordinary test gate with a bounded budget.
+- **Normative source:** none — the harness is Oliver-authored test
+  tooling over the project's own adversarial contracts (provenance
+  docs/CLEANROOM.md session 33).
+- **Contract:** tests/fuzz.zig — a fixed-seed PRNG mutates a comptime
+  seed corpus (one representative input per dialect family) with 1–8
+  random edits biased toward parser-relevant bytes, capped at 4 KiB;
+  every derived input is parsed across **all three dialects** with the
+  full extension surface on and the front matter modes, rendered twice
+  for determinism, and (for Cooklang) serialized twice and scaled —
+  asserting completion without crash, leak (the test allocator fails on
+  leaks), or output nondeterminism. The fixed seed makes the run
+  reproducible; a failure prints the iteration, the violation, and the
+  input raw + hex for minimization.
+- **Design:** one `mutate` engine, one `exercise` body per dialect; the
+  step runs in ~5s under the Debug gate (1,000 iterations), sized to
+  the repo's hermetic ethos — deterministic, no filesystem, no
+  external fuzzer.
+- **Tests:** the fuzz wall itself (1 test). 376/376, 652/652, 60/60
+  re-verified.
+- **Parallelism:** yes; no parser or renderer files touched.
+- **Integration:** after the extension wave; gates re-verified.
+- **State:** this PR (issue #94).
 
 ## Deferred architectural cards
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The documentation is written for two audiences:
 | CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
 | Cooklang canonical corpus | **60/60** |
 | Textile fixture wall | fully green |
-| Test suite | **375/375** |
+| Test suite | **376/376** |
 
 Both conformance gates run in CI on every push/PR
 (`zig build spec-conformance -- spec.txt --gate` and

--- a/tests/fuzz.zig
+++ b/tests/fuzz.zig
@@ -1,0 +1,315 @@
+//! Deterministic mutation-fuzz tests over the public parse API.
+//!
+//! A fixed-seed PRNG mutates a comptime seed corpus (one representative
+//! input per dialect family) into thousands of derived inputs; each one is
+//! parsed across all three dialects with the extension surface on, rendered
+//! twice for determinism, and (for Cooklang) serialized and scaled. The
+//! contracts asserted are the adversarial suite's own (docs/TESTS.md):
+//! completion without crash, leak, unbounded recursion, or output
+//! nondeterminism. The fixed seed makes the whole run reproducible — a
+//! failure prints the iteration, the dialect, and the failing bytes (raw
+//! and hex) for minimization. This is the "dedicated fuzz target" that
+//! docs/TESTS.md recorded as planned; the public
+//! `oliver.parse(allocator, bytes, dialect, options)` API is the fuzz
+//! entry point (issue #94).
+
+const std = @import("std");
+const oliver = @import("oliver");
+
+/// The seed corpus: representative inputs per dialect, chosen to exercise
+/// deep parser states (nesting, delimiter storms, tables, escapes, raw
+/// content, front matter, and the extension surface). Mutations of these
+/// reach shapes hand-written tests never do.
+const seeds = [_][]const u8{
+    // Markdown: emphasis/strong storms, nested containers, links,
+    // code spans/fences, HTML blocks, autolinks, entities, tables,
+    // headings, breaks, and the extension surface (wikilinks, callouts,
+    // task lists, footnotes, definition lists, heading attributes).
+    "# Head *em* **strong** `code` [link](https://x.test/a?b=1&c=2 \"t\")\n" ++
+        "\n" ++
+        "> quote\n" ++
+        "> > nested\n" ++
+        "\n" ++
+        "- a\n" ++
+        "  - b\n" ++
+        "    - c\n" ++
+        "\n" ++
+        "| a | b |\n" ++
+        "| - | :-: |\n" ++
+        "| 1 | 2 |\n" ++
+        "\n" ++
+        "<div class=\"x\">\n" ++
+        "raw & stuff\n" ++
+        "</div>\n" ++
+        "\n" ++
+        "<https://auto.link/x?y=1>\n" ++
+        "\n" ++
+        "[[wikilink|label]] and > [!note] Callout\n" ++
+        "\n" ++
+        "- [x] done\n" ++
+        "- [ ] todo\n" ++
+        "\n" ++
+        "Term\n" ++
+        ": definition\n" ++
+        "\n" ++
+        "[^1]: a note\n" ++
+        "\n" ++
+        "Ref[^1] and \\*escaped\\* and a&nbsp;entity\n",
+    // Markdown: reference links, images, setext, thematic breaks, hard
+    // breaks, entity references, backslash escapes.
+    "Setext\n" ++
+        "======\n" ++
+        "\n" ++
+        "![alt *text*](/img.png \"title\")\n" ++
+        "\n" ++
+        "[ref]: /dest \"title\"\n" ++
+        "\n" ++
+        "See [ref] and [ref][ref] and ![alt][ref].\n" ++
+        "\n" ++
+        "---\n" ++
+        "\n" ++
+        "line  \\\n" ++
+        "break\n",
+    // Textile: phrases with attributes, tables, extended blocks,
+    // footnotes, links, images, macros, definition lists, notextile.
+    "h1. Title\n" ++
+        "\n" ++
+        "*strong* and _em_ and **bold** and __italic__ and\n" ++
+        "%{color:red}span% and ++big++ and --small-- and ^sup^ and ~sub~\n" ++
+        "and ??cite?? and ABC(definition)\n" ++
+        "\n" ++
+        "|_. h |_. h |\n" ++
+        "| a | b |\n" ++
+        "\n" ++
+        "bq. \"quoted\":url a quote\n" ++
+        "\n" ++
+        "fn1. a footnote\n" ++
+        "\n" ++
+        "see[1]\n" ++
+        "\n" ++
+        "p{color:red}(class#id)[lang]. styled\n" ++
+        "\n" ++
+        "notextile. <b>raw</b>\n" ++
+        "\n" ++
+        "pre. verbatim <x>\n",
+    // Textile: bc./pre. code, clear., dl., line attributes, escaping.
+    "bc. code <x> & y\n" ++
+        "\n" ++
+        "pre. raw <b>\n" ++
+        "\n" ++
+        "clear.\n" ++
+        "\n" ++
+        "p<. left align\n" ++
+        "\n" ++
+        "== escaped ==\n" ++
+        "\n" ++
+        "|1|2|\n",
+    // Cooklang: full recipe with frontmatter, ingredients, timers,
+    // cookware, sections, prep steps, references, mixed quantities.
+    "---\n" ++
+        "servings: 2\n" ++
+        "title: Test\n" ++
+        "---\n" ++
+        "\n" ++
+        "> @milk{1 1/2%cup}\n" ++
+        "\n" ++
+        "Add @salt{1/2 tsp} and @pepper{}.\n" ++
+        "\n" ++
+        "Prepared @onion{2} \n" ++
+        "\n" ++
+        "Cook @pasta{200%g} for ~{15%minutes}.\n" ++
+        "\n" ++
+        "Use @pan{}.\n" ++
+        "\n" ++
+        "= Section\n" ++
+        "\n" ++
+        "Step with @tomato{3}.\n" ++
+        "\n" ++
+        "@recipe:other.cook\n",
+    // Cooklang: edge shapes — fixed quantities, ranges, bare ingredients.
+    "Use @water{=2%cup} and @oil{1/2}.\n" ++
+        "\n" ++
+        "@garlic{}\n" ++
+        "\n" ++
+        "@chicken{500%g} @rice{1%cup}\n" ++
+        "\n" ++
+        "~{30%minutes}\n" ++
+        "\n" ++
+        "#tag & standalone text\n",
+    // Front matter edge shapes.
+    "---\ntitle: A & B\n---\nbody\n",
+    "+++\nfoo = \"bar\"\n+++\ntext\n",
+};
+
+/// The generated input cap (well under `source.max_input_len`, so span
+/// arithmetic never risks overflow) and the per-run mutation budget.
+/// Sized so the step completes in a few seconds under the Debug test
+/// gate while still mutating every seed thousands of edits deep.
+const max_input: usize = 4096;
+const iterations: usize = 1000;
+
+test "fuzz: three-dialect mutation wall over the public parse API" {
+    // A fixed seed makes every run identical: a failure today is the same
+    // failure tomorrow, and the printed input minimizes by hand.
+    var prng = std.Random.DefaultPrng.init(0x0ff1ce);
+    const rnd = prng.random();
+    var buf: [max_input]u8 = undefined;
+    for (0..iterations) |i| {
+        const input = mutate(rnd, &seeds, &buf);
+        try exercise(input, i);
+    }
+}
+
+/// Parses and renders `input` across all three dialects with the extension
+/// surface on, asserting the adversarial contracts: no crash, no leak
+/// (the test allocator fails on leaks/double-frees), deterministic output
+/// (every render/serialize runs twice and must agree byte-for-byte).
+/// On failure the input is printed for minimization.
+fn exercise(input: []const u8, i: usize) !void {
+    // Markdown: every extension on, YAML front matter.
+    {
+        var result = try oliver.parse(std.testing.allocator, input, .markdown, .{
+            .markdown = .{
+                .footnotes = true,
+                .definition_lists = true,
+                .heading_attributes = true,
+                .strikethrough = true,
+                .wikilinks = true,
+                .callouts = true,
+                .smartypants = true,
+                .task_lists = true,
+            },
+            .frontmatter = .yaml,
+        });
+        defer result.deinit();
+        const a = try renderDoc(&result.document);
+        defer std.testing.allocator.free(a);
+        const b = try renderDoc(&result.document);
+        defer std.testing.allocator.free(b);
+        if (!std.mem.eql(u8, a, b)) return fail(input, i, "markdown render nondeterminism");
+    }
+    // Textile: TOML front matter, double render.
+    {
+        var result = try oliver.parse(std.testing.allocator, input, .textile, .{ .frontmatter = .toml });
+        defer result.deinit();
+        const a = try renderDoc(&result.document);
+        defer std.testing.allocator.free(a);
+        const b = try renderDoc(&result.document);
+        defer std.testing.allocator.free(b);
+        if (!std.mem.eql(u8, a, b)) return fail(input, i, "textile render nondeterminism");
+    }
+    // Cooklang: YAML front matter; render, serialize, and scale must all
+    // be deterministic and complete.
+    {
+        var result = try oliver.cooklang.parse(std.testing.allocator, input, .{ .frontmatter = .yaml });
+        defer result.deinit();
+        const a = try renderRecipe(&result.recipe);
+        defer std.testing.allocator.free(a);
+        const b = try renderRecipe(&result.recipe);
+        defer std.testing.allocator.free(b);
+        if (!std.mem.eql(u8, a, b)) return fail(input, i, "cooklang render nondeterminism");
+        const s1 = try serializeRecipe(&result.recipe);
+        defer std.testing.allocator.free(s1);
+        const s2 = try serializeRecipe(&result.recipe);
+        defer std.testing.allocator.free(s2);
+        if (!std.mem.eql(u8, s1, s2)) return fail(input, i, "cooklang serialize nondeterminism");
+        var scaled = try oliver.cooklang_scale.scaleRecipe(std.testing.allocator, &result.recipe, .{
+            .factor = .{ .num = 3, .den = 2 },
+        });
+        defer scaled.deinit();
+        const s3 = try serializeRecipe(&scaled);
+        defer std.testing.allocator.free(s3);
+    }
+}
+
+fn renderDoc(doc: *const oliver.document.Document) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.html.render(std.testing.allocator, &aw.writer, doc, .{});
+    var out = aw.toArrayList();
+    return out.toOwnedSlice(std.testing.allocator);
+}
+
+fn renderRecipe(recipe: *const oliver.cooklang.Recipe) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.cooklang_html.render(std.testing.allocator, &aw.writer, recipe, .{});
+    var out = aw.toArrayList();
+    return out.toOwnedSlice(std.testing.allocator);
+}
+
+fn serializeRecipe(recipe: *const oliver.cooklang.Recipe) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
+    try oliver.cooklang_serialize.serialize(std.testing.allocator, &aw.writer, recipe, .{});
+    var out = aw.toArrayList();
+    return out.toOwnedSlice(std.testing.allocator);
+}
+
+/// Mutates a random seed with 1–8 random edits (overwrite, insert, delete,
+/// block duplicate, truncate), biased toward parser-relevant bytes. The
+/// result is clamped to `max_input`. Returns the seed itself untouched on
+/// a subset of single-edit runs so the pure seeds are exercised too.
+fn mutate(rnd: std.Random, seed_set: []const []const u8, buf: []u8) []const u8 {
+    const seed = seed_set[rnd.uintLessThan(usize, seed_set.len)];
+    var len: usize = @min(seed.len, buf.len);
+    @memcpy(buf[0..len], seed[0..len]);
+    const n_mutations = 1 + rnd.uintLessThan(usize, 8);
+    if (n_mutations == 1 and rnd.boolean()) return seed;
+    var m: usize = 0;
+    while (m < n_mutations and len > 0) : (m += 1) {
+        switch (rnd.uintLessThan(u8, 5)) {
+            0 => { // overwrite one byte
+                buf[rnd.uintLessThan(usize, len)] = interesting(rnd);
+            },
+            1 => { // insert one byte
+                if (len < buf.len) {
+                    const pos = rnd.uintLessThan(usize, len + 1);
+                    std.mem.copyBackwards(u8, buf[pos + 1 .. len + 1], buf[pos..len]);
+                    buf[pos] = interesting(rnd);
+                    len += 1;
+                }
+            },
+            2 => { // delete one byte
+                const pos = rnd.uintLessThan(usize, len);
+                std.mem.copyForwards(u8, buf[pos..], buf[pos + 1 .. len]);
+                len -= 1;
+            },
+            3 => { // duplicate a block
+                const src = rnd.uintLessThan(usize, len);
+                const count = rnd.uintLessThan(usize, @min(64, len - src + 1));
+                if (len + count <= buf.len) {
+                    @memcpy(buf[len .. len + count], buf[src .. src + count]);
+                    len += count;
+                }
+            },
+            4 => { // truncate
+                len = rnd.uintLessThan(usize, len);
+            },
+            else => unreachable,
+        }
+    }
+    return buf[0..len];
+}
+
+/// Bytes biased toward markup structure — delimiters, escapes, whitespace,
+/// digits, and letters — so mutations frequently create parser-relevant
+/// shapes rather than random noise.
+const interesting_bytes =
+    "[](){}<>*_`~#|!&.;:\"'\\\t\n\r\x00 -+/=%0123456789" ++
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+fn interesting(rnd: std.Random) u8 {
+    return interesting_bytes[rnd.uintLessThan(usize, interesting_bytes.len)];
+}
+
+/// Prints the failing input (raw and hex) for triage/minimization and
+/// fails the test with a named violation.
+fn fail(input: []const u8, i: usize, what: []const u8) error{FuzzFailure} {
+    std.debug.print("fuzz failure at iteration {d}: {s}\n", .{ i, what });
+    std.debug.print("--- input ({d} bytes) ---\n{s}\n", .{ input.len, input });
+    std.debug.print("--- hex ---\n", .{});
+    for (input) |b| std.debug.print("{x:0>2}", .{b});
+    std.debug.print("\n", .{});
+    return error.FuzzFailure;
+}


### PR DESCRIPTION
## What

Implements the dedicated fuzz target from #94: a deterministic, multi-dialect fuzz wall over the public `parse` API, wired into the ordinary `zig build test` gate as its own step.

## Changes

- **`tests/fuzz.zig` (new)** — a fixed-seed PRNG mutates a comptime seed corpus (one representative input per dialect family: Markdown nesting/delimiters/tables/links/raw HTML/extensions, Textile phrases/tables/extended blocks/pre., Cooklang recipes with frontmatter and mixed quantities, plus frontmatter edge shapes) with 1–8 biased edits per round, capped at 4 KiB. Each of the 1,000 derived inputs is exercised across **all three dialects** with the full extension surface on and the frontmatter modes.
- **Assertions** — no crash, no leak (test allocator), byte-deterministic output (every render and serialize runs twice and must agree), and Cooklang additionally scaled via `scaleRecipe` and re-serialized. The failure path prints the iteration, the violated contract, and the input raw + hex for minimization.
- **`build.zig`** — a new `fuzz` test step in the ordinary gate, budgeted (~5s in Debug) to stay hermetic: deterministic, no filesystem, no external fuzzer.
- **Docs** — TESTS.md's "remains planned" note flipped to the shipped description with the 376/376 breakdown, WORK-LEDGER F2 card + traffic row, CLEANROOM session 33 provenance record, and the README/index/TEXTILE-PARITY count lines.

## Tests

`zig build test`: **376/376 (14/14 steps — the fuzz wall is its own step)**, CommonMark 652/652, Cooklang 60/60, `zig fmt` clean.

## Verification

- `zig build test --summary all` — all green.
- Fuzz step timed standalone (~5s) to confirm it stays within the gate budget.
- Sweep confirms no stale count references anywhere.

Closes #94.
