### PR TITLE
fix(docs): quote summary values containing colons in front matter

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-13T00:00:00Z
-summary: Oliver is a small, freestanding markup parsing and rendering library in Zig: markup infrastructure, not a publishing framework.
+summary: "Oliver is a small, freestanding markup parsing and rendering library in Zig: markup infrastructure, not a publishing framework."
 ---
 
 # Oliver Architecture

--- a/docs/BLOCKS-PARSING.md
+++ b/docs/BLOCKS-PARSING.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-12T00:00:00Z
-summary: Contract for Oliver's container-block algorithm: block quotes and lists share the container stack (CommonMark section 5).
+summary: "Contract for Oliver's container-block algorithm: block quotes and lists share the container stack (CommonMark section 5)."
 ---
 
 # Oliver Block Parsing: Container Blocks (Block Quotes, Lists)

--- a/docs/C-ABI.md
+++ b/docs/C-ABI.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-16T00:00:00Z
-summary: The stable C ABI for embedding Oliver from C, Rust, Python, Node, and other FFI consumers: the oliver_render / oliver_free surface, the memory-ownership contract, the error codes, and the CI-compiled example.
+summary: "The stable C ABI for embedding Oliver from C, Rust, Python, Node, and other FFI consumers: the oliver_render / oliver_free surface, the memory-ownership contract, the error codes, and the CI-compiled example."
 ---
 
 # C ABI

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: What Oliver parses and renders today on main: the user-facing overview of frontend capabilities.
+summary: "What Oliver parses and renders today on main: the user-facing overview of frontend capabilities."
 ---
 
 # Oliver capabilities

--- a/docs/CLEANROOM.md
+++ b/docs/CLEANROOM.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-13T00:00:00Z
-summary: The binding clean-room contract for everyone who writes Oliver code: read it before adding syntax features.
+summary: "The binding clean-room contract for everyone who writes Oliver code: read it before adding syntax features."
 ---
 
 # Oliver Clean-Room Rules

--- a/docs/COOKLANG.md
+++ b/docs/COOKLANG.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-13T00:00:00Z
-summary: Design and provenance contract for the first-class Cooklang (.cook) frontend: bytes in, a typed Recipe out.
+summary: "Design and provenance contract for the first-class Cooklang (.cook) frontend: bytes in, a typed Recipe out."
 ---
 
 # Cooklang frontend: design contract

--- a/docs/DOCUMENT-MODEL.md
+++ b/docs/DOCUMENT-MODEL.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-13T00:00:00Z
-summary: The normalized typed document is the contract between dialect frontends and every future renderer: not HTML-shaped.
+summary: "The normalized typed document is the contract between dialect frontends and every future renderer: not HTML-shaped."
 ---
 
 # Oliver Document Model

--- a/docs/ENTITIES.md
+++ b/docs/ENTITIES.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-12T00:00:00Z
-summary: Contract for CommonMark section 2.5 entity and numeric character references: implemented, scorecard 17/17.
+summary: "Contract for CommonMark section 2.5 entity and numeric character references: implemented, scorecard 17/17."
 ---
 
 # Markdown entity and numeric character references

--- a/docs/FEATURE-MATRIX.md
+++ b/docs/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: Oliver's feature matrix: implemented, planned, and deferred items across the Markdown frontend.
+summary: "Oliver's feature matrix: implemented, planned, and deferred items across the Markdown frontend."
 ---
 
 # Oliver Feature Matrix

--- a/docs/HTML-BLOCKS.md
+++ b/docs/HTML-BLOCKS.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-12T00:00:00Z
-summary: Contract for Oliver's HTML block handling (section 4.6): all seven types implemented, scorecard 44/44.
+summary: "Contract for Oliver's HTML block handling (section 4.6): all seven types implemented, scorecard 44/44."
 ---
 
 # Markdown HTML blocks (§4.6)

--- a/docs/IMAGES-PARSING.md
+++ b/docs/IMAGES-PARSING.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-12T00:00:00Z
-summary: Contract for the inline-images slice of Oliver's Markdown frontend, derived from CommonMark section 6.7: implemented.
+summary: "Contract for the inline-images slice of Oliver's Markdown frontend, derived from CommonMark section 6.7: implemented."
 ---
 
 # Oliver Inline Parsing: Images

--- a/docs/LEAF-BLOCKS.md
+++ b/docs/LEAF-BLOCKS.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-12T00:00:00Z
-summary: Implementation contract for CommonMark sections 4.1 and 4.3 leaf blocks: thematic breaks and Setext headings.
+summary: "Implementation contract for CommonMark sections 4.1 and 4.3 leaf blocks: thematic breaks and Setext headings."
 ---
 
 # Markdown leaf blocks: thematic breaks and Setext headings

--- a/docs/RAW-HTML.md
+++ b/docs/RAW-HTML.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: Contract for the raw HTML slice of Oliver's Markdown frontend (section 6.6): implemented.
+summary: "Contract for the raw HTML slice of Oliver's Markdown frontend (section 6.6): implemented."
 ---
 
 # Oliver Inline Parsing: Raw HTML (§6.6)

--- a/docs/SESSION-1-REPORT.md
+++ b/docs/SESSION-1-REPORT.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: The first Oliver session: repository foundation, specification research, feature matrix, document model, and the smallest vertical slice.
+summary: "The first Oliver session: repository foundation, specification research, feature matrix, document model, and the smallest vertical slice."
 ---
 
 # Session 1 Report

--- a/docs/TASK-LISTS.md
+++ b/docs/TASK-LISTS.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-16T00:00:00Z
-summary: The opt-in GFM task list items extension ([ ] / [x] / [X] checkboxes) in the Markdown frontend: shape, recognition rules, chosen behaviors, and rendering.
+summary: "The opt-in GFM task list items extension ([ ] / [x] / [X] checkboxes) in the Markdown frontend: shape, recognition rules, chosen behaviors, and rendering."
 ---
 
 # Task lists (extension)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-13T00:00:00Z
-summary: Tests are product contracts: zig build test runs six suites covering library modules, fixtures, conformance, CLI parsing, the XHTML profile, and the fuzz wall.
+summary: "Tests are product contracts: zig build test runs six suites covering library modules, fixtures, conformance, CLI parsing, the XHTML profile, and the fuzz wall."
 ---
 
 # Oliver tests and fixtures

--- a/docs/TEXTILE-PARITY.md
+++ b/docs/TEXTILE-PARITY.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-13T00:00:00Z
-summary: Textile has no normative corpus, so its quality bar is a fixture audit: the parity audit holds the frontend to documented expectations.
+summary: "Textile has no normative corpus, so its quality bar is a fixture audit: the parity audit holds the frontend to documented expectations."
 ---
 
 # Textile parity audit

--- a/docs/WIKILINKS.md
+++ b/docs/WIKILINKS.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-16T00:00:00Z
-summary: The opt-in modular wikilinks extension ([[target]] / [[target|label]]) in the Markdown frontend: shape, precedence, fallbacks, and the resolver policy.
+summary: "The opt-in modular wikilinks extension ([[target]] / [[target|label]]) in the Markdown frontend: shape, precedence, fallbacks, and the resolver policy."
 ---
 
 # Wikilinks (extension)

--- a/docs/XHTML.md
+++ b/docs/XHTML.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: The XHTML output profile: same normalized IR, same semantics, an XML-compatible serialization, with a fail-closed raw-HTML policy and a mechanical well-formedness gate.
+summary: "The XHTML output profile: same normalized IR, same semantics, an XML-compatible serialization, with a fail-closed raw-HTML policy and a mechanical well-formedness gate."
 ---
 
 # XHTML output profile

--- a/docs/github-pages.md
+++ b/docs/github-pages.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: How Oliver publishes this docs tree to GitHub Pages with a pinned Boris binary: profile, plan, artifact, and audit contracts.
+summary: "How Oliver publishes this docs tree to GitHub Pages with a pinned Boris binary: profile, plan, artifact, and audit contracts."
 ---
 
 # GitHub Pages publication

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 published_at: 2026-08-14T00:00:00Z
-summary: Oliver documentation home: a small, freestanding markup parsing and rendering library in Zig.
+summary: "Oliver documentation home: a small, freestanding markup parsing and rendering library in Zig."
 ---
 
 # Oliver documentation


### PR DESCRIPTION
## Problem

Viewing any affected doc on GitHub showed:

> Error in user YAML: (<unknown>): mapping values are not allowed in this context at line 2 column 33

The `summary:` front-matter values contained an unquoted colon-space
(e.g. `Oliver's feature matrix: implemented, ...`), which YAML parses as a
nested mapping indicator. The `published_at` timestamps were fine.

## Fix

Double-quote the `summary` value in all 21 affected docs (values contain
apostrophes, so double quotes avoid single-quote escaping).

## Verification

- PyYAML now parses the front matter of every `.md` in the repo as a mapping
  with the expected keys, including duplicate-key detection.
- Swept standalone `.yml`/`.yaml` and `.json` files: all valid.
- `tests/fixtures/markdown/frontmatter-unclosed.md` is intentionally
  unterminated (parser fixture) and was left alone.