### PR TITLE
fix(ci): pass -R to the publish job's gh release calls

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -134,13 +134,17 @@ jobs:
 
       # Create the release once; on later runs it already exists and only
       # the assets are replaced (--clobber makes re-runs idempotent).
+      # This job has no checkout (it only ships artifacts), so gh cannot
+      # discover the repository from a .git directory — every call passes
+      # -R explicitly or dies with "failed to run git: fatal: not a git
+      # repository" (issue #117).
       - name: Publish to the builds release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if ! gh release view builds >/dev/null 2>&1; then
-            gh release create builds \
+          if ! gh release view builds -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create builds -R "$GITHUB_REPOSITORY" \
               --title "Oliver prebuilt binaries" \
               --notes "Rolling prebuilt binaries for the current tip of main — linux/macos (x86_64, aarch64) and windows-x86_64, each smoke-tested natively in CI before publishing. Download URL: https://github.com/drawmeanelephant/oliver/releases/download/builds/oliver-<os>-<arch>"
           fi
-          gh release upload builds dist/* sha256sums.txt --clobber
+          gh release upload builds dist/* sha256sums.txt --clobber -R "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Closes #117

## What

The Binaries workflow's publish job has failed on every run since the #100 restructure (10/10, first failure = the #100 merge run itself; last success = #99's, the pre-split layout). Build and smoke-windows pass; publish dies before any API call. This passes `-R "$GITHUB_REPOSITORY"` to the three `gh release` calls so they address the repository directly.

## Changes

- **`.github/workflows/binaries.yml`** — publish job's `gh release view` / `create` / `upload` each gain `-R "$GITHUB_REPOSITORY"`, plus a comment recording why: the job deliberately has no checkout (it only ships artifacts), and without `-R` gh falls back to git discovery and dies with `failed to run git: fatal: not a git repository` — the exact error in every failed-run log since Aug 17. No checkout step added; no other jobs touched. The top-level `permissions: contents: write` was already correct and is unchanged.

## Tests

No unit tests (workflow-only change; no parser/model/renderer/library files touched). The validation is actionlint plus the local suite proving nothing else moved, and the next push to `main` repopulating the `builds` release is the end-to-end proof.

## Verification

- `actionlint .github/workflows/*.yml` → clean (exit 0)
- `zig build test --summary all` → all six suites pass: 317 + 18 + 7 + 91 + 19 + 1 = **453/453** (same totals as #116)
- root-cause repro outside a git tree:
  ```
  $ cd /tmp && gh release view builds
  failed to run git: fatal: not a git repository (or any of the parent directories): .git   # exit 1
  $ cd /tmp && gh release view builds -R drawmeanelephant/oliver
  title: Oliver prebuilt binaries   # exit 0
  ```
- diff review: 3 command lines changed, 4 comment lines added, nothing else (`git show dbdd4c3 --stat` → 1 file, +7/−3)

No CHANGELOG in this repo, so no bullet.


Note: this PR shows zero checks — the fork’s first workflow run sits in GitHub’s `action_required` state awaiting maintainer approval, not failing; the `actionlint` + 453/453 verification above ran locally on the pushed commit `dbdd4c3`.
