### PR TITLE
feat(c-abi): stable C ABI for embedding Oliver (parse + render + free)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,11 @@ jobs:
       # semantic fixed point over every corpus source.
       - name: Cooklang canonical conformance gate (60/60)
         run: zig build cooklang-conformance
+
+      # The stable C ABI leg: compile examples/c_example.c with the
+      # system C compiler against include/oliver.h and the static oliver
+      # library, then run it. The example is self-checking (exits non-zero
+      # on any failed assertion), proving the ABI compiles from C and
+      # round-trips end to end (docs/C-ABI.md).
+      - name: C ABI example (compile + run)
+        run: zig build c-example-run

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ zig build spec-conformance -- spec.txt
 | **Total** | **652/652** |
 
 ```bash
-zig build test    # run all tests (376 tests)
+zig build test    # run all tests (384 tests)
 zig build         # build the static library and CLI into zig-out/
 zig build cooklang-conformance   # Cooklang canonical corpus (vendored)
 ```
@@ -297,6 +297,29 @@ The caller supplies the allocator; the document (or recipe) owns an arena and
 borrows the
 input bytes; rendering streams to any writer. No global state, no hidden
 caches, deterministic output.
+
+### C ABI
+
+Embedding from C, Rust, Python, Node, or other FFI languages: a stable,
+minimal parse + render surface declared in `include/oliver.h`, with the
+memory-ownership contract (caller-supplied allocator pair, caller frees
+via `oliver_free`) and explicit error codes instead of panics
+(docs/C-ABI.md).
+
+```c
+#include "oliver.h"
+
+const char *md = "# Hello *world*\n";
+oliver_buffer buf = oliver_render(my_alloc, my_free, NULL,
+    (const uint8_t *)md, strlen(md),
+    OLIVER_MARKDOWN, OLIVER_FRONTMATTER_NONE, 0,
+    OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+/* buf.data is now owned by the caller; release with: */
+oliver_free(my_free, NULL, buf);
+```
+
+A self-checking consumer (`examples/c_example.c`) is compiled and run by
+`zig build c-example-run` and by CI on every change.
 
 ## CLI (provisional)
 

--- a/build.zig
+++ b/build.zig
@@ -168,6 +168,28 @@ pub fn build(b: *std.Build) void {
     });
     const run_fuzz_tests = b.addRunArtifact(fuzz_tests);
 
+    // The stable C ABI example consumer (examples/c_example.c): compiled
+    // with the system C compiler against include/oliver.h and the static
+    // oliver library, then run to prove the ABI compiles from C and
+    // round-trips (docs/C-ABI.md). Self-checking — exits non-zero on any
+    // failed assertion, so the step is also the CI gate leg.
+    const c_example_mod = b.createModule(.{
+        .root_source_file = null,
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    c_example_mod.addCSourceFile(.{ .file = b.path("examples/c_example.c"), .flags = &.{"-std=c11"} });
+    c_example_mod.addIncludePath(b.path("include"));
+    c_example_mod.linkLibrary(lib);
+    const c_example = b.addExecutable(.{
+        .name = "oliver-c-example",
+        .root_module = c_example_mod,
+    });
+    const c_example_run = b.addRunArtifact(c_example);
+    const c_example_step = b.step("c-example-run", "Build and run the C ABI example consumer");
+    c_example_step.dependOn(&c_example_run.step);
+
     const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_lib_tests.step);
     test_step.dependOn(&run_fixture_tests.step);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,7 @@ The two boundaries that matter:
 | `src/cooklang_serialize.zig` | canonical Cooklang serializer (Recipe → valid `.cook`) |
 | `src/cooklang_scale.zig` | pure Cooklang scaling (Recipe → scaled Recipe; public `classifyQuantity` / `parseFactor` / `scaleAmount` over authored amount strings; exact rationals; mixed `1 1/2` is a canonical input; `ScaledAmount.changed` distinguishes a rewrite from an overflow passthrough) |
 | `src/cooklang_menu.zig` | `.menu` convenience view (Recipe → day/meal structure) |
+| `src/c_abi.zig` | stable C ABI: `oliver_render` / `oliver_free` exports, the caller-allocator bridge, explicit error codes (docs/C-ABI.md) |
 | `src/main.zig` | provisional CLI: arguments + stdio only; no parser semantics |
 | `tools/cooklang_conformance.zig` | Cooklang canonical-corpus harness (`zig build cooklang-conformance`) |
 | `tests/fixtures_test.zig` | fixture-driven tests + adversarial smoke tests |
@@ -213,7 +214,9 @@ includes/transclusion, syntax-highlighting subprocesses.
 ## Provisional decisions (revisit deliberately)
 
 - The renderer takes a plain `*std.Io.Writer`-compatible value (anytype
-  `writeAll`), which couples the library to the Zig 0.16 writer shape. The C
-  ABI milestone will add a render-to-buffer path.
+  `writeAll`), which couples the library to the Zig 0.16 writer shape. The
+  C ABI (`src/c_abi.zig`, docs/C-ABI.md) provides the render-to-buffer
+  path on top of it: `oliver_render` parses and renders into an owned,
+  exactly-sized buffer through `std.Io.Writer.Allocating`.
 - `ParseOptions` is empty; fields arrive as policy decisions do.
 - Heading levels are `u8`; spans are `u32`. Both are documented bounds.

--- a/docs/C-ABI.md
+++ b/docs/C-ABI.md
@@ -1,0 +1,139 @@
+---
+published_at: 2026-08-16T00:00:00Z
+summary: The stable C ABI for embedding Oliver from C, Rust, Python, Node, and other FFI consumers: the oliver_render / oliver_free surface, the memory-ownership contract, the error codes, and the CI-compiled example.
+---
+
+# C ABI
+
+**Status:** implemented (issue #96, milestone v1.1; ledger card S2).  \
+**Module:** `src/c_abi.zig` (exports), `include/oliver.h` (C
+declaration), `examples/c_example.c` (CI-compiled consumer)  \
+**Entry points:** `oliver_render(alloc, free, ctx, bytes, len, dialect,
+frontmatter, markdown_flags, profile, raw_html, heading_ids,
+footnotes) -> oliver_buffer`, `oliver_free(free, ctx, buffer)`
+
+Oliver markets itself as markup infrastructure for consumers to build
+around, but until v1.1 the only consumer surface was the Zig API. The
+C ABI is the stable embedding seam: a minimal parse + render surface
+declared in a plain C header, so C, Rust, Python, Node, and other FFI
+consumers can embed Oliver without adopting Zig. The session record's
+architectural concern (docs/SESSION-1-REPORT.md, concern 1) — that any
+C-ABI surface must target the Zig 0.16 `std.Io` shapes and use
+`std.Io.Writer.Allocating` for the render-to-buffer path — is what this
+module implements.
+
+## 1. Surface
+
+```c
+typedef void *(*oliver_alloc_fn)(void *ctx, size_t size);
+typedef void (*oliver_free_fn)(void *ctx, void *ptr, size_t size);
+
+typedef struct oliver_buffer {
+    uint8_t *data;   /* owned on success; NULL on error */
+    size_t len;      /* byte length of `data` on success; 0 on error */
+    int error_code;  /* OLIVER_OK on success, else an OLIVER_ERR_* code */
+} oliver_buffer;
+
+oliver_buffer oliver_render(
+    oliver_alloc_fn alloc, oliver_free_fn free, void *ctx,
+    const uint8_t *bytes, size_t len,
+    int dialect, int frontmatter, uint32_t markdown_flags,
+    int profile, int raw_html, int heading_ids, int footnotes);
+
+void oliver_free(oliver_free_fn free, void *ctx, oliver_buffer buf);
+```
+
+One call parses and renders: `oliver_render` runs the same pipeline as
+the Zig API — `oliver.parse` (dialect dispatch, front matter pre-pass,
+diagnostics) followed by `oliver.html.render` — into an owned buffer.
+The Cooklang entry points (parse/scale/serialize) are a follow-up slice
+of the ABI, per issue #96.
+
+## 2. Memory-ownership contract
+
+- The caller supplies the allocator: a malloc-style `alloc`/`free` pair
+  plus an opaque context. `alloc` must provide at least `max_align_t`
+  alignment (the malloc contract); Oliver's internal allocations never
+  request more.
+- On success, `buffer.data` points to `len` bytes **owned by the
+  caller**, allocated through the supplied pair. Release them with
+  `oliver_free`, passing the **same** `free` and `ctx` used at render
+  time (the buffer's size is passed back to `free`, matching the
+  allocation).
+- On any error, `error_code` is non-zero, `data` is NULL, `len` is 0,
+  and there is nothing to free.
+- The input bytes are borrowed for the duration of the call only.
+- Documented failures return error codes; **internal bugs abort** the
+  process (they never return garbage). The module maps every documented
+  Zig error onto a code; anything else is a bug and panics rather than
+  crossing the boundary with a wrong result.
+
+## 3. Parameters
+
+`dialect`, `frontmatter`, `profile`, and `raw_html` are small integer
+enums declared in the header (`OLIVER_MARKDOWN`/`OLIVER_TEXTILE`,
+`OLIVER_FRONTMATTER_NONE`/`YAML`/`TOML`, `OLIVER_PROFILE_HTML`/`XHTML`,
+`OLIVER_RAW_HTML_ALLOWED`/`ESCAPED`/`REJECTED`). Any out-of-range value
+is `OLIVER_ERR_INVALID_ARGUMENT`, as is a null allocator pair or null
+`bytes` with a non-zero `len`.
+
+`markdown_flags` is the parse-extension bitmask (`OLIVER_MD_FOOTNOTES`
+… `OLIVER_MD_TASK_LISTS`, bit 0 = footnotes); all extensions are off by
+default, matching `markdown.Options`. `profile`, `raw_html`,
+`heading_ids`, and `footnotes` are the render options
+(`html.RenderOptions`). Note `footnotes` appears on **both** sides: the
+`OLIVER_MD_FOOTNOTES` bit turns the parse extension on, the `footnotes`
+argument turns the rendered section on — both are needed for footnote
+output.
+
+## 4. Error codes
+
+| code | meaning |
+| --- | --- |
+| `OLIVER_OK` | success; `data`/`len` valid |
+| `OLIVER_ERR_INPUT_TOO_LARGE` | input exceeds `source.max_input_len` (u32 spans) |
+| `OLIVER_ERR_OUT_OF_MEMORY` | the caller's allocator returned NULL |
+| `OLIVER_ERR_RAW_HTML_REJECTED` | `raw_html = REJECTED` and raw content was found (docs/RAW-HTML.md §3) |
+| `OLIVER_ERR_RAW_HTML_NOT_XML_WELL_FORMED` | XHTML profile, raw content present — the fail-closed error (docs/XHTML.md) |
+| `OLIVER_ERR_INVALID_ARGUMENT` | null allocator, null bytes with `len > 0`, out-of-range enum |
+
+## 5. Implementation notes
+
+- **Allocator bridge.** The caller's pair is wrapped in a Zig
+  `std.mem.Allocator` for the duration of the call (a stack-local state
+  struct holds the two function pointers plus the user context). The
+  pair has no realloc, so `resize` returns false and `remap` returns
+  null; the Allocator wrapper handles growth by allocating, copying, and
+  freeing.
+- **Render-to-buffer path.** `std.Io.Writer.Allocating` accumulates the
+  output; the result is then copied into a fresh, exactly-sized
+  allocation so the caller's `free` (which receives the returned `len`)
+  matches the allocation size exactly.
+- **No panics across the boundary for documented failures.** Argument
+  validation and every mapped error return codes. The one remaining
+  `@panic` is the `else` arm of the error map — unreachable for
+  documented errors, and the documented contract for internal bugs.
+- **Thread-safety.** A call is pure: no global state, no hidden caches.
+  Distinct calls may run on distinct threads; sharing one allocator pair
+  across threads is the caller's concern (as with malloc).
+
+## 6. Example and CI
+
+`examples/c_example.c` is a self-checking C consumer: a plain
+`malloc`/`free` pair, then byte-assertions over Markdown, Textile,
+front matter, the extension surface under the XHTML profile with escaped
+raw HTML, the two raw-content error codes, and the invalid-argument
+paths. It exits non-zero on any failed assertion, so the build step is
+also the gate:
+
+```text
+zig build c-example-run     # compiles examples/c_example.c against
+                            # include/oliver.h and the static library,
+                            # then runs it
+```
+
+CI runs it as its own leg after the conformance gates (`.github/
+workflows/ci.yml`, "C ABI example (compile + run)"), proving the header
+compiles from C and the ABI round-trips end to end on every change. The
+exports are forced into the static archive by the `comptime { _ = c_abi; }`
+block in `src/oliver.zig`.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -80,6 +80,11 @@ YAML). Derived operations over the same model:
   `oliver.cooklang.parse` plus the derived operations for Cooklang. The
   caller supplies the allocator; results own their arenas; text payloads
   borrow the input bytes (which must outlive the result).
+- **C ABI**: `oliver_render` / `oliver_free` over the public parse +
+  render path — a stable embedding seam for C, Rust, Python, Node, and
+  other FFI consumers, declared in `include/oliver.h` with the
+  memory-ownership contract and explicit error codes (docs/C-ABI.md),
+  proven by the CI-compiled `examples/c_example.c`.
 - **CLI**: `oliver render --from <markdown|textile|cooklang>
   [--to <html|xhtml>]`, `oliver serialize --from cooklang`,
   `oliver scale --from cooklang (--factor n[/d] | --servings n)`,

--- a/docs/CLEANROOM.md
+++ b/docs/CLEANROOM.md
@@ -706,3 +706,12 @@ unbounded recursion, or output nondeterminism; docs/TESTS.md). The seed
 corpus is the project's own representative inputs, and the mutation
 engine is a plain seeded PRNG over byte edits. No parser implementation
 source was consulted.
+
+Session 34 (S2 stable C ABI) provenance record: no upstream
+specification — the ABI is Oliver-authored surface over the project's
+own public Zig API (`oliver.parse` + `oliver.html.render`), designed
+from the session record's own architectural concern 1 (the
+render-to-buffer path for the future C ABI should use
+`std.Io.Writer.Allocating`). The C header, ownership contract, error
+codes, and example are the module's own contract (docs/C-ABI.md). No
+parser implementation source was consulted.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -194,8 +194,9 @@ fifth — the XHTML profile suite — is described in its own section below):
    paths (`renderWith` / `scaleWith`, the same paths `main` uses).
    They run as part of the ordinary `zig build test` gate.
 
-The current complete result is **376/376 tests passing** with Zig 0.16.0
-(309 library module tests + 18 fixture/adversarial tests + 7
+The current complete result is **384/384 tests passing** with Zig 0.16.0
+(317 library module tests — including 8 C-ABI tests over the exported
+`oliver_render`/`oliver_free` surface — + 18 fixture/adversarial tests + 7
 conformance-harness tests + 22 CLI argument-parsing tests + 19 XHTML
 profile tests + 1 fuzz wall). On top of the unit gate: the CommonMark
 0.31.2 corpus stays **652/652** with 0 mismatches (docs/README), the

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1179,7 +1179,7 @@ against `oliver render --from textile` during this wrap-up.
 | `notextile.` raw block | 2 | implemented (T25) | §23 |
 | inline composition (mixed families) | 1 | implemented (T4) | §3 |
 
-**105 fixture pairs, 376/376 tests, 652/652 CommonMark.** The
+**105 fixture pairs, 384/384 tests, 652/652 CommonMark.** The
 convergence pairs in `tests/fixtures_test.zig` additionally prove the
 shared renderer is byte-identical across dialects (Textile `*x*` ↔
 Markdown `**x**`, `_x_` ↔ `*x*`, `"x":u` ↔ `[x](u)`, `!img.png!` ↔

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -53,9 +53,10 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 | shared worker | S1 scale-factor grammar alignment | review findings #85–#86: `oliver scale --factor` routes through the library's `parseFactor` (decimals, mixed `1 1/2`, spaces around the slash accepted; leading zeros, `1/2/3`, `some`, over-u32 values rejected) instead of a parallel u32 split parser; `parseFactor` caps at u32 to match `ScaleBy.factor` while `scaleAmount` keeps its u64 path; `--factor`/`--servings` gain duplicate rejection; `scaleWith` is the shared scale path; 3 new tests (parseFactor u32 boundary; factor grammar battery; scale end-to-end); docs/COOKLANG.md §11 + README + TESTS | after #74 and CK7 | merged (PR #87) |
 | Cooklang worker | CK6 string-quantity classify/scale + mixed numbers | public `classifyQuantity` / `parseFactor` / `scaleAmount` over authored amount strings (the exact-rational path, not `parseQuantity`'s f64 decimal arm); `scaleRecipe` becomes a caller of `scaleAmount` on ingredient quantities only; mixed `1 1/2` is a canonical scalable input (emits integer / fraction / terminating decimal); timers/cookware/refs still never scale; `scale-mixed` fixture; docs/COOKLANG.md §11 | after CK3 (issue #76; lets consumers delete a forked string scale) | merged (PR #77) |
 | Cooklang worker | CK7 scale edge-case hardening | review findings on the merged CK6 surface (issues #79–#81): `parseMixedNumber` trims leading/trailing ASCII space/tab (issue #79); `familyOfAmount` reads the decimal family from the source form exactly — no f64/i64 probe, terminating decimals at any magnitude (issue #80); `ScaledAmount.changed` distinguishes a rewrite from an overflow passthrough (issue #81); 3 unit tests pin the whitespace battery, the >i64 terminating cases, and the changed/passthrough triggers; docs/COOKLANG.md §11 + FEATURE-MATRIX + ARCHITECTURE + CLEANROOM session 29 | after CK6 | merged (PR #82) |
-| Markdown extension worker | E5 GFM task lists | `Options.task_lists` checkbox recognition at a list item's content start (a `.task_checkbox` leaf; `[ ]`/`[x]`/`[X]` + trailing whitespace; strict shape — the item's first block at the content's first bytes, else literal); disabled `<input type="checkbox">` rendering with valueless `disabled`/`checked` and the render profile's void form (xml-form under `.xhtml`; the profiles agree byte-for-byte); the label scans normally after the checkbox; `--task-lists` CLI flag; docs/TASK-LISTS.md + fixture pair + xhtml hermetic pin + CLI end-to-end test | after the extension wave (issue #92, v1.1) | this PR |
-| shared worker | E6 raw-HTML policy | `html.RenderOptions.raw_html` — the ARCHITECTURE "allowed / escaped / rejected" knob, now implemented: `allowed` (verbatim, the default; XHTML still fails closed), `escaped` (HTML-escapes the bytes — well-formed under both profiles, closing the `pre.` XHTML gap), `rejected` (`error.RawHtmlRejected`, fail closed even in HTML mode); applies uniformly to `.raw_html` inline, `.html_block` (Markdown §4.6 + Textile `==`/`notextile.`), and Textile `pre.` verbatim; `--raw-html allowed|escaped|rejected` CLI flag (render-only, duplicate-rejected); docs/RAW-HTML.md §3 + unit tests + xhtml hermetic pin + CLI battery | after the extension wave (issue #93, v1.1) | this PR |
-| shared worker | F2 deterministic mutation-fuzz wall | `tests/fuzz.zig` — the "dedicated fuzz target" docs/TESTS.md recorded as planned: a fixed-seed PRNG mutates a comptime seed corpus (representative inputs per dialect) into 1,000 derived inputs, each parsed across all three dialects with the extension surface on and the front matter modes, rendered/serialized twice for determinism, and (for Cooklang) scaled — asserting no crash, no leak (test allocator), and byte-deterministic output; failures print the iteration, dialect, and bytes for minimization; wired into `zig build test` as its own step (~5s in Debug) | after the extension wave (issue #94, v1.1) | this PR |
+| Markdown extension worker | E5 GFM task lists | `Options.task_lists` checkbox recognition at a list item's content start (a `.task_checkbox` leaf; `[ ]`/`[x]`/`[X]` + trailing whitespace; strict shape — the item's first block at the content's first bytes, else literal); disabled `<input type="checkbox">` rendering with valueless `disabled`/`checked` and the render profile's void form (xml-form under `.xhtml`; the profiles agree byte-for-byte); the label scans normally after the checkbox; `--task-lists` CLI flag; docs/TASK-LISTS.md + fixture pair + xhtml hermetic pin + CLI end-to-end test | after the extension wave (issue #92, v1.1) | merged (PR #97) |
+| shared worker | E6 raw-HTML policy | `html.RenderOptions.raw_html` — the ARCHITECTURE "allowed / escaped / rejected" knob, now implemented: `allowed` (verbatim, the default; XHTML still fails closed), `escaped` (HTML-escapes the bytes — well-formed under both profiles, closing the `pre.` XHTML gap), `rejected` (`error.RawHtmlRejected`, fail closed even in HTML mode); applies uniformly to `.raw_html` inline, `.html_block` (Markdown §4.6 + Textile `==`/`notextile.`), and Textile `pre.` verbatim; `--raw-html allowed|escaped|rejected` CLI flag (render-only, duplicate-rejected); docs/RAW-HTML.md §3 + unit tests + xhtml hermetic pin + CLI battery | after the extension wave (issue #93, v1.1) | merged (PR #97) |
+| shared worker | F2 deterministic mutation-fuzz wall | `tests/fuzz.zig` — the "dedicated fuzz target" docs/TESTS.md recorded as planned: a fixed-seed PRNG mutates a comptime seed corpus (representative inputs per dialect) into 1,000 derived inputs, each parsed across all three dialects with the extension surface on and the front matter modes, rendered/serialized twice for determinism, and (for Cooklang) scaled — asserting no crash, no leak (test allocator), and byte-deterministic output; failures print the iteration, dialect, and bytes for minimization; wired into `zig build test` as its own step (~5s in Debug) | after the extension wave (issue #94, v1.1) | merged (PR #98) |
+| shared worker | S2 stable C ABI | `src/c_abi.zig` exports — `oliver_render(alloc, free, ctx, bytes, len, dialect, frontmatter, markdown_flags, profile, raw_html, heading_ids, footnotes)` parsing and rendering in one call into an owned, exactly-sized buffer, plus `oliver_free`; the caller's malloc-style pair bridges into a Zig allocator for the call (no realloc — growth allocs/copies/frees), documented failures return `Buffer.error_code` (input-too-large, oom, raw-html-rejected, not-xml-well-formed, invalid-argument) instead of panicking across the boundary, and the render-to-buffer path uses `std.Io.Writer.Allocating` per the session record; `include/oliver.h` declares the surface with the ownership contract; `examples/c_example.c` (a self-checking C consumer) is built and run by `zig build c-example-run` and its own CI leg; docs/C-ABI.md | after the extension wave (issue #96, v1.1) | this PR |
 
 ## M1 — Thematic-break / Setext precedence rung
 
@@ -1506,7 +1507,7 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
   xhtml hermetic pin. 371/371, 652/652, 60/60 re-verified.
 - **Parallelism:** yes; Textile and Cooklang untouched.
 - **Integration:** after the extension wave; gates re-verified.
-- **State:** this PR (issue #92).
+- **State:** merged on main (PR #97).
 
 ## E6 — Raw-HTML policy (issue #93)
 
@@ -1539,7 +1540,7 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 - **Parallelism:** yes; Textile and Cooklang untouched (the `pre.`
   arm is exercised but its default behavior is unchanged).
 - **Integration:** after the extension wave; gates re-verified.
-- **State:** this PR (issue #93).
+- **State:** merged on main (PR #97).
 
 ## F2 — Deterministic mutation-fuzz wall (issue #94)
 
@@ -1569,7 +1570,45 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
   re-verified.
 - **Parallelism:** yes; no parser or renderer files touched.
 - **Integration:** after the extension wave; gates re-verified.
-- **State:** this PR (issue #94).
+- **State:** merged on main (PR #98).
+
+## S2 — Stable C ABI (issue #96)
+
+- **Objective:** give the "markup infrastructure" its embedding seam — a
+  stable C ABI so C, Rust, Python, Node, and other FFI consumers can
+  embed Oliver without adopting Zig, the surface the session record
+  flagged as future work (docs/SESSION-1-REPORT.md, concern 1: the
+  render-to-buffer path for the future C ABI should use
+  `std.Io.Writer.Allocating`).
+- **Normative source:** the module's own ABI contract
+  (docs/C-ABI.md); Oliver-authored surface over the public Zig API
+  (provenance docs/CLEANROOM.md session 34).
+- **Contract:** src/c_abi.zig — `oliver_render` parses and renders in
+  one call into an owned, exactly-sized buffer, plus `oliver_free`. The
+  caller supplies a malloc-style allocator pair (documented max_align_t
+  alignment contract); the pair bridges into a Zig allocator for the
+  call, with no realloc (resize false, remap null — growth
+  allocs/copies/frees). Documented failures return explicit
+  `Buffer.error_code` values (input-too-large, out-of-memory,
+  raw-html-rejected, not-xml-well-formed, invalid-argument) rather than
+  panicking across the boundary; internal bugs abort. The header
+  (include/oliver.h) declares the surface and the ownership contract;
+  the Markdown parse-extension surface is a bitmask; the footnotes
+  extension needs both its parse bit and the render flag.
+- **Design:** the render-to-buffer path uses `std.Io.Writer.Allocating`
+  per the session record; the result is copied into a fresh
+  exactly-sized allocation so the caller's `free` (receiving the
+  returned `len`) matches the allocation. A stack-local state struct
+  holds the two function pointers plus the user context for the call.
+- **Tests:** 8 c-abi unit tests over the exported surface (render,
+  dialect dispatch, extension flags, both raw-html error codes, escaped
+  well-formedness, invalid arguments, ownership) + the self-checking
+  `examples/c_example.c` run by `zig build c-example-run`. 384/384,
+  652/652, 60/60 re-verified.
+- **Parallelism:** yes; no parser, model, or renderer files touched
+  (src/oliver.zig re-exports the module).
+- **Integration:** after the extension wave; gates re-verified.
+- **State:** this PR (issue #96).
 
 ## Deferred architectural cards
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The documentation is written for two audiences:
 | CommonMark 0.31.2 corpus | **652/652**, 0 mismatches |
 | Cooklang canonical corpus | **60/60** |
 | Textile fixture wall | fully green |
-| Test suite | **376/376** |
+| Test suite | **384/384** |
 
 Both conformance gates run in CI on every push/PR
 (`zig build spec-conformance -- spec.txt --gate` and

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -30,6 +30,12 @@
           "summary": "Pipeline, the two document families, module map, boundaries."
         },
         {
+          "file": "C-ABI.md",
+          "title": "C ABI",
+          "audience": "dev",
+          "summary": "The stable embedding seam: oliver_render / oliver_free over the public parse + render path, the ownership contract, error codes, and the CI-compiled example (shipped, issue #96, v1.1)."
+        },
+        {
           "file": "DOCUMENT-MODEL.md",
           "title": "Document model",
           "audience": "dev",

--- a/examples/c_example.c
+++ b/examples/c_example.c
@@ -1,0 +1,133 @@
+/*
+ * c_example.c — a self-checking C consumer of the Oliver C ABI.
+ *
+ * Built and run by `zig build c-example-run` (and the CI gate) to prove
+ * the ABI compiles from C and round-trips: render Markdown, Textile, and
+ * an extension combination; assert the exact bytes; exercise the explicit
+ * error-code paths and the ownership contract. Exits 0 only if every
+ * check passes.
+ *
+ * The allocator pair is plain malloc/free — the minimal compliant
+ * implementation (max_align_t alignment, context unused).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "oliver.h"
+
+static void *my_alloc(void *ctx, size_t size) {
+    (void)ctx;
+    return malloc(size);
+}
+
+static void my_free(void *ctx, void *ptr, size_t size) {
+    (void)ctx;
+    (void)size;
+    free(ptr);
+}
+
+static int checks = 0;
+
+static void check_bytes(const char *what, oliver_buffer buf, const char *expected) {
+    checks++;
+    size_t want = strlen(expected);
+    if (buf.error_code != OLIVER_OK) {
+        fprintf(stderr, "FAIL %s: error %d\n", what, buf.error_code);
+        exit(1);
+    }
+    if (buf.len != want || memcmp(buf.data, expected, want) != 0) {
+        fprintf(stderr, "FAIL %s: got %zu bytes, expected %zu\n", what, buf.len, want);
+        fprintf(stderr, "  got:      %.*s\n", (int)buf.len, (const char *)buf.data);
+        fprintf(stderr, "  expected: %s\n", expected);
+        exit(1);
+    }
+    oliver_free(my_free, NULL, buf);
+}
+
+static void check_error(const char *what, oliver_buffer buf, int want_error) {
+    checks++;
+    if (buf.error_code != want_error) {
+        fprintf(stderr, "FAIL %s: got error %d, expected %d\n", what, buf.error_code, want_error);
+        exit(1);
+    }
+    if (buf.data != NULL || buf.len != 0) {
+        fprintf(stderr, "FAIL %s: error buffer must be empty\n", what);
+        exit(1);
+    }
+    /* Nothing to free on an error buffer. */
+}
+
+int main(void) {
+    const char *md = "# Hello *world*\n";
+    oliver_buffer buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)md, strlen(md),
+        OLIVER_MARKDOWN, OLIVER_FRONTMATTER_NONE, 0,
+        OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+    check_bytes("markdown basic", buf, "<h1>Hello <em>world</em></h1>\n");
+
+    const char *textile = "h1. Hello *world*\n";
+    buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)textile, strlen(textile),
+        OLIVER_TEXTILE, OLIVER_FRONTMATTER_NONE, 0,
+        OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+    check_bytes("textile basic", buf, "<h1>Hello <strong>world</strong></h1>\n");
+
+    /* Extensions: wikilinks + smartypants + task lists (parse bits), with
+     * the XHTML profile (the XML-form void element) and escaped raw HTML. */
+    const char *ext = "- [x] done [[Page|label]] \"hi\" <br/>\n";
+    buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)ext, strlen(ext),
+        OLIVER_MARKDOWN, OLIVER_FRONTMATTER_NONE,
+        OLIVER_MD_WIKILINKS | OLIVER_MD_SMARTYPANTS | OLIVER_MD_TASK_LISTS,
+        OLIVER_PROFILE_XHTML, OLIVER_RAW_HTML_ESCAPED, 0, 0);
+    check_bytes("extensions + xhtml + escaped raw html", buf,
+                "<ul>\n<li><input type=\"checkbox\" disabled=\"\" checked=\"\" />done <a href=\"Page\">label</a> \xe2\x80\x9chi\xe2\x80\x9d &lt;br/&gt;</li>\n</ul>\n");
+
+    /* Front matter: yaml fence stripped, body rendered. */
+    const char *fm = "---\ntitle: Doc\n---\n\n# Body\n";
+    buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)fm, strlen(fm),
+        OLIVER_MARKDOWN, OLIVER_FRONTMATTER_YAML, 0,
+        OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+    check_bytes("yaml front matter", buf, "<h1>Body</h1>\n");
+
+    /* Explicit error codes: rejected raw HTML and XHTML fail-closed. */
+    const char *raw = "before <script>bad()</script> after\n";
+    buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)raw, strlen(raw),
+        OLIVER_MARKDOWN, OLIVER_FRONTMATTER_NONE, 0,
+        OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_REJECTED, 0, 0);
+    check_error("raw html rejected", buf, OLIVER_ERR_RAW_HTML_REJECTED);
+
+    buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)raw, strlen(raw),
+        OLIVER_MARKDOWN, OLIVER_FRONTMATTER_NONE, 0,
+        OLIVER_PROFILE_XHTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+    check_error("xhtml raw html fail-closed", buf, OLIVER_ERR_RAW_HTML_NOT_XML_WELL_FORMED);
+
+    /* Invalid arguments return OLIVER_ERR_INVALID_ARGUMENT, not a crash. */
+    buf = oliver_render(
+        NULL, my_free, NULL,
+        (const uint8_t *)md, strlen(md),
+        OLIVER_MARKDOWN, OLIVER_FRONTMATTER_NONE, 0,
+        OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+    check_error("null allocator", buf, OLIVER_ERR_INVALID_ARGUMENT);
+
+    buf = oliver_render(
+        my_alloc, my_free, NULL,
+        (const uint8_t *)md, strlen(md),
+        99, OLIVER_FRONTMATTER_NONE, 0,
+        OLIVER_PROFILE_HTML, OLIVER_RAW_HTML_ALLOWED, 0, 0);
+    check_error("bad dialect", buf, OLIVER_ERR_INVALID_ARGUMENT);
+
+    printf("c-example: %d checks passed\n", checks);
+    return 0;
+}

--- a/include/oliver.h
+++ b/include/oliver.h
@@ -1,0 +1,129 @@
+/*
+ * oliver.h — the stable C ABI for embedding Oliver.
+ *
+ * A minimal parse + render surface over the public Zig API
+ * (docs/C-ABI.md). Consumers in C, Rust, Python, Node, and other FFI
+ * languages can embed Oliver without adopting Zig.
+ *
+ * Memory-ownership contract:
+ *   - The caller supplies the allocator: a malloc-style `alloc`/`free`
+ *     pair plus an opaque context. `alloc` must provide at least
+ *     `max_align_t` alignment (the malloc contract); Oliver's internal
+ *     allocations never request more.
+ *   - `oliver_render` returns a buffer. On success (`error_code ==
+ *     OLIVER_OK`) the buffer's `data` points to `len` bytes that are
+ *     owned by the caller. Release them with `oliver_free`, passing the
+ *     SAME `free` function and `ctx` used at render time.
+ *   - On any error, `error_code` is non-zero and `data` is NULL with
+ *     `len == 0`; there is nothing to free.
+ *   - The input bytes are borrowed for the duration of the call only.
+ *   - Documented failures return error codes; internal bugs abort the
+ *     process (they never return garbage).
+ *
+ * Thread-safety: a call is pure — no global state, no hidden caches.
+ * Distinct calls may run on distinct threads; sharing one allocator pair
+ * across threads is the caller's concern (as with malloc).
+ */
+
+#ifndef OLIVER_H
+#define OLIVER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The caller-supplied allocator pair. `ctx` is passed through unchanged. */
+typedef void *(*oliver_alloc_fn)(void *ctx, size_t size);
+typedef void (*oliver_free_fn)(void *ctx, void *ptr, size_t size);
+
+/* Error codes (the Zig side mirrors them; values are part of the ABI). */
+enum {
+    OLIVER_OK = 0,
+    OLIVER_ERR_INPUT_TOO_LARGE = 1,          /* input exceeds 4 GiB (u32 spans) */
+    OLIVER_ERR_OUT_OF_MEMORY = 2,            /* the caller's allocator returned NULL */
+    OLIVER_ERR_RAW_HTML_REJECTED = 3,        /* raw_html = OLIVER_RAW_HTML_REJECTED and raw content was found */
+    OLIVER_ERR_RAW_HTML_NOT_XML_WELL_FORMED = 4, /* XHTML profile, raw content present (fail closed) */
+    OLIVER_ERR_INVALID_ARGUMENT = 5,         /* null allocator, null bytes with len > 0, out-of-range enum */
+};
+
+/* Input dialect. */
+enum {
+    OLIVER_MARKDOWN = 0,
+    OLIVER_TEXTILE = 1,
+};
+
+/* Front matter handling (shared by all frontends, off by default). */
+enum {
+    OLIVER_FRONTMATTER_NONE = 0,
+    OLIVER_FRONTMATTER_YAML = 1,
+    OLIVER_FRONTMATTER_TOML = 2,
+};
+
+/* Renderer output profile. */
+enum {
+    OLIVER_PROFILE_HTML = 0,
+    OLIVER_PROFILE_XHTML = 1,
+};
+
+/* Raw-content policy (Markdown raw HTML inline tags and HTML blocks,
+ * Textile ==/notextile. escapes and pre. verbatim blocks). */
+enum {
+    OLIVER_RAW_HTML_ALLOWED = 0,  /* verbatim (default; XHTML still fails closed) */
+    OLIVER_RAW_HTML_ESCAPED = 1,  /* HTML-escaped; well-formed under both profiles */
+    OLIVER_RAW_HTML_REJECTED = 2, /* fail with OLIVER_ERR_RAW_HTML_REJECTED */
+};
+
+/* Markdown parse-extension bitmask (all off by default). */
+enum {
+    OLIVER_MD_FOOTNOTES = 1 << 0,
+    OLIVER_MD_DEFINITION_LISTS = 1 << 1,
+    OLIVER_MD_HEADING_ATTRIBUTES = 1 << 2,
+    OLIVER_MD_STRIKETHROUGH = 1 << 3,
+    OLIVER_MD_WIKILINKS = 1 << 4,
+    OLIVER_MD_CALLOUTS = 1 << 5,
+    OLIVER_MD_SMARTYPANTS = 1 << 6,
+    OLIVER_MD_TASK_LISTS = 1 << 7,
+};
+
+/* An owned render result. */
+typedef struct oliver_buffer {
+    uint8_t *data;      /* owned on success; NULL on error */
+    size_t len;         /* byte length of `data` on success; 0 on error */
+    int error_code;     /* OLIVER_OK on success, else an OLIVER_ERR_* code */
+} oliver_buffer;
+
+/* Renders `bytes[0..len]` in the given dialect to an owned buffer.
+ *
+ * `alloc`/`free`/`ctx` are the caller's allocator pair (see the contract
+ * above). `markdown_flags` is the OLIVER_MD_* bitmask. `profile`,
+ * `raw_html`, `heading_ids`, and `footnotes` are the render options;
+ * note `footnotes` appears on both sides — OLIVER_MD_FOOTNOTES turns the
+ * parse extension on, the `footnotes` argument turns the rendered
+ * section on, and both are needed for footnote output.
+ */
+oliver_buffer oliver_render(
+    oliver_alloc_fn alloc,
+    oliver_free_fn free,
+    void *ctx,
+    const uint8_t *bytes,
+    size_t len,
+    int dialect,
+    int frontmatter,
+    uint32_t markdown_flags,
+    int profile,
+    int raw_html,
+    int heading_ids,
+    int footnotes);
+
+/* Releases a buffer returned by `oliver_render`. `free` and `ctx` must be
+ * the same pair passed at render time. */
+void oliver_free(oliver_free_fn free, void *ctx, oliver_buffer buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OLIVER_H */

--- a/src/c_abi.zig
+++ b/src/c_abi.zig
@@ -1,0 +1,442 @@
+//! The stable C ABI for embedding Oliver from C, Rust, Python, Node, and
+//! other FFI consumers (docs/C-ABI.md).
+//!
+//! Surface (include/oliver.h declares the C side):
+//!
+//! ```c
+//! oliver_buffer oliver_render(
+//!     oliver_alloc_fn alloc, oliver_free_fn free, void *ctx,
+//!     const uint8_t *bytes, size_t len,
+//!     int dialect, int frontmatter, uint32_t markdown_flags,
+//!     int profile, int raw_html, int heading_ids, int footnotes);
+//! void oliver_free(oliver_free_fn free, void *ctx, oliver_buffer buf);
+//! ```
+//!
+//! Contract:
+//! - The caller supplies the allocator: a malloc-style `alloc`/`free` pair
+//!   plus an opaque context. `alloc` must provide at least `max_align_t`
+//!   alignment (the malloc contract); Oliver's allocations never request
+//!   more.
+//! - The returned buffer is owned by the caller and must be released with
+//!   `oliver_free`, passing the **same** `free` and `ctx` used at render
+//!   time.
+//! - Documented failures return an explicit error code in
+//!   `Buffer.error_code` (`data` is null, `len` is 0, nothing to free);
+//!   internal bugs abort rather than returning garbage. Input bytes are
+//!   borrowed for the duration of the call only.
+//!
+//! The render-to-buffer path uses `std.Io.Writer.Allocating` — the Zig
+//! 0.16 writer seam the session record calls out for the C ABI
+//! (docs/SESSION-1-REPORT.md, architectural concern 1) — wrapped to hand
+//! the caller an owned, exactly-sized buffer.
+
+const std = @import("std");
+const oliver = @import("oliver.zig");
+
+/// Error codes returned in `Buffer.error_code`. The values are part of
+/// the stable ABI; include/oliver.h mirrors them.
+pub const Error = enum(c_int) {
+    ok = 0,
+    input_too_large = 1,
+    out_of_memory = 2,
+    raw_html_rejected = 3,
+    raw_html_not_xml_well_formed = 4,
+    invalid_argument = 5,
+};
+
+/// An owned render result. On success (`error_code == ok`), `data`
+/// points to `len` bytes owned by the caller (release with
+/// `oliver_free`); on any error, `data` is null and `len` is 0.
+pub const Buffer = extern struct {
+    data: ?[*]u8 = null,
+    len: usize = 0,
+    error_code: c_int = @intFromEnum(Error.ok),
+};
+
+/// The C allocator shape: malloc-style, plus an opaque context.
+pub const CAllocFn = *const fn (?*anyopaque, usize) callconv(.c) ?*anyopaque;
+/// The C deallocator shape: free-style, plus an opaque context.
+pub const CFreeFn = *const fn (?*anyopaque, ?*anyopaque, usize) callconv(.c) void;
+
+/// Per-call state bridging the caller's C allocator pair into a Zig
+/// `std.mem.Allocator` for the duration of the call. A pointer to a
+/// stack-local copy is the Allocator's context; nothing escapes.
+const CAllocState = struct {
+    alloc_fn: CAllocFn,
+    free_fn: CFreeFn,
+    user_ctx: ?*anyopaque,
+};
+
+fn cAlloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+    _ = ret_addr;
+    const state: *const CAllocState = @ptrCast(@alignCast(ctx));
+    // The caller's allocator must provide at least max_align_t alignment
+    // (the malloc contract, documented in include/oliver.h). Oliver's
+    // allocations never request more, so the pointer is usable as-is.
+    std.debug.assert(alignment.toByteUnits() <= @sizeOf(std.c.max_align_t));
+    const raw = state.alloc_fn(state.user_ctx, len) orelse return null;
+    return @ptrCast(raw);
+}
+
+/// No in-place resize: the pair has no realloc. The Allocator wrapper
+/// handles growth by allocating, copying, and freeing.
+fn cResize(
+    ctx: *anyopaque,
+    memory: []u8,
+    alignment: std.mem.Alignment,
+    new_len: usize,
+    ret_addr: usize,
+) bool {
+    _ = ctx;
+    _ = memory;
+    _ = alignment;
+    _ = new_len;
+    _ = ret_addr;
+    return false;
+}
+
+/// No relocation: returning null signals the wrapper to allocate, copy,
+/// and free.
+fn cRemap(
+    ctx: *anyopaque,
+    memory: []u8,
+    alignment: std.mem.Alignment,
+    new_len: usize,
+    ret_addr: usize,
+) ?[*]u8 {
+    _ = ctx;
+    _ = memory;
+    _ = alignment;
+    _ = new_len;
+    _ = ret_addr;
+    return null;
+}
+
+fn cFree(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+    _ = alignment;
+    _ = ret_addr;
+    const state: *const CAllocState = @ptrCast(@alignCast(ctx));
+    state.free_fn(state.user_ctx, memory.ptr, memory.len);
+}
+
+const vtable: std.mem.Allocator.VTable = .{
+    .alloc = cAlloc,
+    .resize = cResize,
+    .remap = cRemap,
+    .free = cFree,
+};
+
+/// Enum values across the ABI boundary. All are validated; anything else
+/// is `invalid_argument`.
+const DialectC = enum(c_int) { markdown = 0, textile = 1 };
+const FrontmatterC = enum(c_int) { none = 0, yaml = 1, toml = 2 };
+const ProfileC = enum(c_int) { html = 0, xhtml = 1 };
+const RawHtmlC = enum(c_int) { allowed = 0, escaped = 1, rejected = 2 };
+
+/// Markdown parse-extension bitmask (parse side of
+/// `oliver.MarkdownOptions`; bit 0 is the low bit).
+pub const MarkdownFlag = struct {
+    pub const footnotes: u32 = 1 << 0;
+    pub const definition_lists: u32 = 1 << 1;
+    pub const heading_attributes: u32 = 1 << 2;
+    pub const strikethrough: u32 = 1 << 3;
+    pub const wikilinks: u32 = 1 << 4;
+    pub const callouts: u32 = 1 << 5;
+    pub const smartypants: u32 = 1 << 6;
+    pub const task_lists: u32 = 1 << 7;
+};
+
+/// Renders `bytes` in the given dialect into an owned buffer.
+///
+/// `alloc`/`free`/`ctx` are the caller's allocator pair (see the module
+/// contract). `markdown_flags` is the `MarkdownFlag` bitmask; `profile`,
+/// `raw_html`, `heading_ids`, and `footnotes` are the render options
+/// (html.RenderOptions). `footnotes` appears on both sides: the parse
+/// flag turns the extension on, the render option emits the section —
+/// both are needed for footnote output.
+pub export fn oliver_render(
+    alloc_fn: ?CAllocFn,
+    free_fn: ?CFreeFn,
+    user_ctx: ?*anyopaque,
+    bytes: ?[*]const u8,
+    len: usize,
+    dialect: c_int,
+    frontmatter: c_int,
+    markdown_flags: u32,
+    profile: c_int,
+    raw_html: c_int,
+    heading_ids: c_int,
+    footnotes: c_int,
+) callconv(.c) Buffer {
+    const alloc = alloc_fn orelse return err(Error.invalid_argument);
+    const free = free_fn orelse return err(Error.invalid_argument);
+    if (len > 0 and bytes == null) return err(Error.invalid_argument);
+    const src = bytes orelse @as([*]const u8, @ptrFromInt(@alignOf(usize)));
+    const dialect_c: DialectC = switch (dialect) {
+        0 => .markdown,
+        1 => .textile,
+        else => return err(Error.invalid_argument),
+    };
+    const fm_c: FrontmatterC = switch (frontmatter) {
+        0 => .none,
+        1 => .yaml,
+        2 => .toml,
+        else => return err(Error.invalid_argument),
+    };
+    const profile_c: ProfileC = switch (profile) {
+        0 => .html,
+        1 => .xhtml,
+        else => return err(Error.invalid_argument),
+    };
+    const raw_c: RawHtmlC = switch (raw_html) {
+        0 => .allowed,
+        1 => .escaped,
+        2 => .rejected,
+        else => return err(Error.invalid_argument),
+    };
+    if (heading_ids != 0 and heading_ids != 1) return err(Error.invalid_argument);
+    if (footnotes != 0 and footnotes != 1) return err(Error.invalid_argument);
+
+    var state = CAllocState{ .alloc_fn = alloc, .free_fn = free, .user_ctx = user_ctx };
+    const a: std.mem.Allocator = .{ .ptr = &state, .vtable = &vtable };
+
+    return renderImpl(
+        a,
+        src[0..len],
+        dialect_c,
+        fm_c,
+        markdown_flags,
+        profile_c,
+        raw_c,
+        heading_ids == 1,
+        footnotes == 1,
+    ) catch |e| err(mapError(e));
+}
+
+/// Releases a buffer returned by `oliver_render`. `free` and `ctx` must be
+/// the same pair passed at render time.
+pub export fn oliver_free(free_fn: ?CFreeFn, user_ctx: ?*anyopaque, buf: Buffer) callconv(.c) void {
+    if (buf.data) |data| {
+        if (free_fn) |free| free(user_ctx, data, buf.len);
+    }
+}
+
+fn renderImpl(
+    a: std.mem.Allocator,
+    input: []const u8,
+    dialect: DialectC,
+    fm: FrontmatterC,
+    markdown_flags: u32,
+    profile: ProfileC,
+    raw_html: RawHtmlC,
+    heading_ids: bool,
+    footnotes: bool,
+) !Buffer {
+    var result = try oliver.parse(a, input, switch (dialect) {
+        .markdown => .markdown,
+        .textile => .textile,
+    }, .{
+        .frontmatter = switch (fm) {
+            .none => .none,
+            .yaml => .yaml,
+            .toml => .toml,
+        },
+        .markdown = .{
+            .footnotes = markdown_flags & MarkdownFlag.footnotes != 0,
+            .definition_lists = markdown_flags & MarkdownFlag.definition_lists != 0,
+            .heading_attributes = markdown_flags & MarkdownFlag.heading_attributes != 0,
+            .strikethrough = markdown_flags & MarkdownFlag.strikethrough != 0,
+            .wikilinks = markdown_flags & MarkdownFlag.wikilinks != 0,
+            .callouts = markdown_flags & MarkdownFlag.callouts != 0,
+            .smartypants = markdown_flags & MarkdownFlag.smartypants != 0,
+            .task_lists = markdown_flags & MarkdownFlag.task_lists != 0,
+        },
+    });
+    defer result.deinit();
+
+    var aw = std.Io.Writer.Allocating.init(a);
+    defer aw.deinit();
+    try oliver.html.render(a, &aw.writer, &result.document, .{
+        .profile = switch (profile) {
+            .html => .html,
+            .xhtml => .xhtml,
+        },
+        .raw_html = switch (raw_html) {
+            .allowed => .allowed,
+            .escaped => .escaped,
+            .rejected => .rejected,
+        },
+        .heading_ids = heading_ids,
+        .footnotes = footnotes,
+    });
+
+    // Move the rendered bytes into an exactly-sized allocation so the
+    // caller's free (which receives the returned len) matches the
+    // allocation size.
+    var list = aw.toArrayList();
+    defer list.deinit(a);
+    const out = try a.alloc(u8, list.items.len);
+    @memcpy(out, list.items);
+    return .{ .data = out.ptr, .len = out.len, .error_code = @intFromEnum(Error.ok) };
+}
+
+fn err(code: Error) Buffer {
+    return .{ .data = null, .len = 0, .error_code = @intFromEnum(code) };
+}
+
+fn mapError(e: anyerror) Error {
+    return switch (e) {
+        error.InputTooLarge => .input_too_large,
+        error.OutOfMemory => .out_of_memory,
+        error.RawHtmlRejected => .raw_html_rejected,
+        error.RawHtmlNotXmlWellFormed => .raw_html_not_xml_well_formed,
+        else => @panic("oliver_render: unhandled error"),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A malloc-style pair over an arena, so the Zig test binary exercises the
+/// exact exported surface without linking libc. Arena frees are no-ops, but
+/// every allocation is 16-byte aligned (the max_align_t contract).
+fn testAlloc(ctx: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
+    const arena: *std.heap.ArenaAllocator = @ptrCast(@alignCast(ctx.?));
+    const bytes = arena.allocator().alignedAlloc(u8, .fromByteUnits(16), size) catch return null;
+    return bytes.ptr;
+}
+
+fn testFree(ctx: ?*anyopaque, ptr: ?*anyopaque, size: usize) callconv(.c) void {
+    _ = ctx;
+    _ = ptr;
+    _ = size;
+}
+
+fn render(
+    arena: *std.heap.ArenaAllocator,
+    input: []const u8,
+    dialect: c_int,
+    frontmatter: c_int,
+    flags: u32,
+    profile: c_int,
+    raw_html: c_int,
+    heading_ids: c_int,
+    footnotes: c_int,
+) Buffer {
+    return oliver_render(
+        testAlloc,
+        testFree,
+        arena,
+        input.ptr,
+        input.len,
+        dialect,
+        frontmatter,
+        flags,
+        profile,
+        raw_html,
+        heading_ids,
+        footnotes,
+    );
+}
+
+test "c-abi: markdown round-trips through the exported surface" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const buf = render(&arena, "# Hello *world*\n", 0, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 0), buf.error_code);
+    const out = buf.data.?[0..buf.len];
+    defer oliver_free(testFree, &arena, buf);
+    try std.testing.expectEqualStrings("<h1>Hello <em>world</em></h1>\n", out);
+}
+
+test "c-abi: textile dialect renders through the same surface" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const buf = render(&arena, "h1. Hello *world*\n", 1, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 0), buf.error_code);
+    defer oliver_free(testFree, &arena, buf);
+    try std.testing.expectEqualStrings("<h1>Hello <strong>world</strong></h1>\n", buf.data.?[0..buf.len]);
+}
+
+test "c-abi: markdown extension flags enable the extension surface" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // footnotes (bit 0) + wikilinks (bit 4) + callouts (bit 5) +
+    // smartypants (bit 6) + task lists (bit 7); footnotes render on.
+    const flags = MarkdownFlag.footnotes | MarkdownFlag.wikilinks | MarkdownFlag.callouts | MarkdownFlag.smartypants | MarkdownFlag.task_lists;
+    const buf = render(&arena, "- [x] done [[Page|label]] \"hi\"\n\n> [!note] Title\n> Body\n\n[^a]: def\n\nref[^a]\n", 0, 0, flags, 0, 0, 0, 1);
+    try std.testing.expectEqual(@as(c_int, 0), buf.error_code);
+    defer oliver_free(testFree, &arena, buf);
+    const out = buf.data.?[0..buf.len];
+    try std.testing.expect(std.mem.indexOf(u8, out, "<input type=\"checkbox\" disabled=\"\" checked=\"\" />") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Page") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "callout callout-note") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\u{201c}hi\u{201d}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "footnotes") != null);
+}
+
+test "c-abi: raw_html rejected returns the explicit error code, not a panic" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const buf = render(&arena, "before <script>bad()</script> after\n", 0, 0, 0, 0, 2, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 3), buf.error_code);
+    try std.testing.expect(buf.data == null);
+    try std.testing.expectEqual(@as(usize, 0), buf.len);
+}
+
+test "c-abi: xhtml fails closed on raw html with the well-formedness code" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const buf = render(&arena, "<div>\nraw\n</div>\n", 0, 0, 0, 1, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 4), buf.error_code);
+    try std.testing.expect(buf.data == null);
+}
+
+test "c-abi: raw_html escaped renders well-formed under both profiles" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const buf = render(&arena, "before <script>bad()</script> after\n", 0, 0, 0, 1, 1, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 0), buf.error_code);
+    defer oliver_free(testFree, &arena, buf);
+    try std.testing.expectEqualStrings("<p>before &lt;script&gt;bad()&lt;/script&gt; after</p>\n", buf.data.?[0..buf.len]);
+}
+
+test "c-abi: invalid arguments return invalid_argument instead of crashing" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const input = "# x\n";
+
+    // null allocator pair
+    const b1 = oliver_render(null, testFree, &arena, input.ptr, input.len, 0, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b1.error_code);
+    const b2 = oliver_render(testAlloc, null, &arena, input.ptr, input.len, 0, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b2.error_code);
+
+    // null bytes with nonzero length
+    const b3 = oliver_render(testAlloc, testFree, &arena, null, 4, 0, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b3.error_code);
+
+    // out-of-range enum values
+    const b4 = render(&arena, input, 9, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b4.error_code);
+    const b5 = render(&arena, input, 0, 9, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b5.error_code);
+    const b6 = render(&arena, input, 0, 0, 0, 9, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b6.error_code);
+    const b7 = render(&arena, input, 0, 0, 0, 0, 9, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b7.error_code);
+    const b8 = render(&arena, input, 0, 0, 0, 0, 0, 2, 0);
+    try std.testing.expectEqual(@as(c_int, 5), b8.error_code);
+    const b9 = render(&arena, input, 0, 0, 0, 0, 0, 0, 2);
+    try std.testing.expectEqual(@as(c_int, 5), b9.error_code);
+}
+
+test "c-abi: oliver_free releases the buffer through the same allocator" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const buf = render(&arena, "# x\n", 0, 0, 0, 0, 0, 0, 0);
+    try std.testing.expectEqual(@as(c_int, 0), buf.error_code);
+    oliver_free(testFree, &arena, buf); // no-op under the arena; the contract is exercised
+    try std.testing.expectEqual(@as(c_int, 0), buf.error_code);
+}

--- a/src/oliver.zig
+++ b/src/oliver.zig
@@ -50,6 +50,11 @@ pub const cooklang_scale = @import("cooklang_scale.zig");
 /// The Cooklang `.menu` convenience view (semantic day/meal structure
 /// over a parsed Recipe; docs/COOKLANG.md §12).
 pub const cooklang_menu = @import("cooklang_menu.zig");
+/// The stable C ABI for embedding Oliver from C, Rust, Python, Node, and
+/// other FFI consumers: `oliver_render` / `oliver_free` over the public
+/// parse + render path, with explicit error codes (docs/C-ABI.md,
+/// include/oliver.h).
+pub const c_abi = @import("c_abi.zig");
 
 comptime {
     // The Cooklang modules have their own entry points and are never
@@ -62,6 +67,9 @@ comptime {
     _ = cooklang_serialize;
     _ = cooklang_scale;
     _ = cooklang_menu;
+    // Force the C ABI exports into the static library: exported functions
+    // in a lazily-analyzed file would otherwise be dropped from the archive.
+    _ = c_abi;
 }
 
 pub const version = "1.0.0";


### PR DESCRIPTION
## What

Implements the stable C ABI from #96: a minimal parse + render surface (`oliver_render` / `oliver_free`) over the public Zig API, so C, Rust, Python, Node, and other FFI consumers can embed Oliver without adopting Zig.

## Changes

- **`src/c_abi.zig` (new)** — `oliver_render(alloc, free, ctx, bytes, len, dialect, frontmatter, markdown_flags, profile, raw_html, heading_ids, footnotes) -> oliver_buffer` parses and renders in one call into an owned, exactly-sized buffer, plus `oliver_free`. The caller's malloc-style pair bridges into a Zig allocator for the call (no realloc — growth allocs/copies/frees); documented failures return explicit `error_code` values (input-too-large, out-of-memory, raw-html-rejected, not-xml-well-formed, invalid-argument) instead of panicking across the boundary. The render-to-buffer path uses `std.Io.Writer.Allocating`, per the session record's architectural concern (docs/SESSION-1-REPORT.md concern 1).
- **`include/oliver.h` (new)** — the C declaration: the surface, the ownership contract (caller-supplied allocator pair with the max_align_t contract, caller frees via the same pair, error buffers are empty, input borrowed per call), the error-code enum, and the parameter enums + Markdown parse-extension bitmask.
- **`examples/c_example.c` (new)** — a self-checking consumer over plain `malloc`/`free`: byte-assertions for Markdown, Textile, YAML front matter, the extension surface under the XHTML profile with escaped raw HTML, both raw-content error codes, and the invalid-argument paths. Exits non-zero on any failure.
- **`build.zig`** — `c-example-run` step: compiles the C file against the header and the static library (exports forced into the archive via `comptime { _ = c_abi; }`), then runs it.
- **`.github/workflows/ci.yml`** — the C ABI leg ("C ABI example (compile + run)") after the conformance gates.
- **Docs** — contract doc `docs/C-ABI.md` registered in `nav.json`; ARCHITECTURE's "C ABI milestone will add a render-to-buffer path" flipped to implemented + module-map row; CAPABILITIES bullet; README "C ABI" subsection; TESTS.md counts (317 lib / 384 total); index/TEXTILE-PARITY count lines; WORK-LEDGER S2 card + traffic row (plus the E5/E6/F2 state flips to their merged PRs); CLEANROOM session 34 provenance record.

## Tests

`zig build test`: **384/384 (14/14 steps)** — the 8 c-abi unit tests cover render round-trips, dialect dispatch, extension flags, both raw-html error codes, escaped well-formedness, the invalid-argument battery, and ownership. CommonMark 652/652, Cooklang 60/60, `zig fmt` clean.

## Verification

- `zig build c-example-run` — the C example compiles and passes all 8 self-checks.
- `nm` confirms `oliver_render`/`oliver_free` are exported from the static archive.
- Conformance gates re-verified (652/652, 60/60); sweep confirms no stale count references.

Closes #96.
