### PR TITLE
fix: recognize oliver wrap subcommand in parseArgs (#115)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -209,6 +209,9 @@ pub fn parseArgs(args: []const []const u8) error{ Usage, Help, Version }!RunConf
         } else if (std.mem.eql(u8, arg, "meta")) {
             if (command != null) return error.Usage;
             command = .meta;
+        } else if (std.mem.eql(u8, arg, "wrap")) {
+            if (command != null) return error.Usage;
+            command = .wrap;
         } else if (std.mem.eql(u8, arg, "plan")) {
             if (command != null) return error.Usage;
             command = .plan;


### PR DESCRIPTION
Closes #115

`parseArgs` in `src/main.zig:200` handled `render`/`serialize`/`scale`/`menu`/`meta`/`plan`/`manifest` but not `wrap`, so

```bash
oliver wrap --template /tmp/t.html --meta-json /tmp/m.json --assets-root ./assets/ --body /tmp/b.html
# → usage, exit 1 (should wrap)
```

failed with `error.Usage` even though `Command.wrap` (`src/main.zig:52`) and all `--template`/`--meta-json`/`--assets-root`/`--body` flag handling existed.

**Fix:** Add

```zig
else if (std.mem.eql(u8, arg, "wrap")) { if (command != null) return error.Usage; command = .wrap; }
```

alongside `meta`/`plan` in the subcommand dispatch. Existing `wrap` validation (`saw_wrap_*` + `.wrap =>` branch) and `wrapDispatch` already expected `.wrap`; only the token was missing.

**Verification:**
- `zig build` → `oliver wrap` now wraps (html-escaped meta + literal body/assets)
- `zig build test --summary all` → 453/453 pass (317+18+7+91+19+1)
- dup/conflicting subcommands and extra flags correctly return `error.Usage` (exit 1)
- manual repro: `oliver wrap --template /tmp/t.html --meta-json /tmp/m.json --assets-root ./assets/ --body /tmp/b.html` exit 0, title/body substituted