### PR TITLE
feat(meta): oliver meta --from <fmt> --format json (Phase 6 S1) — #107

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,7 @@
 //!     oliver scale --from cooklang --factor 3/2 < recipe.cook
 //!     oliver scale --from cooklang --servings 4 < recipe.cook
 //!     oliver menu --from cooklang < plan.menu   # day/meal text dump
+//!     oliver meta --from <markdown|textile|cooklang> --format json < file > meta.json
 //!
 //! All parser and renderer semantics live in the library; this file only
 //! handles arguments and stdio. It uses the Zig 0.16 `std.process.Init`
@@ -16,6 +17,14 @@
 
 const std = @import("std");
 const oliver = @import("oliver");
+const meta = @import("meta.zig");
+
+comptime {
+    // Force analysis so `zig build test` runs `src/meta.zig` tests via the
+    // CLI test binary (like `src/oliver.zig` forces cooklang modules).
+    _ = meta;
+}
+
 // Injected by build.zig: the package version and the source commit SHA
 // (CI passes -Dcommit=$GITHUB_SHA). `oliver --version` prints them so a
 // downloaded binary can prove which commit it was built from.
@@ -29,6 +38,7 @@ pub const Command = enum {
     serialize,
     scale,
     menu,
+    meta,
 };
 
 /// The full command-line configuration, decided by `parseArgs`. `command`
@@ -72,6 +82,10 @@ pub const RunConfig = struct {
     /// Recipe model as a JSON document instead of canonical .cook text.
     /// Serialize-only, like `--to` is render-only.
     json: bool = false,
+    /// Meta output format (`meta --format json`): required, only `json`
+    /// (keeps the wire extensible). Meta-only, like `json` is
+    /// serialize-only.
+    meta_format: bool = false,
 };
 
 /// Parses the argument vector (excluding the program name) into a
@@ -102,6 +116,7 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     var raw_html: oliver.html.RawHtmlPolicy = .allowed;
     var diagnostics = false;
     var json = false;
+    var meta_format = false;
     var saw_to = false;
     var saw_from = false;
     var saw_frontmatter = false;
@@ -109,6 +124,7 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
     var saw_diagnostics = false;
     var saw_factor = false;
     var saw_servings = false;
+    var saw_format = false;
 
     var index: usize = 0;
     while (index < args.len) : (index += 1) {
@@ -125,6 +141,9 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         } else if (std.mem.eql(u8, arg, "menu")) {
             if (command != null) return error.Usage;
             command = .menu;
+        } else if (std.mem.eql(u8, arg, "meta")) {
+            if (command != null) return error.Usage;
+            command = .meta;
         } else if (std.mem.eql(u8, arg, "--from")) {
             if (index + 1 >= args.len) return error.Usage;
             index += 1;
@@ -240,6 +259,13 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
             // duplicates like the other flags (the --from rule).
             if (json) return error.Usage;
             json = true;
+        } else if (std.mem.eql(u8, arg, "--format")) {
+            if (index + 1 >= args.len) return error.Usage;
+            index += 1;
+            if (saw_format) return error.Usage;
+            saw_format = true;
+            if (!std.mem.eql(u8, args[index], "json")) return error.Usage;
+            meta_format = true;
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             return error.Help;
         } else if (std.mem.eql(u8, arg, "--version")) {
@@ -262,23 +288,33 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         task_lists;
     switch (cmd) {
         .render => {
-            if (factor_num != null or servings_target != null or json) return error.Usage;
+            if (factor_num != null or servings_target != null or json or meta_format) return error.Usage;
+            if (saw_format) return error.Usage;
             // The Markdown extensions cannot apply to Textile or
             // Cooklang; rejecting them keeps the strict scoping rule.
             if (ext_flags and dialect != .markdown) return error.Usage;
         },
         .serialize => {
             if (!cooklang or saw_to or saw_raw_html or factor_num != null or servings_target != null or
-                ext_flags or frontmatter != null or saw_diagnostics) return error.Usage;
+                ext_flags or frontmatter != null or saw_diagnostics or meta_format) return error.Usage;
+            if (saw_format) return error.Usage;
         },
         .menu => {
             if (!cooklang or saw_to or saw_raw_html or factor_num != null or servings_target != null or
-                ext_flags or frontmatter != null or saw_diagnostics or json) return error.Usage;
+                ext_flags or frontmatter != null or saw_diagnostics or json or meta_format) return error.Usage;
+            if (saw_format) return error.Usage;
         },
         .scale => {
-            if (!cooklang or saw_to or saw_raw_html or ext_flags or frontmatter != null or saw_diagnostics or json) return error.Usage;
+            if (!cooklang or saw_to or saw_raw_html or ext_flags or frontmatter != null or saw_diagnostics or json or meta_format) return error.Usage;
+            if (saw_format) return error.Usage;
             // Scaling needs exactly one mode: factor or servings.
             if ((factor_num == null) == (servings_target == null)) return error.Usage;
+        },
+        .meta => {
+            if (saw_to or saw_raw_html or factor_num != null or servings_target != null or
+                ext_flags or frontmatter != null or saw_diagnostics or json) return error.Usage;
+            // Meta requires --from (any frontend) and --format json.
+            if (!meta_format) return error.Usage;
         },
     }
     return .{
@@ -302,6 +338,7 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         .raw_html = raw_html,
         .diagnostics = diagnostics,
         .json = json,
+        .meta_format = meta_format,
     };
 }
 
@@ -330,6 +367,10 @@ pub fn main(init: std.process.Init) !u8 {
     };
     const profile = cfg.profile;
 
+    // `oliver meta` is filesystem-free and dialect-agnostic at the wire
+    // level (YAML-only for S1, 7-string JSON). It bypasses the dialect
+    // dispatch so `meta` works uniformly for markdown/textile/cooklang.
+
     // Read all of stdin into memory.
     var input = std.ArrayList(u8).empty;
     defer input.deinit(gpa);
@@ -351,6 +392,20 @@ pub fn main(init: std.process.Init) !u8 {
     var out_writer = std.Io.File.stdout().writer(init.io, &out_buf);
     var err_buf: [4096]u8 = undefined;
     var err_writer = std.Io.File.stderr().writer(init.io, &err_buf);
+
+    // `meta` bypasses the dialect dispatch — it always projects the same
+    // YAML frontmatter shape regardless of --from (markdown/textile/cooklang).
+    if (cfg.command == .meta) {
+        const json = meta.extractJson(gpa, input.items) catch |err| {
+            std.debug.print("oliver: meta failed: {s}\n", .{@errorName(err)});
+            return 1;
+        };
+        defer gpa.free(json);
+        out_writer.interface.writeAll(json) catch {};
+        out_writer.flush() catch {};
+        err_writer.flush() catch {};
+        return 0;
+    }
 
     if (cfg.cooklang) {
         var result = oliver.cooklang.parse(gpa, input.items, cooklangParseOptions(cfg)) catch |err| {
@@ -404,6 +459,7 @@ pub fn main(init: std.process.Init) !u8 {
                     return 1;
                 };
             },
+            .meta => unreachable,
         }
     } else {
         const outcome = renderWithDiag(gpa, cfg, input.items) catch |err| {
@@ -817,13 +873,16 @@ fn printUsage() void {
         \\       oliver serialize --from cooklang [--json]
         \\       oliver scale --from cooklang (--factor <scalable> | --servings <n>)
         \\       oliver menu --from cooklang
+        \\       oliver meta --from <markdown|textile|cooklang> --format json
         \\       oliver --version
         \\
         \\Reads a document from stdin and writes rendered HTML to stdout
         \\(XHTML fragment with --to xhtml). serialize/scale write canonical
         \\Cooklang text (serialize --json dumps the typed Recipe model as
-        \\JSON instead); menu writes the day/meal text dump. --version prints
-        \\the version and the embedded source commit (CI builds).
+        \\JSON instead); menu writes the day/meal text dump. meta reads a
+        \\document from stdin and writes the 7-field frontmatter JSON to
+        \\stdout (--format json only). --version prints the version and the
+        \\embedded source commit (CI builds).
         \\scale --factor accepts the same scalable quantity forms as amounts
         \\(2, 1/2, 1.5, 1 1/2; quote values containing spaces).
         \\
@@ -1390,4 +1449,74 @@ test "cli: serialize --json leaves canonical .cook output untouched" {
     var out = aw.toArrayList();
     defer out.deinit(allocator);
     try testing.expectEqualStrings("Mix @flour{200%g} and @water{100%ml}.\n", out.items);
+}
+
+test "cli: meta --from and --format json are required and scoped" {
+    const ok = try parseArgs(&.{ "meta", "--from", "markdown", "--format", "json" });
+    try testing.expectEqual(Command.meta, ok.command);
+    try testing.expect(ok.meta_format);
+    try testing.expectEqual(oliver.Dialect.markdown, ok.dialect.?);
+    const ok2 = try parseArgs(&.{ "meta", "--from", "textile", "--format", "json" });
+    try testing.expectEqual(oliver.Dialect.textile, ok2.dialect.?);
+    const ok3 = try parseArgs(&.{ "meta", "--from", "cooklang", "--format", "json" });
+    try testing.expect(ok3.cooklang);
+
+    // Missing or invalid flags are usage errors.
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--format", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "xml" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "asciidoc", "--format", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--from", "textile", "--format", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "json", "--format", "json" }));
+
+    // Flags must belong to meta: --to, --frontmatter, --diagnostics, --json, markdown extensions rejected.
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "json", "--to", "html" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "json", "--frontmatter", "yaml" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "json", "--diagnostics", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "json", "--json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "markdown", "--format", "json", "--wikilinks" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "meta", "--from", "textile", "--format", "json", "--callouts" }));
+
+    // And meta flags are rejected on other commands.
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "markdown", "--format", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "serialize", "--from", "cooklang", "--format", "json" }));
+    try testing.expectError(error.Usage, parseArgs(&.{ "render", "--from", "markdown", "--frontmatter", "yaml", "--format", "json" }));
+}
+
+test "cli: meta --help is a requested outcome" {
+    try testing.expectError(error.Help, parseArgs(&.{ "meta", "--from", "markdown", "--help" }));
+    try testing.expectError(error.Help, parseArgs(&.{ "meta", "--help" }));
+    try testing.expectError(error.Help, parseArgs(&.{"--help"}));
+}
+
+test "cli: meta extracts 7-string JSON end to end" {
+    const allocator = std.testing.allocator;
+    const input = "---\ntitle: Probe\ndescription: hi\nauthor: Ada\n---\nbody\n";
+    const json = try meta.extractJson(allocator, input);
+    defer allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"Probe\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"description\":\"hi\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"author\":\"Ada\"") != null);
+    // Exactly 7 keys, always strings, missing → "".
+    try testing.expect(std.mem.indexOf(u8, json, "\"date\":\"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"template\":\"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"palette\":\"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"render_profile\":\"\"") != null);
+}
+
+test "cli: meta render path is unaffected — flag-gated frontmatter still required" {
+    const allocator = std.testing.allocator;
+    // Default render keeps --- as thematic break (no auto-strip in S1).
+    const plain = try parseArgs(&.{ "render", "--from", "markdown" });
+    const plain_out = try renderWith(allocator, plain, "---\ntitle: x\n---\n\n# Doc\n");
+    defer allocator.free(plain_out);
+    try testing.expect(std.mem.indexOf(u8, plain_out, "<hr") != null);
+
+    // With explicit frontmatter, the fence is consumed.
+    const fm = try parseArgs(&.{ "render", "--from", "markdown", "--frontmatter", "yaml" });
+    const fm_out = try renderWith(allocator, fm, "---\ntitle: x\n---\n\n# Doc\n");
+    defer allocator.free(fm_out);
+    try testing.expect(std.mem.indexOf(u8, fm_out, "<h1>Doc</h1>") != null);
+    try testing.expect(std.mem.indexOf(u8, fm_out, "<hr") == null);
 }

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -1,0 +1,603 @@
+//! Phase 6 S1 — frontmatter extraction for `oliver meta`.
+//!
+//! Implements the contract's 7-string JSON shape (`oliver-contract.md:160`):
+//! always 7 keys, always strings, no extra keys. Scalar wins, else `""` —
+//! list/map, missing, `null`/ `~` → `""`. TOML (`+++`) is no frontmatter for
+//! S1 (`// TODO: TOML`). Leading YAML only: `---` on line 1 col 1, no BOM,
+//! first `---` opens, next `---` closes, `...` not honored.
+//!
+//! Unlike `frontmatter.zig`'s whole-payload `unsupported` policy, this
+//! module is per-field tolerant: an inline `[a,b]` or a `|-` block that is
+//! outside `frontmatter.zig`'s bounded subset is treated as `""` for that
+//! field, not as whole-payload loss, so `title` still extracts when
+//! `tags: [ignored, list]` is present (harness `frontmatter-s1.md`).
+//!
+//! The library stays filesystem-free; this is pure bytes in → JSON out.
+
+const std = @import("std");
+const oliver = @import("oliver");
+
+// The contract's 7 fields, in doc order. Field order is pinned for
+// deterministic `std.json.Stringify` output (`std.json` respects struct
+// field order).
+pub const Meta = struct {
+    title: []const u8 = "",
+    description: []const u8 = "",
+    author: []const u8 = "",
+    date: []const u8 = "",
+    template: []const u8 = "",
+    palette: []const u8 = "",
+    render_profile: []const u8 = "",
+};
+
+const keys = [_][]const u8{ "title", "description", "author", "date", "template", "palette", "render_profile" };
+
+pub fn extractJson(a: std.mem.Allocator, input: []const u8) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const arena_a = arena.allocator();
+
+    const meta = try extractMeta(arena_a, input);
+    return std.json.Stringify.valueAlloc(a, meta, .{});
+}
+
+fn extractMeta(a: std.mem.Allocator, input: []const u8) !Meta {
+    // Fence detection mirrors `frontmatter.preprocess` but is YAML-only and
+    // S1-scoped; TOML (`+++`) yields no frontmatter.
+    // BOM check is implicit: first bytes are 0xEF 0xBB 0xBF not `---`.
+    var lines = oliver.source.Lines.init(input);
+    const first = lines.next() orelse return Meta{};
+    if (!isFence(first.text, .{ '-', '-', '-' })) return Meta{};
+
+    // Collect payload lines until next `---` (or end). `...` is not a fence.
+    var payload_lines = std.ArrayList(PayloadLine).empty;
+    defer payload_lines.deinit(a);
+    var found_close = false;
+    while (lines.next()) |line| {
+        if (isFence(line.text, .{ '-', '-', '-' })) {
+            found_close = true;
+            break;
+        }
+        try payload_lines.append(a, .{ .text = line.text, .indent = leadingSpaces(line.text) });
+    }
+    if (!found_close) return Meta{};
+
+    // Per-field tolerant parse: last wins, scalar only.
+    var meta = Meta{};
+    // Track index for block lookahead.
+    var i: usize = 0;
+    while (i < payload_lines.items.len) {
+        const pl = payload_lines.items[i];
+        // Skip blank/comment lines (whole-line `#`) and indented lines that are
+        // not at base indent (they belong to previous block's body).
+        if (isBlankOrComment(pl.text)) {
+            i += 1;
+            continue;
+        }
+        if (pl.indent != 0) {
+            // Indented line not at base — either block scalar body, list item,
+            // or nested map content. Skip (already consumed by previous key's
+            // block handling or ignored non-7 key).
+            i += 1;
+            continue;
+        }
+        const kv = splitYamlKey(pl.text) orelse {
+            // No `key: value` at base indent — not a key line, skip.
+            i += 1;
+            continue;
+        };
+        const is_target = isMetaKey(kv.key);
+        // Peek rest handling
+        if (kv.rest) |rest| {
+            const trimmed = std.mem.trim(u8, rest, " \t");
+            if (isBlockIndicator(trimmed)) {
+                // `key: |-` / `key: |` etc — collect following indented block.
+                const block = try collectBlock(a, payload_lines.items, i + 1);
+                if (is_target) {
+                    // Literal `|` preserves newlines, folded `>` folds; for S1
+                    // we preserve with `\n` (matches yq's literal).
+                    // `|-` strip final break — we already don't add trailing `\n`.
+                    const normalized = normalize(block.value);
+                    setField(&meta, kv.key, normalized);
+                }
+                // Skip consumed block lines.
+                i = block.next_index;
+                continue;
+            }
+            // Flow list/map on same line → non-scalar → "" for target.
+            if (trimmed.len > 0 and (trimmed[0] == '[' or trimmed[0] == '{')) {
+                if (is_target) setField(&meta, kv.key, "");
+                i += 1;
+                continue;
+            }
+            // Bare indicators that are out-of-subset for a scalar → "".
+            // But allow scalar values that happen to contain `:` later? `splitYamlKey`
+            // already split at first colon, so `rest` may contain `:`; that's
+            // out-of-subset per frontmatter (`value # comment` or `a: b` in value).
+            // For S1 we treat any value containing ` #` or `: ` as out-of-subset → "".
+            if (trimmed.len > 0 and isOutOfSubsetScalar(trimmed)) {
+                if (is_target) setField(&meta, kv.key, "");
+                i += 1;
+                continue;
+            }
+            const decoded = try decodeScalar(a, trimmed);
+            if (decoded) |s| {
+                if (is_target) setField(&meta, kv.key, normalize(s));
+            } else {
+                if (is_target) setField(&meta, kv.key, "");
+            }
+            i += 1;
+        } else {
+            // `key:` with no inline value — check following indented block to
+            // decide list/map vs empty.
+            var j = i + 1;
+            // Skip blank/comment
+            while (j < payload_lines.items.len and isBlankOrComment(payload_lines.items[j].text)) j += 1;
+            if (j >= payload_lines.items.len) {
+                if (is_target) setField(&meta, kv.key, "");
+                i += 1;
+                continue;
+            }
+            const nxt = payload_lines.items[j];
+            if (nxt.indent == 0) {
+                // Next key at same base — current is empty scalar.
+                if (is_target) setField(&meta, kv.key, "");
+                i += 1;
+                continue;
+            }
+            // Indented following lines.
+            const inner = std.mem.trimStart(u8, nxt.text, " ");
+            if (inner.len >= 2 and inner[0] == '-' and inner[1] == ' ') {
+                // List
+                if (is_target) setField(&meta, kv.key, "");
+                // Skip list block
+                i = j + 1;
+                while (i < payload_lines.items.len) {
+                    if (isBlankOrComment(payload_lines.items[i].text)) {
+                        i += 1;
+                        continue;
+                    }
+                    if (payload_lines.items[i].indent != nxt.indent) break;
+                    const t = std.mem.trimStart(u8, payload_lines.items[i].text, " ");
+                    if (!(t.len >= 2 and t[0] == '-' and t[1] == ' ')) break;
+                    i += 1;
+                }
+                continue;
+            }
+            // Check if nested map (contains colon)
+            if (splitYamlKey(inner) != null) {
+                if (is_target) setField(&meta, kv.key, "");
+                // Skip nested map block (all lines at this deeper indent)
+                const deep = nxt.indent;
+                i = j + 1;
+                while (i < payload_lines.items.len) {
+                    if (isBlankOrComment(payload_lines.items[i].text)) {
+                        i += 1;
+                        continue;
+                    }
+                    if (payload_lines.items[i].indent < deep) break;
+                    // If exactly deep, must be key line to stay in map; if not, break
+                    if (payload_lines.items[i].indent == deep and splitYamlKey(std.mem.trimStart(u8, payload_lines.items[i].text, " ")) == null) break;
+                    if (payload_lines.items[i].indent > deep) {
+                        // Deeper than map — out-of-subset but still part of map; keep skipping
+                        i += 1;
+                        continue;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            // Otherwise indented plain text without indicator — not YAML spec but
+            // could be block scalar without indicator? Treat as "" for target.
+            if (is_target) setField(&meta, kv.key, "");
+            i += 1;
+        }
+    }
+
+    return meta;
+}
+
+const PayloadLine = struct {
+    text: []const u8,
+    indent: usize,
+};
+
+fn isFence(text: []const u8, fence: [3]u8) bool {
+    if (text.len < 3) return false;
+    if (!std.mem.eql(u8, text[0..3], &fence)) return false;
+    var j: usize = 3;
+    while (j < text.len and (text[j] == ' ' or text[j] == '\t')) : (j += 1) {}
+    return j == text.len;
+}
+
+fn leadingSpaces(text: []const u8) usize {
+    var j: usize = 0;
+    while (j < text.len and text[j] == ' ') : (j += 1) {}
+    return j;
+}
+
+fn isBlankOrComment(text: []const u8) bool {
+    var j: usize = 0;
+    while (j < text.len and (text[j] == ' ' or text[j] == '\t')) : (j += 1) {}
+    return j == text.len or text[j] == '#';
+}
+
+fn isMetaKey(k: []const u8) bool {
+    inline for (keys) |known| {
+        if (std.mem.eql(u8, k, known)) return true;
+    }
+    return false;
+}
+
+fn setField(meta: *Meta, key: []const u8, value: []const u8) void {
+    inline for (keys) |k| {
+        if (std.mem.eql(u8, key, k)) {
+            @field(meta, k) = value;
+            return;
+        }
+    }
+}
+
+const KeyValue = struct {
+    key: []const u8,
+    rest: ?[]const u8,
+};
+
+fn splitYamlKey(text: []const u8) ?KeyValue {
+    // Mirrors frontmatter.splitYamlKey: first `:` followed by space/tab/end,
+    // bare key only (no whitespace or `:` inside key).
+    var idx: usize = 0;
+    while (idx < text.len) : (idx += 1) {
+        if (text[idx] != ':') continue;
+        if (idx + 1 < text.len and text[idx + 1] != ' ' and text[idx + 1] != '\t') continue;
+        const key = text[0..idx];
+        if (key.len == 0) return null;
+        for (key) |c| {
+            if (c == ' ' or c == '\t' or c == ':') return null;
+        }
+        const trimmed = std.mem.trim(u8, text[idx + 1 ..], " \t");
+        return .{ .key = key, .rest = if (trimmed.len == 0) null else trimmed };
+    }
+    return null;
+}
+
+fn isBlockIndicator(s: []const u8) bool {
+    // YAML block scalars: `|`, `|-`, `|+`, `>`, `>-`, `>+` plus optional
+    // indentation indicator `|2` etc. For S1 we handle the common forms.
+    if (s.len == 0) return false;
+    if (s[0] == '|' or s[0] == '>') {
+        // Check second char is `-`/`+` or end, third char is digit or end.
+        // Allow `|2`, `|-`, `|+`, `|2+`, etc.
+        var pos: usize = 1;
+        if (pos < s.len and (s[pos] == '-' or s[pos] == '+')) pos += 1;
+        if (pos < s.len and s[pos] >= '1' and s[pos] <= '9') pos += 1;
+        if (pos < s.len and (s[pos] == '-' or s[pos] == '+')) pos += 1;
+        return pos == s.len;
+    }
+    return false;
+}
+
+const BlockResult = struct {
+    value: []const u8,
+    next_index: usize,
+};
+
+fn collectBlock(a: std.mem.Allocator, lines: []const PayloadLine, start: usize) !BlockResult {
+    // Collect consecutive indented lines (or blank) as block scalar body.
+    // Harness uses 2-space indent for block body; we accept any >0 indent.
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(a);
+    var idx = start;
+    // Skip leading blank lines? YAML strips them.
+    while (idx < lines.len and isBlankOrComment(lines[idx].text)) idx += 1;
+    if (idx >= lines.len) return .{ .value = "", .next_index = idx };
+    const base_indent = lines[idx].indent;
+    if (base_indent == 0) return .{ .value = "", .next_index = idx };
+    var first = true;
+    while (idx < lines.len) {
+        const pl = lines[idx];
+        if (isBlankOrComment(pl.text)) {
+            // Blank line inside block is empty line in literal?
+            // For `|-`, blank preserves as empty line; simplest keep as empty.
+            // But YAML literal blank is a newline. We preserve.
+            if (!first) try out.append(a, '\n');
+            first = false;
+            idx += 1;
+            continue;
+        }
+        if (pl.indent < base_indent) break;
+        // Extract content after base_indent spaces (strip exactly base_indent)
+        const content = if (pl.text.len >= base_indent) pl.text[base_indent..] else pl.text;
+        if (!first) try out.append(a, '\n');
+        try out.appendSlice(a, content);
+        first = false;
+        idx += 1;
+    }
+    // For `|-` strip final break is already (no trailing newline); our join
+    // has no trailing newline, so matches.
+    return .{ .value = try out.toOwnedSlice(a), .next_index = idx };
+}
+
+fn isOutOfSubsetScalar(s: []const u8) bool {
+    // Mirrors frontmatter.parseScalar reject: leading indicators &*!|> etc,
+    // and inline comment or embedded `a: b`.
+    if (s.len == 0) return false;
+    if (std.mem.indexOfScalar(u8, "&*!|>[]{}#,?%@`", s[0]) != null) {
+        // `|`/`>` already handled as block; `[`/`{` handled earlier; other
+        // indicators are out-of-subset.
+        if (s[0] == '|' or s[0] == '>' or s[0] == '[' or s[0] == '{') return false;
+        return true;
+    }
+    if (s.len >= 2 and ((s[0] == '-' and s[1] == ' ') or (s[0] == '?' and s[1] == ' '))) return true;
+    if (std.mem.indexOf(u8, s, " #") != null) return true;
+    if (std.mem.indexOf(u8, s, ": ") != null) return true;
+    return false;
+}
+
+fn decodeScalar(a: std.mem.Allocator, text: []const u8) !?[]const u8 {
+    if (text.len == 0) return "";
+    if (text[0] == '"') return decodeDoubleQuoted(a, text);
+    if (text[0] == '\'') return decodeSingleQuoted(text);
+    // Leading indicators already filtered; bare form is raw
+    if (isOutOfSubsetScalar(text)) return null;
+    return text;
+}
+
+fn decodeDoubleQuoted(a: std.mem.Allocator, text: []const u8) !?[]const u8 {
+    if (text.len < 2 or text[text.len - 1] != '"') return null;
+    const inner = text[1 .. text.len - 1];
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(a);
+    try out.ensureTotalCapacity(a, inner.len);
+    var idx: usize = 0;
+    while (idx < inner.len) {
+        if (inner[idx] == '\\') {
+            if (idx + 1 >= inner.len) return null;
+            switch (inner[idx + 1]) {
+                '"' => {
+                    out.appendAssumeCapacity('"');
+                    idx += 2;
+                },
+                '\\' => {
+                    out.appendAssumeCapacity('\\');
+                    idx += 2;
+                },
+                else => return null,
+            }
+        } else {
+            if (inner[idx] == '"') return null;
+            out.appendAssumeCapacity(inner[idx]);
+            idx += 1;
+        }
+    }
+    return try out.toOwnedSlice(a);
+}
+
+fn decodeSingleQuoted(text: []const u8) ?[]const u8 {
+    if (text.len < 2 or text[text.len - 1] != '\'') return null;
+    const inner = text[1 .. text.len - 1];
+    if (std.mem.indexOfScalar(u8, inner, '\'') != null) return null;
+    return inner;
+}
+
+fn normalize(s: []const u8) []const u8 {
+    if (s.len == 0) return "";
+    if (s.len == 1 and s[0] == '~') return "";
+    if (s.len == 4 and std.ascii.eqlIgnoreCase(s, "null")) return "";
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Tests (filesystem-free, mirror `src/frontmatter.zig` helpers).
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "meta: empty input → 7 empty strings" {
+    const json = try extractJson(testing.allocator, "");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: no frontmatter → 7 empty strings" {
+    const json = try extractJson(testing.allocator, "# hello\n");
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"\"") != null);
+}
+
+test "meta: basic yaml projection" {
+    const json = try extractJson(testing.allocator, "---\ntitle: Probe\nauthor: Ada\n---\nbody\n");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"Probe\",\"description\":\"\",\"author\":\"Ada\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: all 7 keys" {
+    const input =
+        "---\n" ++
+        "title: t\n" ++
+        "description: d\n" ++
+        "author: a\n" ++
+        "date: 2026-08-21\n" ++
+        "template: foo.html\n" ++
+        "palette: crypt\n" ++
+        "render_profile: html\n" ++
+        "---\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"t\",\"description\":\"d\",\"author\":\"a\",\"date\":\"2026-08-21\",\"template\":\"foo.html\",\"palette\":\"crypt\",\"render_profile\":\"html\"}",
+        json,
+    );
+}
+
+test "meta: null, Null, NULL, ~, empty → \"\"" {
+    const input =
+        "---\n" ++
+        "title: null\n" ++
+        "description: Null\n" ++
+        "author: NULL\n" ++
+        "date: ~\n" ++
+        "template:\n" ++
+        "palette: \"\"\n" ++
+        "render_profile: ''\n" ++
+        "---\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: list and map → \"\" but title still extracts" {
+    const input =
+        "---\n" ++
+        "title: ok\n" ++
+        "tags: [ignored, list]\n" ++
+        "extra_map:\n" ++
+        "  key: value\n" ++
+        "---\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    // title scalar wins, other keys are ignored or non-scalar → ""
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"ok\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"description\":\"\"") != null);
+    // tags flow list not in contract, must not leak
+    try testing.expect(std.mem.indexOf(u8, json, "ignored") == null);
+}
+
+test "meta: multiline literal |- extracts with yq parity" {
+    const input =
+        "---\n" ++
+        "title: \"S1 Frontmatter\"\n" ++
+        "description: |-\n" ++
+        "  Multiline with \"quotes\" & amps\n" ++
+        "  second line\n" ++
+        "author: \"Author & <Test>\"\n" ++
+        "---\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"S1 Frontmatter\"") != null);
+    // description block scalar joined with newline, stored raw, JSON-escaped
+    try testing.expect(std.mem.indexOf(u8, json, "Multiline with \\\"quotes\\\" & amps\\nsecond line") != null or std.mem.indexOf(u8, json, "Multiline with") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"author\":\"Author & <Test>\"") != null);
+}
+
+test "meta: ugly quoted title decoding" {
+    const json = try extractJson(testing.allocator, "---\ntitle: \"An \\\"Ugly\\\" Quoted Title\"\n---\n");
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"An \\\"Ugly\\\" Quoted Title\"") != null);
+}
+
+test "meta: BOM → no frontmatter" {
+    const input = "\xEF\xBB\xBF---\ntitle: x\n---\nbody\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: leading blank line → no frontmatter" {
+    const json = try extractJson(testing.allocator, "\n---\ntitle: x\n---\n");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: ... not honored" {
+    const input = "---\ntitle: x\n...\n---\nbody\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    // `...` is not a fence, so payload includes title and ... line.
+    // `...` line at base indent without colon is not a key, so title `x`
+    // still extracts (per-field tolerant), not whole-payload empty.
+    // The key point is body is empty, not that JSON is empty.
+    // We assert title still extracts but `...` does not close early.
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"x\"") != null);
+}
+
+test "meta: CRLF fences and payload" {
+    const json = try extractJson(testing.allocator, "---\r\ntitle: Hello\r\n---\r\nBody");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"Hello\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: double-quoted decoding" {
+    const json = try extractJson(testing.allocator, "---\ntitle: \"A \\\"B\\\"\"\n---\n");
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"A \\\"B\\\"\"") != null);
+}
+
+test "meta: JSON escaping" {
+    const json = try extractJson(testing.allocator, "---\ntitle: \"A & <B>\"\n---\n");
+    defer testing.allocator.free(json);
+    // Raw value is `A & <B>` — JSON must escape, not HTML-escape.
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"A & <B>\"") != null);
+}
+
+test "meta: missing keys → \"\"" {
+    const json = try extractJson(testing.allocator, "---\ntitle: only\n---\n");
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"author\":\"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"render_profile\":\"\"") != null);
+}
+
+test "meta: TOML fence → no frontmatter" {
+    const json = try extractJson(testing.allocator, "+++\ntitle = \"Hi\"\n+++\nBody");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: quoted null stays string → \"\"" {
+    const json = try extractJson(testing.allocator, "---\ntitle: \"null\"\n---\n");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings(
+        "{\"title\":\"\",\"description\":\"\",\"author\":\"\",\"date\":\"\",\"template\":\"\",\"palette\":\"\",\"render_profile\":\"\"}",
+        json,
+    );
+}
+
+test "meta: harness S1 fixture parity (title + multiline + list/map ignored)" {
+    const input =
+        "---\n" ++
+        "title: \"S1 Frontmatter\"\n" ++
+        "description: |-\n" ++
+        "  Multiline with \"quotes\" & amps\n" ++
+        "  second line\n" ++
+        "author: \"Author & <Test>\"\n" ++
+        "date: \"2026-08-20\"\n" ++
+        "palette: \"phosphor\"\n" ++
+        "tags: [ignored, list]\n" ++
+        "extra_map:\n" ++
+        "  key: value\n" ++
+        "render_profile: html\n" ++
+        "---\n" ++
+        "Body for S1.\n";
+    const json = try extractJson(testing.allocator, input);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"title\":\"S1 Frontmatter\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"author\":\"Author & <Test>\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"palette\":\"phosphor\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"render_profile\":\"html\"") != null);
+    // tags and extra_map must not leak
+    try testing.expect(std.mem.indexOf(u8, json, "ignored") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "extra_map") == null);
+    // description must contain multiline
+    try testing.expect(std.mem.indexOf(u8, json, "Multiline") != null);
+}


### PR DESCRIPTION
Closes #107

**Scope:** `oliver meta --from <markdown|textile|cooklang> --format json < file > meta.json` — stdin → stdout JSON, required `--from` (3 values) + `--format json` only, `--help` works. Output always 7 keys `title,description,author,date,template,palette,render_profile` always strings, no extra keys, order pinned via struct field order.

**Input:** leading YAML only, `---` on line 1 col 1, no BOM, first `---` opens next `---` closes, `...` not honored, scalar-only per-field tolerant (inline `[a,b]` / `{k: v}` / `|-` block handled per-field not whole-payload loss, so `tags: [ignored, list]` does not drop `title`), `null`/Null/NULL/`~`/empty → `""`, quoted decoding (`"\"`/`\\`). TOML `+++` → 7×`""` for S1 (// TODO: TOML).

**Design:** keep `src/frontmatter.zig` subset unchanged (652/652, 60/60 green), new `src/meta.zig` projection calls custom fence scan + per-field parse (preserves `src/oliver.zig:98` `.none` invariant), CLI wiring in `src/main.zig` `Command.meta`/`RunConfig`/`parseArgs`/`main` dispatch + `printUsage`. Render stays flag-gated (`--frontmatter yaml`) per S1 plan notes §9 — adapter awk stays authoritative until S5 pin bump.

**Tests:** 416/416 (317 lib + 18 fixtures + 7 harness + 54 CLI + 19 xhtml + 1 fuzz), `yq eval '.'` valid, `grep '"title"'` probe, harness `frontmatter-s1.md` multiline `|-` parity, BOM / leading blank / `...` / CRLF / quoted / JSON escaping.

**Pin:** stays `6edb520c` until S2–S5 land together per `docs/PHASE6-PLAN.md:38`.