### PR TITLE
docs(theme): bump sidebar test count 280 -> 394 to match 394/394 gate

### DIFF
--- a/themes/oliver/layouts/main.html
+++ b/themes/oliver/layouts/main.html
@@ -52,7 +52,7 @@
           <div class="txp-status-row"><span class="txp-status-key">CommonMark 0.31.2</span><span class="txp-status-val">652/652</span></div>
           <div class="txp-status-row"><span class="txp-status-key">Cooklang canonical</span><span class="txp-status-val">60/60</span></div>
           <div class="txp-status-row"><span class="txp-status-key">Textile fixture wall</span><span class="txp-status-val">green</span></div>
-          <div class="txp-status-row"><span class="txp-status-key">Test suite</span><span class="txp-status-val">280/280</span></div>
+          <div class="txp-status-row"><span class="txp-status-key">Test suite</span><span class="txp-status-val">394/394</span></div>
         </div>
         <p class="txp-small-text">The walls gate every push. Snapshot from the docs home.</p>
       </div>


### PR DESCRIPTION
Fixes stale hardcoded sidebar widget in `themes/oliver/layouts/main.html:55`.

Live site at https://drawmeanelephant.github.io/oliver/ shows 280/280 in the Conformance widget while the gate and `docs/index.md:29` are 394/394 post-v1.1 (PR #105 just fixed the other 6 doc stragglers).

- `themes/oliver/layouts/main.html:55` `280/280` → `394/394`

No logic change, theme-only.