### PR TITLE
build(ci): ship a native-tested Windows binary in the release matrix

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -14,10 +14,13 @@
 # old commits; the cross-compile matrix below makes that a naming-only
 # change.
 #
-# The matrix is the four platforms consumers actually run. Windows
-# cross-compiles trivially from Zig but would ship untested from a solo
-# maintainer, so it is deliberately excluded until someone needs it.
-# Everything is built on one ubuntu runner: no per-OS runners required.
+# The matrix is the five platforms consumers actually run. Everything is
+# cross-compiled on one ubuntu runner, but Windows is no longer shipped
+# untrusted: a native smoke-test leg on a windows runner executes the
+# same render/`--version` assertions as the Linux binary against the
+# exact artifact that will be published, and the publish job is gated on
+# `needs: [build, smoke-windows]` — the rolling release never ships a
+# binary CI has not executed.
 
 name: Binaries
 
@@ -31,7 +34,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and publish prebuilt binaries
+    name: Build and cross-compile the release matrix
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -50,9 +53,11 @@ jobs:
       - name: Cross-compile the release matrix
         run: |
           mkdir -p dist
-          for target in x86_64-linux x86_64-macos aarch64-linux aarch64-macos; do
+          for target in x86_64-linux x86_64-macos aarch64-linux aarch64-macos x86_64-windows; do
             arch="${target%-*}"
             os="${target#*-}"
+            exe=""
+            [ "$os" = "windows" ] && exe=".exe"
             echo "==> $target"
             # -Dcommit embeds this exact source commit into the binary;
             # `oliver --version` prints it so a pinned consumer can assert
@@ -60,13 +65,14 @@ jobs:
             zig build -Dtarget="$target" -Doptimize=ReleaseSafe \
               -Dcommit="$GITHUB_SHA" \
               --prefix "/tmp/oliver/$target" >/dev/null
-            cp "/tmp/oliver/$target/bin/oliver" "dist/oliver-$os-$arch"
+            cp "/tmp/oliver/$target/bin/oliver$exe" "dist/oliver-$os-$arch$exe"
           done
 
       # Cheap integrity check before anything is published: the native
       # Linux binary must render a known input byte-for-byte and must
-      # report the exact commit that produced it.
-      - name: Smoke-test the native binary
+      # report the exact commit that produced it. The Windows binary
+      # gets the same assertions, natively, in the smoke-windows job.
+      - name: Smoke-test the native Linux binary
         run: |
           test "$(printf '# Hello *world*\n' | dist/oliver-linux-x86_64 render --from markdown)" = \
             '<h1>Hello <em>world</em></h1>'
@@ -77,6 +83,55 @@ jobs:
         run: |
           (cd dist && sha256sum oliver-*) > sha256sums.txt
 
+      # Hand the built artifacts (including the cross-compiled .exe) to
+      # the smoke and publish jobs, so the bytes that get tested are the
+      # bytes that get published.
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: oliver-dist
+          path: |
+            dist/
+            sha256sums.txt
+          if-no-files-found: error
+
+  # The Windows binary is cross-compiled above, so the only honest
+  # question is whether it *runs*. A windows runner executes the same
+  # render/`--version` assertions natively against the exact artifact
+  # that will be published; the publish job is gated on this leg, so the
+  # "untested" caveat is retired rather than papered over.
+  smoke-windows:
+    name: Smoke-test the native Windows binary
+    runs-on: windows-latest
+    timeout-minutes: 15
+    needs: build
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: oliver-dist
+
+      # `shell: bash` keeps the assertions byte-identical to the Linux
+      # leg; Git Bash on the runner executes the .exe directly.
+      - name: Smoke-test the native Windows binary
+        shell: bash
+        run: |
+          test "$(printf '# Hello *world*\n' | dist/oliver-windows-x86_64.exe render --from markdown)" = \
+            '<h1>Hello <em>world</em></h1>'
+          test "$(dist/oliver-windows-x86_64.exe --version)" = \
+            "oliver 1.0.0 (commit $GITHUB_SHA)"
+
+  publish:
+    name: Publish to the builds release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build, smoke-windows]
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: oliver-dist
+
       # Create the release once; on later runs it already exists and only
       # the assets are replaced (--clobber makes re-runs idempotent).
       - name: Publish to the builds release
@@ -86,6 +141,6 @@ jobs:
           if ! gh release view builds >/dev/null 2>&1; then
             gh release create builds \
               --title "Oliver prebuilt binaries" \
-              --notes "Rolling prebuilt binaries for the current tip of main. Download URL: https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>"
+              --notes "Rolling prebuilt binaries for the current tip of main — linux/macos (x86_64, aarch64) and windows-x86_64, each smoke-tested natively in CI before publishing. Download URL: https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>"
           fi
           gh release upload builds dist/* sha256sums.txt --clobber

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ binary for each supported platform, rebuilt on every push to `main`:
 
 - `oliver-linux-x86_64`, `oliver-linux-aarch64`
 - `oliver-macos-x86_64`, `oliver-macos-aarch64`
+- `oliver-windows-x86_64.exe`
 
 Download URL (stable, derived from the tag):
 
@@ -233,7 +234,11 @@ https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-
 ```
 
 `sha256sums.txt` in the same release verifies the assets. The binaries
-are ReleaseSafe and statically linked (macOS links only system libSystem).
+are ReleaseSafe and statically linked (macOS links only system libSystem;
+the Windows binary carries no runtime DLLs). Every platform is
+smoke-tested natively in CI before the release is published — the
+Windows binary gets its own `windows-latest` runner leg, so the rolling
+release never ships a binary CI has not executed.
 
 Every CI-built binary embeds the exact source commit it was built from:
 `oliver --version` prints `oliver <version> (commit <full-sha>)`. A

--- a/docs/CLEANROOM.md
+++ b/docs/CLEANROOM.md
@@ -715,3 +715,12 @@ render-to-buffer path for the future C ABI should use
 `std.Io.Writer.Allocating`). The C header, ownership contract, error
 codes, and example are the module's own contract (docs/C-ABI.md). No
 parser implementation source was consulted.
+
+Session 35 (S3 tested Windows binary) provenance record: no upstream
+specification — the change is CI/release infrastructure over Oliver's
+own shipped CLI surface: the same render/`--version` smoke assertions
+the workflow already ran natively for Linux, now executed on a Windows
+runner against the cross-compiled artifact before publishing. The
+`x86_64-windows` target addition and the `needs: [build,
+smoke-windows]` publish gate are issue #95's spec, not new markup
+behavior. No parser implementation source was consulted.

--- a/docs/WORK-LEDGER.md
+++ b/docs/WORK-LEDGER.md
@@ -56,7 +56,8 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 | Markdown extension worker | E5 GFM task lists | `Options.task_lists` checkbox recognition at a list item's content start (a `.task_checkbox` leaf; `[ ]`/`[x]`/`[X]` + trailing whitespace; strict shape — the item's first block at the content's first bytes, else literal); disabled `<input type="checkbox">` rendering with valueless `disabled`/`checked` and the render profile's void form (xml-form under `.xhtml`; the profiles agree byte-for-byte); the label scans normally after the checkbox; `--task-lists` CLI flag; docs/TASK-LISTS.md + fixture pair + xhtml hermetic pin + CLI end-to-end test | after the extension wave (issue #92, v1.1) | merged (PR #97) |
 | shared worker | E6 raw-HTML policy | `html.RenderOptions.raw_html` — the ARCHITECTURE "allowed / escaped / rejected" knob, now implemented: `allowed` (verbatim, the default; XHTML still fails closed), `escaped` (HTML-escapes the bytes — well-formed under both profiles, closing the `pre.` XHTML gap), `rejected` (`error.RawHtmlRejected`, fail closed even in HTML mode); applies uniformly to `.raw_html` inline, `.html_block` (Markdown §4.6 + Textile `==`/`notextile.`), and Textile `pre.` verbatim; `--raw-html allowed|escaped|rejected` CLI flag (render-only, duplicate-rejected); docs/RAW-HTML.md §3 + unit tests + xhtml hermetic pin + CLI battery | after the extension wave (issue #93, v1.1) | merged (PR #97) |
 | shared worker | F2 deterministic mutation-fuzz wall | `tests/fuzz.zig` — the "dedicated fuzz target" docs/TESTS.md recorded as planned: a fixed-seed PRNG mutates a comptime seed corpus (representative inputs per dialect) into 1,000 derived inputs, each parsed across all three dialects with the extension surface on and the front matter modes, rendered/serialized twice for determinism, and (for Cooklang) scaled — asserting no crash, no leak (test allocator), and byte-deterministic output; failures print the iteration, dialect, and bytes for minimization; wired into `zig build test` as its own step (~5s in Debug) | after the extension wave (issue #94, v1.1) | merged (PR #98) |
-| shared worker | S2 stable C ABI | `src/c_abi.zig` exports — `oliver_render(alloc, free, ctx, bytes, len, dialect, frontmatter, markdown_flags, profile, raw_html, heading_ids, footnotes)` parsing and rendering in one call into an owned, exactly-sized buffer, plus `oliver_free`; the caller's malloc-style pair bridges into a Zig allocator for the call (no realloc — growth allocs/copies/frees), documented failures return `Buffer.error_code` (input-too-large, oom, raw-html-rejected, not-xml-well-formed, invalid-argument) instead of panicking across the boundary, and the render-to-buffer path uses `std.Io.Writer.Allocating` per the session record; `include/oliver.h` declares the surface with the ownership contract; `examples/c_example.c` (a self-checking C consumer) is built and run by `zig build c-example-run` and its own CI leg; docs/C-ABI.md | after the extension wave (issue #96, v1.1) | this PR |
+| shared worker | S2 stable C ABI | `src/c_abi.zig` exports — `oliver_render(alloc, free, ctx, bytes, len, dialect, frontmatter, markdown_flags, profile, raw_html, heading_ids, footnotes)` parsing and rendering in one call into an owned, exactly-sized buffer, plus `oliver_free`; the caller's malloc-style pair bridges into a Zig allocator for the call (no realloc — growth allocs/copies/frees), documented failures return `Buffer.error_code` (input-too-large, oom, raw-html-rejected, not-xml-well-formed, invalid-argument) instead of panicking across the boundary, and the render-to-buffer path uses `std.Io.Writer.Allocating` per the session record; `include/oliver.h` declares the surface with the ownership contract; `examples/c_example.c` (a self-checking C consumer) is built and run by `zig build c-example-run` and its own CI leg; docs/C-ABI.md | after the extension wave (issue #96, v1.1) | merged (PR #99) |
+| shared worker | S3 tested Windows binary | `.github/workflows/binaries.yml` grows `x86_64-windows` to the release matrix (publishing `oliver-windows-x86_64.exe` to the rolling `builds` release) and retires the deliberate-exclusion caveat honestly: a native `windows-latest` smoke-test leg runs the same render/`--version` assertions as the Linux binary against the exact artifact that ships, and the publish job is gated on `needs: [build, smoke-windows]` — the rolling release never ships an untested binary; README platform list + builds-release notes updated | after S2 (issue #95, v1.1) | this PR |
 
 ## M1 — Thematic-break / Setext precedence rung
 
@@ -1608,7 +1609,39 @@ land unchanged: current HEAD, specifications, tests, and discovered seams win.
 - **Parallelism:** yes; no parser, model, or renderer files touched
   (src/oliver.zig re-exports the module).
 - **Integration:** after the extension wave; gates re-verified.
-- **State:** this PR (issue #96).
+- **State:** merged on main (PR #99).
+
+## S3 — Tested Windows binary (issue #95)
+
+- **Objective:** retire the binaries workflow's deliberate-exclusion
+  caveat — Windows cross-compiles trivially from Zig but previously
+  shipped untested — by adding `x86_64-windows` to the release matrix
+  and proving the binary runs natively before anything is published.
+- **Normative source:** issue #95's spec (matrix addition + native
+  smoke leg + docs); no new markup behavior (provenance
+  docs/CLEANROOM.md session 35).
+- **Contract:** `.github/workflows/binaries.yml` — the matrix becomes
+  five targets (`x86_64-linux`, `x86_64-macos`, `aarch64-linux`,
+  `aarch64-macos`, `x86_64-windows`), the Windows artifact ships as
+  `oliver-windows-x86_64.exe`, and the single job splits into three:
+  `build` (ubuntu: cross-compile + native Linux smoke + checksums +
+  artifact upload), `smoke-windows` (`windows-latest`: the same
+  render/`--version` assertions executed against the exact artifact
+  that will be published), and `publish` (gated on `needs: [build,
+  smoke-windows]`). The gate enforces the honest claim: the rolling
+  `builds` release never ships a binary CI has not executed.
+- **Design:** the Windows binary is still cross-compiled once on the
+  ubuntu runner (byte-identical to what ships), so the smoke leg
+  exercises the real artifact; `shell: bash` on the windows runner
+  keeps the assertions byte-identical to the Linux leg. Artifact
+  handoff uses pinned upload/download-artifact v4 actions.
+- **Tests:** no unit tests (workflow-only); the native smoke leg is
+  the test — both legs' assertions, 384/384, 652/652, 60/60
+  re-verified on the untouched tree.
+- **Parallelism:** yes; no parser, model, renderer, or library files
+  touched.
+- **Integration:** after S2; workflow-only.
+- **State:** this PR (issue #95).
 
 ## Deferred architectural cards
 


### PR DESCRIPTION
## What

Ships the tested Windows binary per issue #95, retiring the binaries
workflow's deliberate-exclusion caveat honestly: `x86_64-windows` joins
the release matrix (`oliver-windows-x86_64.exe`), and a **native
`windows-latest` smoke leg** proves the binary runs before anything is
published — the publish job is gated on `needs: [build, smoke-windows]`,
so the rolling `builds` release never ships a binary CI has not
executed.

## Changes

- **`.github/workflows/binaries.yml`** — the single job splits into
  three: `build` (ubuntu: cross-compile all five targets incl.
  `x86_64-windows`, native Linux smoke, checksums, artifact upload),
  `smoke-windows` (`windows-latest`: the same render/`--version`
  assertions as the Linux leg, executed against the exact artifact that
  ships, via `shell: bash` for byte-identical assertions), and `publish`
  (gated on both legs). Artifact handoff uses pinned
  upload/download-artifact v4 actions. The builds-release notes now list
  all five platforms and the pre-publish smoke.
- **`README.md`** — platform list gains `oliver-windows-x86_64.exe`;
  static-linking note covers the Windows binary (no runtime DLLs);
  documents the native smoke gate.
- **`docs/WORK-LEDGER.md`** — S3 card + traffic row; S2 state flipped to
  `merged (PR #99)`.
- **`docs/CLEANROOM.md`** — session 35 provenance record (CI/release
  infrastructure only; no new markup behavior).

## Tests

No unit tests (workflow-only change); the native Windows smoke leg is
the test. The `x86_64-windows` target was cross-compiled locally to
prove the build and `.exe` naming; 384/384, 652/652, 60/60 are
unaffected (no parser/model/renderer files touched).

## Verification

- `yaml.safe_load` parses the workflow; jobs = build, smoke-windows,
  publish with `needs: [build, smoke-windows]` on publish.
- Local cross-compile of `-Dtarget=x86_64-windows -Doptimize=ReleaseSafe`
  produces `bin/oliver.exe` exactly as the workflow expects.
- No stale caveat text remains; ledger table integrity verified.

Closes #95.
